### PR TITLE
Rebuild remote download queue

### DIFF
--- a/API_DOCS.md
+++ b/API_DOCS.md
@@ -430,6 +430,10 @@ This documentation outlines the available API endpoints for the VideoCMS applica
 
 ## Remote Downloads
 
+Remote downloads are globally controlled by `RemoteDownloadEnabled` and per-user controlled by `RemoteDownloadEnabled` in user settings. Both default to enabled. If an administrator disables the global setting, all pending/running remote downloads are canceled. Remote downloads accept HTTP/HTTPS URLs only; unsafe internal/private network targets are blocked by the downloader.
+
+Statuses: `pending`, `downloading`, `importing`, `completed`, `failed`, `canceling`, `canceled`.
+
 ### Create Remote Download
 *   **Method:** `POST`
 *   **Path:** `/remote/download`
@@ -446,27 +450,69 @@ This documentation outlines the available API endpoints for the VideoCMS applica
         "Status": "pending",
         ...
       }
-    ]
-    ```
+	    ]
+	    ```
+*   **Errors:** `403` user disabled, `503` globally disabled, `429` queue limit reached.
 
 ### List Remote Downloads
 *   **Method:** `GET`
 *   **Path:** `/remote/downloads`
 *   **Auth Required:** Yes
+*   **Query Parameters:** `status` (optional), `limit` (default 50, max 200), `offset` (optional)
 *   **Response (JSON):**
-    ```json
-    [
-      {
-        "ID": 1,
-        "Url": "https://example.com/video.mp4",
-        "Status": "downloading",
-        "Progress": 0.45,
-        "BytesDownloaded": 47185920,
-        "TotalSize": 104857600,
-        ...
-      }
-    ]
-    ```
+	    ```json
+	    [
+	      {
+	        "ID": 1,
+	        "Name": "video.mp4",
+	        "Url": "https://example.com/video.mp4",
+	        "Status": "downloading",
+	        "Progress": 0.45,
+	        "BytesDownloaded": 47185920,
+	        "TotalSize": 104857600,
+	        "LinkUUID": "",
+	        ...
+	      }
+	    ]
+	    ```
+
+### Cancel Remote Download
+*   **Method:** `POST`
+*   **Path:** `/remote/download/{id}/cancel`
+*   **Auth Required:** Yes
+*   **Response:** `"ok"`
+*   **Notes:** Pending jobs become `canceled`; running jobs become `canceling` until the worker stops and cleans up.
+
+### Retry Remote Download
+*   **Method:** `POST`
+*   **Path:** `/remote/download/{id}/retry`
+*   **Auth Required:** Yes
+*   **Response:** The reset remote download row.
+*   **Notes:** Only `failed` and `canceled` jobs can be retried.
+
+### Delete Remote Download
+*   **Method:** `DELETE`
+*   **Path:** `/remote/download/{id}`
+*   **Auth Required:** Yes
+*   **Response:** `204 No Content`
+*   **Notes:** Only terminal jobs (`completed`, `failed`, `canceled`) can be removed from history.
+
+### Clear Remote Downloads
+*   **Method:** `DELETE`
+*   **Path:** `/remote/downloads`
+*   **Auth Required:** Yes
+*   **Request Body (JSON):**
+	    ```json
+	    {
+	      "statuses": ["completed", "failed", "canceled"]
+	    }
+	    ```
+*   **Response (JSON):**
+	    ```json
+	    {
+	      "deleted": 3
+	    }
+	    ```
 
 ### Remote Download Traffic Stats
 *   **Method:** `GET`

--- a/cmd/CreateUser.go
+++ b/cmd/CreateUser.go
@@ -53,13 +53,16 @@ func CreateUser() {
 	}
 
 	hash, _ := helpers.HashPassword(password)
