### PR TITLE
ci: skip Discord notifications for Dependabot

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -4,6 +4,8 @@ on:
   - push
 jobs:
   disord_test_message:
+    # Dependabot-triggered workflows cannot access repository action secrets.
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     name: discord commits
     steps:


### PR DESCRIPTION
## Summary
- Skip the secret-dependent Discord notification job for Dependabot-triggered pushes.
- Dependabot workflows do not receive the repository `DISCORD_WEBHOOK` secret; without this guard the action attempts to call `?wait=true` and fails with `ERR_INVALID_URL`.

## Verification
- Targeted ad-hoc verification parsed the workflow and asserted the Dependabot job guard.
- `git diff --check`