+	remoteDownloadEnabled := true
 	user := models.User{
 		Username: username,
 		Hash:     hash,
 		Admin:    isAdmin,
 		Settings: models.UserSettings{
-			WebhooksEnabled: true,
-			WebhooksMax:     10,
+			WebhooksEnabled:       true,
+			WebhooksMax:           10,
+			MaxRemoteDownloads:    models.DefaultMaxRemoteDownloads,
+			RemoteDownloadEnabled: &remoteDownloadEnabled,
 		},
 	}
 	if res := inits.DB.Create(&user); res.Error != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -42,7 +42,7 @@ type Config struct {
 	AppName string
 	BaseUrl string
 
-	ProjectExampleVideo  string
+	ProjectExampleVideo string
 
 	JwtSecretKey       string
 	JwtUploadSecretKey string
@@ -127,16 +127,17 @@ type Config struct {
 
 	ContinueWatchingPopupEnabled *bool
 
-	DownloadEnabled *bool
-	PlayerV2Enabled *bool
+	DownloadEnabled       *bool
+	RemoteDownloadEnabled *bool
+	PlayerV2Enabled       *bool
 
 	MaxParallelDownloads  int64
 	RemoteDownloadTimeout int64
 }
 
 type PublicConfig struct {
-	AppName string
-	BaseUrl string
+	AppName         string
+	BaseUrl         string
 	EncodingEnabled bool
 	UploadEnabled   bool
 
@@ -156,8 +157,9 @@ type PublicConfig struct {
 
 	ContinueWatchingPopupEnabled bool
 
-	DownloadEnabled bool
-	PlayerV2Enabled bool
+	DownloadEnabled       bool
+	RemoteDownloadEnabled bool
+	PlayerV2Enabled       bool
 }
 
 func (c Config) PublicConfig() PublicConfig {
@@ -183,8 +185,9 @@ func (c Config) PublicConfig() PublicConfig {
 
 		ContinueWatchingPopupEnabled: *c.ContinueWatchingPopupEnabled,
 
-		DownloadEnabled: *c.DownloadEnabled,
-		PlayerV2Enabled: *c.PlayerV2Enabled,
+		DownloadEnabled:       *c.DownloadEnabled,
+		RemoteDownloadEnabled: *c.RemoteDownloadEnabled,
+		PlayerV2Enabled:       *c.PlayerV2Enabled,
 	}
 }
 

--- a/configdb/configdb.go
+++ b/configdb/configdb.go
@@ -99,6 +99,7 @@ func Setup() {
 	config.ENV.EnablePluginPgsServer = getEnvDb_bool(&setting.EnablePluginPgsServer, boolPtr(false))
 
 	config.ENV.DownloadEnabled = getEnvDb_bool(&setting.DownloadEnabled, boolPtr(true))
+	config.ENV.RemoteDownloadEnabled = getEnvDb_bool(&setting.RemoteDownloadEnabled, boolPtr(true))
 	config.ENV.ContinueWatchingPopupEnabled = getEnvDb_bool(&setting.ContinueWatchingPopupEnabled, boolPtr(true))
 	config.ENV.PlayerV2Enabled = getEnvDb_bool(&setting.PlayerV2Enabled, boolPtr(true))
 

--- a/controllers/CreateUserController.go
+++ b/controllers/CreateUserController.go
@@ -9,12 +9,14 @@ import (
 )
 
 type CreateUserRequest struct {
-	Username string  `json:"username" validate:"required,min=3,max=32"`
-	Password string  `json:"password" validate:"required,min=8,max=250"`
-	Email    string  `json:"email" validate:"omitempty,email"`
-	Admin    bool    `json:"admin"`
-	Storage  int64   `json:"storage"`
-	Balance  float64 `json:"balance"`
+	Username              string  `json:"username" validate:"required,min=3,max=32"`
+	Password              string  `json:"password" validate:"required,min=8,max=250"`
+	Email                 string  `json:"email" validate:"omitempty,email"`
+	Admin                 bool    `json:"admin"`
+	Storage               int64   `json:"storage"`
+	Balance               float64 `json:"balance"`
+	MaxRemoteDownloads    *int    `json:"maxRemoteDownloads" validate:"omitempty,min=1"`
+	RemoteDownloadEnabled *bool   `json:"remoteDownloadEnabled" validate:"omitempty,boolean"`
 }
 
 func CreateUser(c echo.Context) error {
@@ -23,7 +25,7 @@ func CreateUser(c echo.Context) error {
 		return c.String(status, err.Error())
 	}
 
-	status, user, err := logic.CreateUser(req.Username, req.Password, req.Email, req.Admin, req.Storage, req.Balance)
+	status, user, err := logic.CreateUser(req.Username, req.Password, req.Email, req.Admin, req.Storage, req.Balance, req.MaxRemoteDownloads, req.RemoteDownloadEnabled)
 	if err != nil {
 		return c.String(status, err.Error())
 	}

--- a/controllers/RemoteDownloadController.go
+++ b/controllers/RemoteDownloadController.go
@@ -1,18 +1,32 @@
 package controllers
 
 import (
+	"ch/kirari04/videocms/config"
 	"ch/kirari04/videocms/helpers"
 	"ch/kirari04/videocms/inits"
 	"ch/kirari04/videocms/logic"
 	"ch/kirari04/videocms/models"
+	"ch/kirari04/videocms/services"
+	"errors"
+	"fmt"
 	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
 )
 
 func CreateRemoteDownload(c echo.Context) error {
 	userId := c.Get("UserID").(uint)
+
+	if !globalRemoteDownloadsEnabled() {
+		return c.String(http.StatusServiceUnavailable, "Remote downloads are disabled")
+	}
 
 	// parse & validate request
 	var req models.RemoteDownloadRequest
@@ -25,15 +39,24 @@ func CreateRemoteDownload(c echo.Context) error {
 	if err != nil {
 		return c.String(http.StatusInternalServerError, "Failed to fetch user")
 	}
-
-	maxDownloads := user.Settings.MaxRemoteDownloads
-	if maxDownloads == 0 {
-		maxDownloads = 5 // Default limit if not set
+	if !user.Settings.EffectiveRemoteDownloadEnabled() {
+		return c.String(http.StatusForbidden, "Remote downloads are disabled for this user")
 	}
+	if err := validateRemoteDownloadURLs(req.Urls); err != nil {
+		return c.String(http.StatusBadRequest, err.Error())
+	}
+	if req.ParentFolderID > 0 {
+		var folder models.Folder
+		if res := inits.DB.Where("id = ? AND user_id = ?", req.ParentFolderID, userId).First(&folder); res.Error != nil {
+			return c.String(http.StatusBadRequest, "Parent folder not found")
+		}
+	}
+
+	maxDownloads := user.Settings.EffectiveMaxRemoteDownloads()
 
 	var currentCount int64
 	inits.DB.Model(&models.RemoteDownload{}).
-		Where("user_id = ? AND status IN ?", userId, []string{"pending", "downloading"}).
+		Where("user_id = ? AND status IN ?", userId, models.ActiveRemoteDownloadStatuses()).
 		Count(&currentCount)
 
 	if currentCount+int64(len(req.Urls)) > int64(maxDownloads) {
@@ -41,19 +64,24 @@ func CreateRemoteDownload(c echo.Context) error {
 	}
 
 	// Create records
-	var created []*models.RemoteDownload
-	for _, url := range req.Urls {
-		download := models.RemoteDownload{
-			UserID:         userId,
-			ParentFolderID: req.ParentFolderID,
-			Url:            url,
-			Status:         "pending",
-			Progress:       0,
+	var created []models.RemoteDownload
+	if err := inits.DB.Transaction(func(tx *gorm.DB) error {
+		for _, rawURL := range req.Urls {
+			download := models.RemoteDownload{
+				UserID:         userId,
+				ParentFolderID: req.ParentFolderID,
+				Url:            strings.TrimSpace(rawURL),
+				Status:         models.RemoteDownloadStatusPending,
+				Progress:       0,
+			}
+			if res := tx.Create(&download); res.Error != nil {
+				return res.Error
+			}
+			created = append(created, download)
 		}
-		if res := inits.DB.Create(&download); res.Error != nil {
-			return c.String(http.StatusInternalServerError, "Failed to create download task")
-		}
-		created = append(created, &download)
+		return nil
+	}); err != nil {
+		return c.String(http.StatusInternalServerError, "Failed to create download task")
 	}
 
 	return c.JSON(http.StatusCreated, created)
@@ -63,11 +91,219 @@ func ListRemoteDownloads(c echo.Context) error {
 	userId := c.Get("UserID").(uint)
 
 	var downloads []models.RemoteDownload
-	if res := inits.DB.Where("user_id = ?", userId).Order("created_at DESC").Limit(50).Find(&downloads); res.Error != nil {
+	limit, _ := strconv.Atoi(c.QueryParam("limit"))
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 200 {
+		limit = 200
+	}
+	offset, _ := strconv.Atoi(c.QueryParam("offset"))
+	if offset < 0 {
+		offset = 0
+	}
+
+	query := inits.DB.Where("user_id = ?", userId)
+	status := c.QueryParam("status")
+	if status != "" {
+		if !isKnownRemoteDownloadStatus(status) {
+			return c.String(http.StatusBadRequest, "Invalid status")
+		}
+		query = query.Where("status = ?", status)
+	}
+
+	if res := query.Order("created_at DESC").Limit(limit).Offset(offset).Find(&downloads); res.Error != nil {
 		return c.String(http.StatusInternalServerError, "Failed to fetch downloads")
 	}
 
 	return c.JSON(http.StatusOK, downloads)
+}
+
+func CancelRemoteDownload(c echo.Context) error {
+	downloadID, err := parseRemoteDownloadID(c)
+	if err != nil {
+		return c.String(http.StatusBadRequest, "Invalid download ID")
+	}
+
+	status, err := services.CancelRemoteDownload(c.Get("UserID").(uint), downloadID)
+	if err != nil {
+		return c.String(status, err.Error())
+	}
+	return c.String(http.StatusOK, "ok")
+}
+
+func RetryRemoteDownload(c echo.Context) error {
+	userID := c.Get("UserID").(uint)
+	downloadID, err := parseRemoteDownloadID(c)
+	if err != nil {
+		return c.String(http.StatusBadRequest, "Invalid download ID")
+	}
+
+	download, status, err := retryRemoteDownload(userID, downloadID)
+	if err != nil {
+		return c.String(status, err.Error())
+	}
+	return c.JSON(status, download)
+}
+
+func DeleteRemoteDownload(c echo.Context) error {
+	userID := c.Get("UserID").(uint)
+	downloadID, err := parseRemoteDownloadID(c)
+	if err != nil {
+		return c.String(http.StatusBadRequest, "Invalid download ID")
+	}
+
+	var download models.RemoteDownload
+	if res := inits.DB.Where("id = ? AND user_id = ?", downloadID, userID).First(&download); res.Error != nil {
+		return c.String(http.StatusNotFound, "download not found")
+	}
+	if !models.IsRemoteDownloadTerminal(download.Status) {
+		return c.String(http.StatusConflict, "active downloads cannot be deleted")
+	}
+	if res := inits.DB.Delete(&download); res.Error != nil {
+		return c.String(http.StatusInternalServerError, "failed to delete download")
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+func ClearRemoteDownloads(c echo.Context) error {
+	userID := c.Get("UserID").(uint)
+	var req models.RemoteDownloadClearRequest
+	if status, err := helpers.Validate(c, &req); err != nil {
+		return c.String(status, err.Error())
+	}
+
+	seen := map[string]bool{}
+	for _, status := range req.Statuses {
+		if !models.IsRemoteDownloadTerminal(status) {
+			return c.String(http.StatusBadRequest, "only terminal statuses can be cleared")
+		}
+		if seen[status] {
+			return c.String(http.StatusBadRequest, "statuses must be distinct")
+		}
+		seen[status] = true
+	}
+
+	res := inits.DB.Where("user_id = ? AND status IN ?", userID, req.Statuses).Delete(&models.RemoteDownload{})
+	if res.Error != nil {
+		return c.String(http.StatusInternalServerError, "failed to clear downloads")
+	}
+	return c.JSON(http.StatusOK, echo.Map{"deleted": res.RowsAffected})
+}
+
+func parseRemoteDownloadID(c echo.Context) (uint, error) {
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	return uint(id), err
+}
+
+func retryRemoteDownload(userID uint, downloadID uint) (*models.RemoteDownload, int, error) {
+	if !globalRemoteDownloadsEnabled() {
+		return nil, http.StatusServiceUnavailable, errors.New("remote downloads are disabled")
+	}
+
+	user, err := helpers.GetUser(userID)
+	if err != nil {
+		return nil, http.StatusInternalServerError, errors.New("failed to fetch user")
+	}
+	if !user.Settings.EffectiveRemoteDownloadEnabled() {
+		return nil, http.StatusForbidden, errors.New("remote downloads are disabled for this user")
+	}
+
+	var download models.RemoteDownload
+	if res := inits.DB.Where("id = ? AND user_id = ?", downloadID, userID).First(&download); res.Error != nil {
+		return nil, http.StatusNotFound, errors.New("download not found")
+	}
+	if download.Status != models.RemoteDownloadStatusFailed && download.Status != models.RemoteDownloadStatusCanceled {
+		return nil, http.StatusConflict, errors.New("only failed or canceled downloads can be retried")
+	}
+
+	var currentCount int64
+	inits.DB.Model(&models.RemoteDownload{}).
+		Where("user_id = ? AND status IN ?", userID, models.ActiveRemoteDownloadStatuses()).
+		Count(&currentCount)
+	if currentCount+1 > int64(user.Settings.EffectiveMaxRemoteDownloads()) {
+		return nil, http.StatusTooManyRequests, errors.New("queue limit reached")
+	}
+	if err := validateRemoteDownloadURLs([]string{download.Url}); err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+	if download.ParentFolderID > 0 {
+		var folder models.Folder
+		if res := inits.DB.Where("id = ? AND user_id = ?", download.ParentFolderID, userID).First(&folder); res.Error != nil {
+			return nil, http.StatusBadRequest, errors.New("parent folder not found")
+		}
+	}
+
+	removeRemoteDownloadTemp(download.TempPath, download.Name)
+
+	if res := inits.DB.Model(&download).Updates(map[string]interface{}{
+		"status":              models.RemoteDownloadStatusPending,
+		"progress":            0,
+		"error":               "",
+		"temp_path":           "",
+		"link_id":             0,
+		"link_uuid":           "",
+		"file_id":             0,
+		"bytes_downloaded":    0,
+		"total_size":          0,
+		"duration":            0,
+		"started_at":          nil,
+		"finished_at":         nil,
+		"cancel_requested_at": nil,
+		"canceled_at":         nil,
+	}); res.Error != nil {
+		return nil, http.StatusInternalServerError, errors.New("failed to retry download")
+	}
+
+	if res := inits.DB.First(&download, download.ID); res.Error != nil {
+		return nil, http.StatusInternalServerError, errors.New("failed to load retried download")
+	}
+	return &download, http.StatusOK, nil
+}
+
+func removeRemoteDownloadTemp(tempPath string, fileName string) {
+	if tempPath == "" {
+		return
+	}
+	_ = os.Remove(tempPath)
+	if ext := filepath.Ext(fileName); ext != "" {
+		_ = os.Remove(tempPath + ext)
+	}
+}
+
+func globalRemoteDownloadsEnabled() bool {
+	return config.ENV.RemoteDownloadEnabled == nil || *config.ENV.RemoteDownloadEnabled
+}
+
+func validateRemoteDownloadURLs(urls []string) error {
+	for _, rawURL := range urls {
+		parsed, err := url.Parse(strings.TrimSpace(rawURL))
+		if err != nil {
+			return fmt.Errorf("invalid URL: %s", rawURL)
+		}
+		if parsed.Scheme != "http" && parsed.Scheme != "https" {
+			return errors.New("remote downloads only support http and https URLs")
+		}
+		if parsed.Host == "" {
+			return errors.New("remote download URL is missing a host")
+		}
+	}
+	return nil
+}
+
+func isKnownRemoteDownloadStatus(status string) bool {
+	switch status {
+	case models.RemoteDownloadStatusPending,
+		models.RemoteDownloadStatusDownloading,
+		models.RemoteDownloadStatusImporting,
+		models.RemoteDownloadStatusCompleted,
+		models.RemoteDownloadStatusFailed,
+		models.RemoteDownloadStatusCanceling,
+		models.RemoteDownloadStatusCanceled:
+		return true
+	default:
+		return false
+	}
 }
 
 func GetRemoteDownloadStats(c echo.Context) error {

--- a/controllers/UpdateSettingsController.go
+++ b/controllers/UpdateSettingsController.go
@@ -1,10 +1,12 @@
 package controllers
 
 import (
+	"ch/kirari04/videocms/config"
 	"ch/kirari04/videocms/configdb"
 	"ch/kirari04/videocms/helpers"
 	"ch/kirari04/videocms/inits"
 	"ch/kirari04/videocms/models"
+	"ch/kirari04/videocms/services"
 	"log"
 	"net/http"
 
@@ -19,9 +21,12 @@ func UpdateSettings(c echo.Context) error {
 		return c.String(status, err.Error())
 	}
 
-	if res := inits.DB.First(&models.Setting{}, validation.ID); res.Error != nil {
+	var previousSetting models.Setting
+	if res := inits.DB.First(&previousSetting, validation.ID); res.Error != nil {
 		return c.String(http.StatusBadRequest, "Setting not found by id")
 	}
+	remoteDownloadsWereEnabled := previousSetting.RemoteDownloadEnabled != "false"
+	remoteDownloadsNowDisabled := validation.RemoteDownloadEnabled == "false"
 
 	var setting models.Setting
 	setting.ID = validation.ID
@@ -94,6 +99,7 @@ func UpdateSettings(c echo.Context) error {
 	setting.PluginPgsServer = validation.PluginPgsServer
 	setting.EnablePluginPgsServer = validation.EnablePluginPgsServer
 	setting.DownloadEnabled = validation.DownloadEnabled
+	setting.RemoteDownloadEnabled = validation.RemoteDownloadEnabled
 	setting.ContinueWatchingPopupEnabled = validation.ContinueWatchingPopupEnabled
 	setting.PlayerV2Enabled = validation.PlayerV2Enabled
 	setting.MaxParallelDownloads = validation.MaxParallelDownloads
@@ -102,6 +108,11 @@ func UpdateSettings(c echo.Context) error {
 	if res := inits.DB.Save(&setting); res.Error != nil {
 		log.Fatalln("Failed to save settings", res.Error)
 		return c.NoContent(http.StatusInternalServerError)
+	}
+	if remoteDownloadsWereEnabled && remoteDownloadsNowDisabled {
+		disabled := false
+		config.ENV.RemoteDownloadEnabled = &disabled
+		services.CancelAllRemoteDownloads("Remote downloads disabled by administrator")
 	}
 	// reload config in background
 	go func() {

--- a/controllers/UpdateUserController.go
+++ b/controllers/UpdateUserController.go
@@ -10,12 +10,13 @@ import (
 )
 
 type UpdateUserRequest struct {
-	Username           string   `json:"username"`
-	Email              string   `json:"email" validate:"omitempty,email"`
-	Admin              *bool    `json:"admin"`
-	Storage            *int64   `json:"storage"`
-	Balance            *float64 `json:"balance"`
-	MaxRemoteDownloads *int     `json:"maxRemoteDownloads" validate:"omitempty,min=0"`
+	Username              string   `json:"username"`
+	Email                 string   `json:"email" validate:"omitempty,email"`
+	Admin                 *bool    `json:"admin"`
+	Storage               *int64   `json:"storage"`
+	Balance               *float64 `json:"balance"`
+	MaxRemoteDownloads    *int     `json:"maxRemoteDownloads" validate:"omitempty,min=1"`
+	RemoteDownloadEnabled *bool    `json:"remoteDownloadEnabled" validate:"omitempty,boolean"`
 }
 
 func UpdateUser(c echo.Context) error {
@@ -30,7 +31,7 @@ func UpdateUser(c echo.Context) error {
 		return c.String(status, err.Error())
 	}
 
-	status, user, err := logic.UpdateUser(id, req.Username, req.Email, req.Admin, req.Storage, req.Balance, req.MaxRemoteDownloads)
+	status, user, err := logic.UpdateUser(id, req.Username, req.Email, req.Admin, req.Storage, req.Balance, req.MaxRemoteDownloads, req.RemoteDownloadEnabled)
 	if err != nil {
 		return c.String(status, err.Error())
 	}

--- a/inits/Models.go
+++ b/inits/Models.go
@@ -49,8 +49,10 @@ func Models() {
 			Hash:     string(rawhash),
 			Admin:    true,
 			Settings: models.UserSettings{
-				WebhooksEnabled: true,
-				WebhooksMax:     100,
+				WebhooksEnabled:       true,
+				WebhooksMax:           100,
+				MaxRemoteDownloads:    models.DefaultMaxRemoteDownloads,
+				RemoteDownloadEnabled: boolPtr(true),
 			},
 		}
 		if res := DB.Create(&user); res.Error != nil {
@@ -63,4 +65,8 @@ func mustRun(err error) {
 	if err != nil {
 		log.Fatalln("Failed to migrate: ", err)
 	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
 }

--- a/logic/GetAccount.go
+++ b/logic/GetAccount.go
@@ -16,14 +16,16 @@ import (
 )
 
 type GetAccountResponse struct {
-	Username string
-	Admin    bool
-	Email    string
-	Balance  float64
-	Storage  int64
-	Used     int64
-	Files    int64
-	Settings models.UserSettings
+	Username              string
+	Admin                 bool
+	Email                 string
+	Balance               float64
+	Storage               int64
+	Used                  int64
+	Files                 int64
+	Settings              models.UserSettings
+	MaxRemoteDownloads    int
+	RemoteDownloadEnabled bool
 }
 
 func GetAccount(userID uint) (status int, response *GetAccountResponse, err error) {
@@ -71,14 +73,16 @@ func GetAccount(userID uint) (status int, response *GetAccountResponse, err erro
 	}
 
 	newResponse := GetAccountResponse{
-		Username: dbUser.Username,
-		Admin:    dbUser.Admin,
-		Email:    dbUser.Email,
-		Balance:  dbUser.Balance,
-		Storage:  dbUser.Storage,
-		Settings: dbUser.Settings,
-		Used:     dbUsed.StorageUsed,
-		Files:    dbUsed.UploadedFiles,
+		Username:              dbUser.Username,
+		Admin:                 dbUser.Admin,
+		Email:                 dbUser.Email,
+		Balance:               dbUser.Balance,
+		Storage:               dbUser.Storage,
+		Settings:              dbUser.Settings,
+		MaxRemoteDownloads:    dbUser.Settings.EffectiveMaxRemoteDownloads(),
+		RemoteDownloadEnabled: dbUser.Settings.EffectiveRemoteDownloadEnabled(),
+		Used:                  dbUsed.StorageUsed,
+		Files:                 dbUsed.UploadedFiles,
 	}
 	// save in cache
 	inits.Cache.Set(fmt.Sprintf("account-%d", userID), newResponse, time.Minute)

--- a/logic/User.go
+++ b/logic/User.go
@@ -9,6 +9,36 @@ import (
 	"net/http"
 )
 
+type UserResponse struct {
+	models.Model
+	Username              string
+	Admin                 bool
+	Email                 string
+	Balance               float64
+	Storage               int64
+	Settings              models.UserSettings
+	MaxRemoteDownloads    int
+	RemoteDownloadEnabled bool
+	UsedStorage           int64 `json:"used_storage"`
+	FileCount             int64 `json:"file_count"`
+}
+
+func NewUserResponse(user models.User, usedStorage int64, fileCount int64) UserResponse {
+	return UserResponse{
+		Model:                 user.Model,
+		Username:              user.Username,
+		Admin:                 user.Admin,
+		Email:                 user.Email,
+		Balance:               user.Balance,
+		Storage:               user.Storage,
+		Settings:              user.Settings,
+		MaxRemoteDownloads:    user.Settings.EffectiveMaxRemoteDownloads(),
+		RemoteDownloadEnabled: user.Settings.EffectiveRemoteDownloadEnabled(),
+		UsedStorage:           usedStorage,
+		FileCount:             fileCount,
+	}
+}
+
 func GetUsers(page, limit int, search string) (int, interface{}, error) {
 	type UserWithUsage struct {
 		models.User
@@ -44,8 +74,13 @@ func GetUsers(page, limit int, search string) (int, interface{}, error) {
 		return http.StatusInternalServerError, nil, errors.New("failed to fetch users")
 	}
 
+	userResponses := make([]UserResponse, 0, len(users))
+	for _, user := range users {
+		userResponses = append(userResponses, NewUserResponse(user.User, user.UsedStorage, user.FileCount))
+	}
+
 	return http.StatusOK, map[string]interface{}{
-		"data": users,
+		"data": userResponses,
 		"meta": map[string]interface{}{
 			"total": total,
 			"page":  page,
@@ -54,7 +89,7 @@ func GetUsers(page, limit int, search string) (int, interface{}, error) {
 	}, nil
 }
 
-func CreateUser(username, password, email string, admin bool, storage int64, balance float64) (int, *models.User, error) {
+func CreateUser(username, password, email string, admin bool, storage int64, balance float64, maxRemoteDownloads *int, remoteDownloadEnabled *bool) (int, *UserResponse, error) {
 	// Check for existing username
 	var count int64
 	inits.DB.Model(&models.User{}).Where("username = ?", username).Count(&count)
@@ -75,6 +110,15 @@ func CreateUser(username, password, email string, admin bool, storage int64, bal
 		return http.StatusInternalServerError, nil, errors.New("failed to process password")
 	}
 
+	effectiveMaxRemoteDownloads := models.DefaultMaxRemoteDownloads
+	if maxRemoteDownloads != nil && *maxRemoteDownloads > 0 {
+		effectiveMaxRemoteDownloads = *maxRemoteDownloads
+	}
+	effectiveRemoteDownloadEnabled := true
+	if remoteDownloadEnabled != nil {
+		effectiveRemoteDownloadEnabled = *remoteDownloadEnabled
+	}
+
 	user := models.User{
 		Username: username,
 		Hash:     hash,
@@ -82,24 +126,30 @@ func CreateUser(username, password, email string, admin bool, storage int64, bal
 		Admin:    admin,
 		Storage:  storage,
 		Balance:  balance,
+		Settings: models.UserSettings{
+			MaxRemoteDownloads:    effectiveMaxRemoteDownloads,
+			RemoteDownloadEnabled: &effectiveRemoteDownloadEnabled,
+		},
 	}
 
 	if result := inits.DB.Create(&user); result.Error != nil {
 		return http.StatusInternalServerError, nil, errors.New("failed to create user")
 	}
 
-	return http.StatusCreated, &user, nil
+	response := NewUserResponse(user, 0, 0)
+	return http.StatusCreated, &response, nil
 }
 
-func GetUser(id uint64) (int, *models.User, error) {
+func GetUser(id uint64) (int, *UserResponse, error) {
 	var user models.User
 	if result := inits.DB.First(&user, id); result.Error != nil {
 		return http.StatusNotFound, nil, errors.New("user not found")
 	}
-	return http.StatusOK, &user, nil
+	response := NewUserResponse(user, 0, 0)
+	return http.StatusOK, &response, nil
 }
 
-func UpdateUser(id uint64, username, email string, admin *bool, storage *int64, balance *float64, maxRemoteDownloads *int) (int, *models.User, error) {
+func UpdateUser(id uint64, username, email string, admin *bool, storage *int64, balance *float64, maxRemoteDownloads *int, remoteDownloadEnabled *bool) (int, *UserResponse, error) {
 	var user models.User
 	if result := inits.DB.First(&user, id); result.Error != nil {
 		return http.StatusNotFound, nil, errors.New("user not found")
@@ -138,12 +188,17 @@ func UpdateUser(id uint64, username, email string, admin *bool, storage *int64, 
 	if maxRemoteDownloads != nil {
 		user.Settings.MaxRemoteDownloads = *maxRemoteDownloads
 	}
+	if remoteDownloadEnabled != nil {
+		user.Settings.RemoteDownloadEnabled = remoteDownloadEnabled
+	}
 
 	if result := inits.DB.Save(&user); result.Error != nil {
 		return http.StatusInternalServerError, nil, errors.New("failed to update user")
 	}
 
-	return http.StatusOK, &user, nil
+	inits.Cache.Delete(fmt.Sprintf("account-%d", id))
+	response := NewUserResponse(user, 0, 0)
+	return http.StatusOK, &response, nil
 }
 
 func DeleteUser(id uint64) (int, error) {

--- a/models/RemoteDownload.go
+++ b/models/RemoteDownload.go
@@ -4,23 +4,70 @@ import (
 	"time"
 )
 
+const (
+	RemoteDownloadStatusPending     = "pending"
+	RemoteDownloadStatusDownloading = "downloading"
+	RemoteDownloadStatusImporting   = "importing"
+	RemoteDownloadStatusCompleted   = "completed"
+	RemoteDownloadStatusFailed      = "failed"
+	RemoteDownloadStatusCanceling   = "canceling"
+	RemoteDownloadStatusCanceled    = "canceled"
+)
+
 type RemoteDownload struct {
 	Model
-	UserID          uint    `gorm:"index"`
-	ParentFolderID  uint    `gorm:"index"`
-	Url             string  `gorm:"size:2048;"`
-	Status          string  `gorm:"size:32;"` // pending, downloading, completed, failed
-	Progress        float64 // 0.0 to 1.0
-	Error           string  `gorm:"size:1024;"`
-	FileID          uint    `gorm:"index"`
-	BytesDownloaded int64
-	TotalSize       int64
-	Duration        float64
-	StartedAt       *time.Time
-	FinishedAt      *time.Time
+	UserID            uint    `gorm:"index"`
+	ParentFolderID    uint    `gorm:"index"`
+	Url               string  `gorm:"size:2048;"`
+	Name              string  `gorm:"size:128;"`
+	Status            string  `gorm:"size:32;"` // pending, downloading, importing, completed, failed, canceling, canceled
+	Progress          float64 // 0.0 to 1.0
+	Error             string  `gorm:"size:1024;"`
+	TempPath          string  `gorm:"size:1024;" json:"-"`
+	LinkID            uint    `gorm:"index"`
+	LinkUUID          string  `gorm:"size:64;"`
+	FileID            uint    `gorm:"index"`
+	BytesDownloaded   int64
+	TotalSize         int64
+	Duration          float64
+	StartedAt         *time.Time
+	FinishedAt        *time.Time
+	CancelRequestedAt *time.Time
+	CanceledAt        *time.Time
 }
 
 type RemoteDownloadRequest struct {
 	Urls           []string `json:"urls" validate:"required,min=1,max=20,dive,url"`
 	ParentFolderID uint     `json:"parentFolderID"`
+}
+
+type RemoteDownloadClearRequest struct {
+	Statuses []string `json:"statuses" validate:"required,min=1,max=3"`
+}
+
+func IsRemoteDownloadTerminal(status string) bool {
+	switch status {
+	case RemoteDownloadStatusCompleted, RemoteDownloadStatusFailed, RemoteDownloadStatusCanceled:
+		return true
+	default:
+		return false
+	}
+}
+
+func IsRemoteDownloadActive(status string) bool {
+	switch status {
+	case RemoteDownloadStatusPending, RemoteDownloadStatusDownloading, RemoteDownloadStatusImporting, RemoteDownloadStatusCanceling:
+		return true
+	default:
+		return false
+	}
+}
+
+func ActiveRemoteDownloadStatuses() []string {
+	return []string{
+		RemoteDownloadStatusPending,
+		RemoteDownloadStatusDownloading,
+		RemoteDownloadStatusImporting,
+		RemoteDownloadStatusCanceling,
+	}
 }

--- a/models/Setting.go
+++ b/models/Setting.go
@@ -7,8 +7,8 @@ type SettingValidation struct {
 
 type Setting struct {
 	Model
-	AppName              string `validate:"required,min=1,max=120" gorm:"size:120;"`
-	BaseUrl              string `validate:"required,min=1,max=120" gorm:"size:120;"`
+	AppName string `validate:"required,min=1,max=120" gorm:"size:120;"`
+	BaseUrl string `validate:"required,min=1,max=120" gorm:"size:120;"`
 
 	ProjectExampleVideo string `validate:"required,min=1,max=512" gorm:"size:512;"`
 
@@ -88,6 +88,7 @@ type Setting struct {
 	EnablePluginPgsServer string `validate:"required,boolean"`
 
 	DownloadEnabled              string `validate:"required,boolean"`
+	RemoteDownloadEnabled        string `validate:"required,boolean"`
 	ContinueWatchingPopupEnabled string `validate:"required,boolean"`
 	PlayerV2Enabled              string `validate:"required,boolean"`
 

--- a/models/UserSettings.go
+++ b/models/UserSettings.go
@@ -8,11 +8,28 @@ import (
 )
 
 type UserSettings struct {
-	WebhooksEnabled     bool
-	WebhooksMax         int
-	UploadSessionsMax   int64
-	EnablePlayerCaptcha bool
-	MaxRemoteDownloads  int
+	WebhooksEnabled       bool
+	WebhooksMax           int
+	UploadSessionsMax     int64
+	EnablePlayerCaptcha   bool
+	MaxRemoteDownloads    int
+	RemoteDownloadEnabled *bool
+}
+
+const DefaultMaxRemoteDownloads = 5
+
+func (j UserSettings) EffectiveRemoteDownloadEnabled() bool {
+	if j.RemoteDownloadEnabled == nil {
+		return true
+	}
+	return *j.RemoteDownloadEnabled
+}
+
+func (j UserSettings) EffectiveMaxRemoteDownloads() int {
+	if j.MaxRemoteDownloads <= 0 {
+		return DefaultMaxRemoteDownloads
+	}
+	return j.MaxRemoteDownloads
 }
 
 // Scan scan value into Jsonb, implements sql.Scanner interface

--- a/models/UserSettings_test.go
+++ b/models/UserSettings_test.go
@@ -1,0 +1,36 @@
+package models
+
+import "testing"
+
+func TestUserSettingsEffectiveRemoteDownloadEnabledDefaultsTrue(t *testing.T) {
+	settings := UserSettings{}
+
+	if !settings.EffectiveRemoteDownloadEnabled() {
+		t.Fatal("missing RemoteDownloadEnabled should default to enabled")
+	}
+}
+
+func TestUserSettingsEffectiveRemoteDownloadEnabledUsesExplicitValue(t *testing.T) {
+	enabled := false
+	settings := UserSettings{RemoteDownloadEnabled: &enabled}
+
+	if settings.EffectiveRemoteDownloadEnabled() {
+		t.Fatal("explicit disabled RemoteDownloadEnabled should be respected")
+	}
+}
+
+func TestUserSettingsEffectiveMaxRemoteDownloadsDefaults(t *testing.T) {
+	settings := UserSettings{}
+
+	if got := settings.EffectiveMaxRemoteDownloads(); got != DefaultMaxRemoteDownloads {
+		t.Fatalf("expected default max remote downloads %d, got %d", DefaultMaxRemoteDownloads, got)
+	}
+}
+
+func TestUserSettingsEffectiveMaxRemoteDownloadsUsesExplicitValue(t *testing.T) {
+	settings := UserSettings{MaxRemoteDownloads: 12}
+
+	if got := settings.EffectiveMaxRemoteDownloads(); got != 12 {
+		t.Fatalf("expected explicit max remote downloads 12, got %d", got)
+	}
+}

--- a/routes/api.go
+++ b/routes/api.go
@@ -118,6 +118,10 @@ func Api() {
 	// Remote Download
 	protectedApi.POST("/remote/download", controllers.CreateRemoteDownload)
 	protectedApi.GET("/remote/downloads", controllers.ListRemoteDownloads)
+	protectedApi.DELETE("/remote/downloads", controllers.ClearRemoteDownloads)
+	protectedApi.POST("/remote/download/:id/cancel", controllers.CancelRemoteDownload)
+	protectedApi.POST("/remote/download/:id/retry", controllers.RetryRemoteDownload)
+	protectedApi.DELETE("/remote/download/:id", controllers.DeleteRemoteDownload)
 	protectedApi.GET("/account/remote-download", controllers.GetRemoteDownloadStats)
 	protectedApi.GET("/account/remote-download/duration", controllers.GetRemoteDownloadDurationStats)
 	protectedApi.GET("/account/remote-download/top", controllers.GetTopRemoteDownloadStats)

--- a/services/Downloader.go
+++ b/services/Downloader.go
@@ -2,112 +2,157 @@ package services
 
 import (
 	"ch/kirari04/videocms/config"
-	"ch/kirari04/videocms/helpers"
 	"ch/kirari04/videocms/inits"
 	"ch/kirari04/videocms/logic"
 	"ch/kirari04/videocms/models"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"log"
+	"mime"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
+	"unicode"
+
+	"github.com/google/uuid"
 )
 
-var downloadLimitChan chan bool
+var (
+	activeDownloadsMu     sync.Mutex
+	activeDownloadCancels = map[uint]context.CancelFunc{}
+)
 
 func Downloader() {
-	// Initialize with a default buffer, will be resized based on config in the loop or we just set a reasonable max
-	// Actually Encoder re-makes the channel, but that's a bit racy if config changes.
-	// For now, let's just initialize it once or check config periodically.
-	// A better way is to semaphore, but let's stick to the project pattern.
-
-	// We'll delay the start slightly to ensure config is loaded
 	time.Sleep(time.Second * 5)
+	resetStaleRemoteDownloads()
 
 	for {
-		maxDownloads := 1
-		if config.ENV.MaxParallelDownloads > 0 {
-			maxDownloads = int(config.ENV.MaxParallelDownloads)
+		if remoteDownloadsEnabled() {
+			loadDownloadTasks()
 		}
-
-		// If channel is nil or capacity changed (simple check), recreate
-		if downloadLimitChan == nil || cap(downloadLimitChan) != maxDownloads {
-			downloadLimitChan = make(chan bool, maxDownloads)
-		}
-
-		go loadDownloadTasks()
 		time.Sleep(time.Second * 5)
 	}
 }
 
 func loadDownloadTasks() {
-	var pendingDownloads []models.RemoteDownload
+	availableSlots := availableRemoteDownloadSlots()
+	if availableSlots <= 0 {
+		return
+	}
 
+	var pendingDownloads []models.RemoteDownload
 	inits.DB.
-		Where("status = ?", "pending").
+		Where("status = ?", models.RemoteDownloadStatusPending).
 		Order("created_at ASC").
-		Limit(10).
+		Limit(availableSlots).
 		Find(&pendingDownloads)
 
 	for _, download := range pendingDownloads {
-		// Acquire slot
-		downloadLimitChan <- true
+		if availableRemoteDownloadSlots() <= 0 {
+			return
+		}
+		if !remoteDownloadsEnabled() {
+			return
+		}
+
+		now := time.Now()
+		claimed := inits.DB.Model(&models.RemoteDownload{}).
+			Where("id = ? AND status = ?", download.ID, models.RemoteDownloadStatusPending).
+			Updates(map[string]interface{}{
+				"status":     models.RemoteDownloadStatusDownloading,
+				"started_at": &now,
+				"error":      "",
+				"progress":   0,
+			})
+		if claimed.Error != nil || claimed.RowsAffected != 1 {
+			continue
+		}
+
+		download.Status = models.RemoteDownloadStatusDownloading
+		download.StartedAt = &now
+		ctx, cancel := context.WithCancel(context.Background())
+		registerActiveDownload(download.ID, cancel)
 
 		go func(task models.RemoteDownload) {
-			defer func() {
-				<-downloadLimitChan
-			}()
-			processDownload(task)
+			defer unregisterActiveDownload(task.ID)
+			processDownload(ctx, task)
 		}(download)
 	}
 }
 
-func processDownload(task models.RemoteDownload) {
-	// Update status to downloading
-	now := time.Now()
-	task.Status = "downloading"
-	task.StartedAt = &now
-	inits.DB.Save(&task)
-
-	// Create temp file
-	tempDir := os.TempDir()
-	fileName := filepath.Base(task.Url)
-	// Sanitize filename
-	fileName = strings.Map(func(r rune) rune {
-		if strings.ContainsRune(`<>:"/\|?*`, r) {
-			return -1
-		}
-		return r
-	}, fileName)
-	if fileName == "" || fileName == "." {
-		fileName = "downloaded_file"
+func availableRemoteDownloadSlots() int {
+	maxDownloads := 1
+	if config.ENV.MaxParallelDownloads > 0 {
+		maxDownloads = int(config.ENV.MaxParallelDownloads)
 	}
 
-	destPath := filepath.Join(tempDir, fmt.Sprintf("dl_%d_%s", task.ID, fileName))
+	activeDownloadsMu.Lock()
+	activeCount := len(activeDownloadCancels)
+	activeDownloadsMu.Unlock()
 
-	// Setup request
-	req, err := http.NewRequest("GET", task.Url, nil)
-	if err != nil {
-		failDownload(&task, fmt.Sprintf("Failed to create request: %v", err))
+	return maxDownloads - activeCount
+}
+
+func remoteDownloadsEnabled() bool {
+	return config.ENV.RemoteDownloadEnabled == nil || *config.ENV.RemoteDownloadEnabled
+}
+
+func registerActiveDownload(id uint, cancel context.CancelFunc) {
+	activeDownloadsMu.Lock()
+	activeDownloadCancels[id] = cancel
+	activeDownloadsMu.Unlock()
+}
+
+func unregisterActiveDownload(id uint) {
+	activeDownloadsMu.Lock()
+	delete(activeDownloadCancels, id)
+	activeDownloadsMu.Unlock()
+}
+
+func activeRemoteDownloadIDs() map[uint]bool {
+	activeDownloadsMu.Lock()
+	defer activeDownloadsMu.Unlock()
+
+	ids := make(map[uint]bool, len(activeDownloadCancels))
+	for id := range activeDownloadCancels {
+		ids[id] = true
+	}
+	return ids
+}
+
+func processDownload(parentCtx context.Context, task models.RemoteDownload) {
+	if isCancelRequested(task.ID) {
+		finishCanceled(&task, "Download canceled")
+		return
+	}
+	if err := validateRemoteURLScheme(task.Url); err != nil {
+		failDownload(&task, err.Error())
 		return
 	}
 
-	// Timeout
-	timeout := time.Duration(config.ENV.RemoteDownloadTimeout) * time.Second
-	if timeout == 0 {
-		timeout = 30 * time.Minute // Default
+	downloadCtx := parentCtx
+	cancelTimeout := func() {}
+	if config.ENV.RemoteDownloadTimeout > 0 {
+		downloadCtx, cancelTimeout = context.WithTimeout(parentCtx, time.Duration(config.ENV.RemoteDownloadTimeout)*time.Second)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	req = req.WithContext(ctx)
+	defer cancelTimeout()
 
-	resp, err := http.DefaultClient.Do(req)
+	req, err := http.NewRequestWithContext(downloadCtx, http.MethodGet, task.Url, nil)
 	if err != nil {
-		failDownload(&task, fmt.Sprintf("Network error: %v", err))
+		failOrCancelDownload(&task, fmt.Sprintf("Failed to create request: %v", err))
+		return
+	}
+
+	resp, err := secureHTTPClient().Do(req)
+	if err != nil {
+		failOrCancelDownload(&task, fmt.Sprintf("Network error: %v", err))
 		return
 	}
 	defer resp.Body.Close()
@@ -117,83 +162,493 @@ func processDownload(task models.RemoteDownload) {
 		return
 	}
 
-	// Get size if available
-	contentLength := resp.ContentLength
-	task.TotalSize = contentLength
-	inits.DB.Save(&task)
+	totalSize := int64(0)
+	if resp.ContentLength > 0 {
+		totalSize = resp.ContentLength
+	}
+	if totalSize > 0 && config.ENV.MaxUploadFilesize > 0 && totalSize > config.ENV.MaxUploadFilesize {
+		failDownload(&task, fmt.Sprintf("Remote file exceeds max upload size (%d bytes)", config.ENV.MaxUploadFilesize))
+		return
+	}
 
-	out, err := os.Create(destPath)
+	fileName := resolveRemoteFileName(task, resp)
+	tempPath := filepath.Join(config.ENV.FolderVideoUploadsPriv, fmt.Sprintf("remote_%d_%s.download", task.ID, uuid.NewString()))
+	if err := os.MkdirAll(filepath.Dir(tempPath), 0755); err != nil {
+		failDownload(&task, fmt.Sprintf("Failed to prepare upload folder: %v", err))
+		return
+	}
+
+	task.Name = fileName
+	task.TotalSize = totalSize
+	task.TempPath = tempPath
+	if res := inits.DB.Model(&task).Updates(map[string]interface{}{
+		"name":       task.Name,
+		"total_size": task.TotalSize,
+		"temp_path":  task.TempPath,
+	}); res.Error != nil {
+		failDownload(&task, "Failed to persist download metadata")
+		return
+	}
+
+	out, err := os.Create(tempPath)
 	if err != nil {
 		failDownload(&task, fmt.Sprintf("Failed to create temp file: %v", err))
 		return
 	}
-	defer out.Close()
-	defer os.Remove(destPath) // Clean up temp file after we are done (CreateFile copies/moves it?)
-	// Actually logic.CreateFile likely moves it or we need to keep it until processed.
-	// logic.CreateFile takes &filePath. If it moves it, we are good. If it copies, we need to delete.
-	// Looking at CreateFile -> CloneFileByHash (if exists) -> else ...
-	// logic.CreateFile -> checks CloneFileByHash. If not found -> moves/processes.
-	// Wait, logic.CreateFile seems to call ffmpeg on the file.
-	// Let's assume we need to pass the path and let CreateFile handle it.
-	// BUT, CreateFile signature: func CreateFile(fromFile *string, ...)
-	// logic/CreateFile.go:
-	// if err == nil { return status, newLink, true, err } // file exists (dedup)
-	// ...
-	// Run file through ffmpeg...
-	// It doesn't seem to strictly move it in all cases, but let's check.
-	// To be safe, we will defer remove, but only if CreateFile doesn't need it anymore.
-	// CreateFile usually takes ownership or we should copy.
-	// Let's write to it first.
 
-	// Progress tracker
-	counter := &WriteCounter{
-		Total:    uint64(contentLength),
-		Download: &task,
-	}
-	if _, err = io.Copy(out, io.TeeReader(resp.Body, counter)); err != nil {
-		out.Close()
-		failDownload(&task, fmt.Sprintf("Download failed: %v", err))
+	copied, copyErr := copyRemoteBody(downloadCtx, resp.Body, out, &task)
+	closeErr := out.Close()
+	if copyErr != nil {
+		cleanupRemoteTemp(tempPath, fileName)
+		failOrCancelDownload(&task, fmt.Sprintf("Download failed: %v", copyErr))
 		return
 	}
-	out.Close()
-
-	// Download finished
-	finishTime := time.Now()
-	duration := finishTime.Sub(*task.StartedAt).Seconds()
-	task.Duration = duration
-	task.BytesDownloaded = int64(counter.Downloaded)
-
-	// Calculate Hash
-	hash, err := helpers.HashFile(destPath)
-	if err != nil {
-		failDownload(&task, fmt.Sprintf("Hashing failed: %v", err))
+	if closeErr != nil {
+		cleanupRemoteTemp(tempPath, fileName)
+		failDownload(&task, fmt.Sprintf("Failed to close temp file: %v", closeErr))
 		return
 	}
 
-	// Create File in CMS
-	// Note: We pass empty string for excludeSessionUUID as this isn't an upload session
-	status, _, _, err := logic.CreateFile(&destPath, task.ParentFolderID, fileName, hash, task.BytesDownloaded, task.UserID, "")
+	task.BytesDownloaded = copied
+	if isCancelRequested(task.ID) {
+		cleanupRemoteTemp(tempPath, fileName)
+		finishCanceled(&task, "Download canceled")
+		return
+	}
+
+	if res := inits.DB.Model(&task).Updates(map[string]interface{}{
+		"status":           models.RemoteDownloadStatusImporting,
+		"bytes_downloaded": task.BytesDownloaded,
+		"progress":         0.95,
+	}); res.Error != nil {
+		cleanupRemoteTemp(tempPath, fileName)
+		failDownload(&task, "Failed to update import status")
+		return
+	}
+	task.Status = models.RemoteDownloadStatusImporting
+	task.Progress = 0.95
+
+	fileUUID := uuid.NewString()
+	status, dbLink, cloned, err := logic.CreateFile(&tempPath, task.ParentFolderID, task.Name, fileUUID, task.BytesDownloaded, task.UserID, "")
 	if err != nil {
+		cleanupRemoteTemp(tempPath, fileName)
 		failDownload(&task, fmt.Sprintf("Import failed (status %d): %v", status, err))
 		return
 	}
+	if dbLink == nil {
+		cleanupRemoteTemp(tempPath, fileName)
+		failDownload(&task, "Import failed: missing created link")
+		return
+	}
 
-	// Success
-	task.Status = "completed"
+	if isCancelRequested(task.ID) {
+		_ = deleteImportedRemoteLink(task.UserID, dbLink.ID)
+		if cloned {
+			cleanupRemoteTemp(tempPath, fileName)
+		}
+		finishCanceled(&task, "Download canceled")
+		return
+	}
+
+	if cloned {
+		cleanupRemoteTemp(tempPath, fileName)
+	}
+
+	finishTime := time.Now()
+	duration := 0.0
+	if task.StartedAt != nil {
+		duration = finishTime.Sub(*task.StartedAt).Seconds()
+	}
+
+	task.Status = models.RemoteDownloadStatusCompleted
 	task.FinishedAt = &finishTime
 	task.Progress = 1.0
+	task.Duration = duration
+	task.LinkID = dbLink.ID
+	task.LinkUUID = dbLink.UUID
+	task.FileID = dbLink.FileID
+	task.Error = ""
+	task.TempPath = ""
 	inits.DB.Save(&task)
 
-	// Log Stats
 	logStats(task)
+}
+
+func secureHTTPClient() *http.Client {
+	transport := &http.Transport{
+		Proxy: nil,
+		DialContext: func(ctx context.Context, network string, address string) (net.Conn, error) {
+			return dialPublicAddress(ctx, network, address)
+		},
+	}
+
+	return &http.Client{
+		Transport: transport,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return errors.New("stopped after 10 redirects")
+			}
+			return validateRemoteURLScheme(req.URL.String())
+		},
+	}
+}
+
+func dialPublicAddress(ctx context.Context, network string, address string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+
+	ips, err := net.DefaultResolver.LookupIP(ctx, "ip", host)
+	if err != nil {
+		return nil, err
+	}
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("no IP addresses found for %s", host)
+	}
+
+	for _, ip := range ips {
+		if isBlockedRemoteIP(ip) {
+			return nil, fmt.Errorf("remote host resolves to blocked IP %s", ip.String())
+		}
+	}
+
+	dialer := &net.Dialer{Timeout: 30 * time.Second}
+	return dialer.DialContext(ctx, network, net.JoinHostPort(ips[0].String(), port))
+}
+
+func isBlockedRemoteIP(ip net.IP) bool {
+	if ip == nil {
+		return true
+	}
+	return ip.IsUnspecified() ||
+		ip.IsLoopback() ||
+		ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast()
+}
+
+func validateRemoteURLScheme(rawURL string) error {
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return err
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return errors.New("remote downloads only support http and https URLs")
+	}
+	if parsed.Host == "" {
+		return errors.New("remote download URL is missing a host")
+	}
+	return nil
+}
+
+func resolveRemoteFileName(task models.RemoteDownload, resp *http.Response) string {
+	if disposition := resp.Header.Get("Content-Disposition"); disposition != "" {
+		_, params, err := mime.ParseMediaType(disposition)
+		if err == nil {
+			if filename := params["filename"]; filename != "" {
+				return sanitizeRemoteFileName(filename, task.ID)
+			}
+			if filename := params["filename*"]; filename != "" {
+				return sanitizeRemoteFileName(filename, task.ID)
+			}
+		}
+	}
+
+	if resp.Request != nil && resp.Request.URL != nil {
+		if baseName := filepath.Base(resp.Request.URL.Path); baseName != "." && baseName != "/" && baseName != "" {
+			if decoded, err := url.PathUnescape(baseName); err == nil {
+				return sanitizeRemoteFileName(decoded, task.ID)
+			}
+			return sanitizeRemoteFileName(baseName, task.ID)
+		}
+	}
+
+	return sanitizeRemoteFileName(fmt.Sprintf("remote-download-%d", task.ID), task.ID)
+}
+
+func sanitizeRemoteFileName(name string, id uint) string {
+	name = filepath.Base(strings.TrimSpace(name))
+	name = strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) || strings.ContainsRune(`<>:"/\|?*`, r) {
+			return '_'
+		}
+		return r
+	}, name)
+	name = strings.Trim(name, " ._")
+	if name == "" {
+		name = fmt.Sprintf("remote-download-%d", id)
+	}
+
+	const maxNameLength = 128
+	runes := []rune(name)
+	if len(runes) <= maxNameLength {
+		return name
+	}
+
+	ext := filepath.Ext(name)
+	extRunes := []rune(ext)
+	if ext != "" && len(extRunes) < maxNameLength-8 {
+		baseRunes := []rune(strings.TrimSuffix(name, ext))
+		allowedBaseLength := maxNameLength - len(extRunes)
+		if len(baseRunes) > allowedBaseLength {
+			baseRunes = baseRunes[:allowedBaseLength]
+		}
+		return strings.TrimRight(string(baseRunes), " ._") + ext
+	}
+	return string(runes[:maxNameLength])
+}
+
+func copyRemoteBody(ctx context.Context, src io.Reader, dst io.Writer, task *models.RemoteDownload) (int64, error) {
+	buffer := make([]byte, 64*1024)
+	var downloaded int64
+	lastUpdate := time.Now()
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return downloaded, err
+		}
+
+		n, readErr := src.Read(buffer)
+		if n > 0 {
+			downloaded += int64(n)
+			if config.ENV.MaxUploadFilesize > 0 && downloaded > config.ENV.MaxUploadFilesize {
+				return downloaded, fmt.Errorf("remote file exceeds max upload size (%d bytes)", config.ENV.MaxUploadFilesize)
+			}
+			if _, err := dst.Write(buffer[:n]); err != nil {
+				return downloaded, err
+			}
+
+			if time.Since(lastUpdate) > time.Second {
+				task.BytesDownloaded = downloaded
+				if task.TotalSize > 0 {
+					task.Progress = float64(downloaded) / float64(task.TotalSize)
+				}
+				inits.DB.Model(task).Updates(map[string]interface{}{
+					"bytes_downloaded": task.BytesDownloaded,
+					"progress":         task.Progress,
+				})
+				lastUpdate = time.Now()
+			}
+		}
+		if readErr != nil {
+			if readErr == io.EOF {
+				task.BytesDownloaded = downloaded
+				if task.TotalSize > 0 {
+					task.Progress = float64(downloaded) / float64(task.TotalSize)
+				}
+				inits.DB.Model(task).Updates(map[string]interface{}{
+					"bytes_downloaded": task.BytesDownloaded,
+					"progress":         task.Progress,
+				})
+				return downloaded, nil
+			}
+			return downloaded, readErr
+		}
+	}
+}
+
+func failOrCancelDownload(task *models.RemoteDownload, reason string) {
+	if isCancelRequested(task.ID) {
+		cleanupRemoteTemp(task.TempPath, task.Name)
+		finishCanceled(task, "Download canceled")
+		return
+	}
+	failDownload(task, reason)
 }
 
 func failDownload(task *models.RemoteDownload, reason string) {
 	now := time.Now()
-	task.Status = "failed"
-	task.Error = reason
+	task.Status = models.RemoteDownloadStatusFailed
+	task.Error = truncateRemoteError(reason)
 	task.FinishedAt = &now
+	if task.StartedAt != nil {
+		task.Duration = now.Sub(*task.StartedAt).Seconds()
+	}
+	task.TempPath = ""
 	inits.DB.Save(task)
+}
+
+func finishCanceled(task *models.RemoteDownload, reason string) {
+	now := time.Now()
+	task.Status = models.RemoteDownloadStatusCanceled
+	task.Error = truncateRemoteError(reason)
+	task.FinishedAt = &now
+	task.CanceledAt = &now
+	task.Progress = 0
+	if task.StartedAt != nil {
+		task.Duration = now.Sub(*task.StartedAt).Seconds()
+	}
+	task.TempPath = ""
+	inits.DB.Save(task)
+}
+
+func isCancelRequested(id uint) bool {
+	var current models.RemoteDownload
+	if res := inits.DB.Select("status").First(&current, id); res.Error != nil {
+		return false
+	}
+	return current.Status == models.RemoteDownloadStatusCanceling || current.Status == models.RemoteDownloadStatusCanceled
+}
+
+func cleanupRemoteTemp(tempPath string, fileName string) {
+	if tempPath == "" {
+		return
+	}
+	_ = os.Remove(tempPath)
+	if ext := filepath.Ext(fileName); ext != "" {
+		_ = os.Remove(tempPath + ext)
+	}
+}
+
+func deleteImportedRemoteLink(userID uint, linkID uint) error {
+	if linkID == 0 {
+		return nil
+	}
+	_, err := logic.DeleteFiles(&models.LinksDeleteValidation{
+		LinkIDs: []models.LinkDeleteValidation{{LinkID: linkID}},
+	}, userID, false)
+	return err
+}
+
+func truncateRemoteError(reason string) string {
+	const maxErrorLength = 1024
+	if len(reason) <= maxErrorLength {
+		return reason
+	}
+	return reason[:maxErrorLength]
+}
+
+func CancelRemoteDownload(userID uint, downloadID uint) (int, error) {
+	var task models.RemoteDownload
+	if res := inits.DB.Where("id = ? AND user_id = ?", downloadID, userID).First(&task); res.Error != nil {
+		return http.StatusNotFound, errors.New("download not found")
+	}
+
+	if models.IsRemoteDownloadTerminal(task.Status) {
+		return http.StatusConflict, errors.New("download is already finished")
+	}
+
+	now := time.Now()
+	switch task.Status {
+	case models.RemoteDownloadStatusPending:
+		task.Status = models.RemoteDownloadStatusCanceled
+		task.Error = "Download canceled"
+		task.CancelRequestedAt = &now
+		task.CanceledAt = &now
+		task.FinishedAt = &now
+		if res := inits.DB.Save(&task); res.Error != nil {
+			return http.StatusInternalServerError, errors.New("failed to cancel download")
+		}
+		return http.StatusOK, nil
+	default:
+		if res := inits.DB.Model(&task).Updates(map[string]interface{}{
+			"status":              models.RemoteDownloadStatusCanceling,
+			"error":               "Cancellation requested",
+			"cancel_requested_at": &now,
+		}); res.Error != nil {
+			return http.StatusInternalServerError, errors.New("failed to request cancellation")
+		}
+
+		activeDownloadsMu.Lock()
+		cancel := activeDownloadCancels[task.ID]
+		activeDownloadsMu.Unlock()
+		if cancel != nil {
+			cancel()
+			return http.StatusOK, nil
+		}
+
+		cleanupRemoteTemp(task.TempPath, task.Name)
+		task.Status = models.RemoteDownloadStatusCanceled
+		task.Error = "Download canceled"
+		task.CanceledAt = &now
+		task.FinishedAt = &now
+		task.TempPath = ""
+		inits.DB.Save(&task)
+		return http.StatusOK, nil
+	}
+}
+
+func CancelAllRemoteDownloads(reason string) {
+	now := time.Now()
+	activeIDsMap := activeRemoteDownloadIDs()
+	activeIDs := make([]uint, 0, len(activeIDsMap))
+	for id := range activeIDsMap {
+		activeIDs = append(activeIDs, id)
+	}
+
+	if len(activeIDs) > 0 {
+		inits.DB.Model(&models.RemoteDownload{}).
+			Where("id IN ? AND status IN ?", activeIDs, []string{
+				models.RemoteDownloadStatusDownloading,
+				models.RemoteDownloadStatusImporting,
+				models.RemoteDownloadStatusCanceling,
+			}).
+			Updates(map[string]interface{}{
+				"status":              models.RemoteDownloadStatusCanceling,
+				"error":               truncateRemoteError(reason),
+				"cancel_requested_at": &now,
+			})
+
+		activeDownloadsMu.Lock()
+		for _, cancel := range activeDownloadCancels {
+			cancel()
+		}
+		activeDownloadsMu.Unlock()
+	}
+
+	cancelQuery := inits.DB.Model(&models.RemoteDownload{}).
+		Where("status = ?", models.RemoteDownloadStatusPending)
+	if len(activeIDs) > 0 {
+		cancelQuery = cancelQuery.Or("status IN ? AND id NOT IN ?", []string{
+			models.RemoteDownloadStatusDownloading,
+			models.RemoteDownloadStatusImporting,
+			models.RemoteDownloadStatusCanceling,
+		}, activeIDs)
+	} else {
+		cancelQuery = cancelQuery.Or("status IN ?", []string{
+			models.RemoteDownloadStatusDownloading,
+			models.RemoteDownloadStatusImporting,
+			models.RemoteDownloadStatusCanceling,
+		})
+	}
+	cancelQuery.Updates(map[string]interface{}{
+		"status":              models.RemoteDownloadStatusCanceled,
+		"error":               truncateRemoteError(reason),
+		"cancel_requested_at": &now,
+		"canceled_at":         &now,
+		"finished_at":         &now,
+		"temp_path":           "",
+	})
+}
+
+func resetStaleRemoteDownloads() {
+	var staleDownloads []models.RemoteDownload
+	if res := inits.DB.Where("status IN ?", []string{
+		models.RemoteDownloadStatusDownloading,
+		models.RemoteDownloadStatusImporting,
+		models.RemoteDownloadStatusCanceling,
+	}).Find(&staleDownloads); res.Error != nil {
+		log.Printf("Failed to load stale remote downloads: %v", res.Error)
+		return
+	}
+
+	now := time.Now()
+	for _, task := range staleDownloads {
+		cleanupRemoteTemp(task.TempPath, task.Name)
+		if task.Status == models.RemoteDownloadStatusCanceling {
+			task.Status = models.RemoteDownloadStatusCanceled
+			task.Error = "Download canceled during server restart"
+			task.CanceledAt = &now
+		} else {
+			task.Status = models.RemoteDownloadStatusFailed
+			task.Error = "Download interrupted by server restart"
+		}
+		task.FinishedAt = &now
+		task.TempPath = ""
+		inits.DB.Save(&task)
+	}
 }
 
 func logStats(task models.RemoteDownload) {
@@ -202,8 +657,6 @@ func logStats(task models.RemoteDownload) {
 	if err == nil && u.Host != "" {
 		domain = u.Host
 	} else {
-		// Fallback for cases where url.Parse might fail or return empty host (e.g. missing scheme)
-		// Extract domain by looking for // and taking the next part
 		parts := strings.Split(task.Url, "//")
 		if len(parts) > 1 {
 			domain = strings.Split(parts[1], "/")[0]
@@ -217,30 +670,4 @@ func logStats(task models.RemoteDownload) {
 		Seconds: task.Duration,
 	}
 	inits.DB.Create(&stat)
-}
-
-type WriteCounter struct {
-	Total      uint64
-	Downloaded uint64
-	Download   *models.RemoteDownload
-	LastUpdate time.Time
-}
-
-func (wc *WriteCounter) Write(p []byte) (int, error) {
-	n := len(p)
-	wc.Downloaded += uint64(n)
-
-	// Update DB every second to avoid spam
-	if time.Since(wc.LastUpdate) > time.Second {
-		wc.Download.BytesDownloaded = int64(wc.Downloaded)
-		if wc.Total > 0 {
-			wc.Download.Progress = float64(wc.Downloaded) / float64(wc.Total)
-		}
-		inits.DB.Model(wc.Download).Updates(map[string]interface{}{
-			"bytes_downloaded": wc.Download.BytesDownloaded,
-			"progress":         wc.Download.Progress,
-		})
-		wc.LastUpdate = time.Now()
-	}
-	return n, nil
 }

--- a/services/Downloader_test.go
+++ b/services/Downloader_test.go
@@ -1,0 +1,66 @@
+package services
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+func TestValidateRemoteURLScheme(t *testing.T) {
+	valid := []string{
+		"http://example.com/video.mp4",
+		"https://example.com/video.mp4",
+	}
+	for _, rawURL := range valid {
+		if err := validateRemoteURLScheme(rawURL); err != nil {
+			t.Fatalf("expected %s to be valid: %v", rawURL, err)
+		}
+	}
+
+	invalid := []string{
+		"ftp://example.com/video.mp4",
+		"https:///missing-host",
+	}
+	for _, rawURL := range invalid {
+		if err := validateRemoteURLScheme(rawURL); err == nil {
+			t.Fatalf("expected %s to be invalid", rawURL)
+		}
+	}
+}
+
+func TestBlockedRemoteIPs(t *testing.T) {
+	blocked := []string{
+		"127.0.0.1",
+		"10.0.0.1",
+		"172.16.0.1",
+		"192.168.1.1",
+		"169.254.1.1",
+		"224.0.0.1",
+		"::1",
+		"fc00::1",
+	}
+	for _, rawIP := range blocked {
+		if !isBlockedRemoteIP(net.ParseIP(rawIP)) {
+			t.Fatalf("expected %s to be blocked", rawIP)
+		}
+	}
+
+	if isBlockedRemoteIP(net.ParseIP("93.184.216.34")) {
+		t.Fatal("expected public IP to be allowed")
+	}
+}
+
+func TestSanitizeRemoteFileName(t *testing.T) {
+	name := sanitizeRemoteFileName(`bad<>:"/\|?*.mp4`, 1)
+	if strings.ContainsAny(name, `<>:"/\|?*`) {
+		t.Fatalf("expected sanitized filename, got %q", name)
+	}
+
+	longName := sanitizeRemoteFileName(strings.Repeat("a", 160)+".mp4", 1)
+	if len([]rune(longName)) > 128 {
+		t.Fatalf("expected filename to be truncated to 128 runes, got %d", len([]rune(longName)))
+	}
+	if !strings.HasSuffix(longName, ".mp4") {
+		t.Fatalf("expected extension to be preserved, got %q", longName)
+	}
+}


### PR DESCRIPTION
## Summary
- add global and per-user remote download enablement controls
- rebuild remote download queue with cancel, retry, delete, clear, and stale-job handling
- add safer HTTP downloader behavior: HTTP/HTTPS only, redirect limit, private/internal IP blocking, max-size checks, and proper temp cleanup
- persist LinkUUID/LinkID/FileID for completed remote downloads
- update API docs and nested frontend/docs pointers

## Related PRs
- Frontend: https://github.com/Kirari04/videocms-frontend/pull/4
- Docs: https://github.com/Kirari04/videocms-docs/pull/2

## Verification
- go test ./...
- bun run build in videocms-frontend