### PR TITLE
Support comma-separated CORS origins

### DIFF
--- a/inits/Server.go
+++ b/inits/Server.go
@@ -220,19 +220,48 @@ func BuildServer(env config.Config, middlewareFactory *middlewares.Factory) *ech
 	}))
 
 	// cors configuration
-	app.Use(middleware.CORSWithConfig(middleware.CORSConfig{
-		AllowOrigins:     []string{env.CorsAllowOrigins},
-		AllowMethods:     []string{http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete, http.MethodOptions},
-		AllowHeaders:     append([]string{env.CorsAllowHeaders}, tusCorsHeaders()...),
-		ExposeHeaders:    tusCorsExposeHeaders(),
-		AllowCredentials: *env.CorsAllowCredentials,
-		MaxAge:           7200,
-	}))
+	app.Use(middleware.CORSWithConfig(serverCORSConfig(env)))
 
 	// Logging
 	app.Use(middleware.RequestLogger())
 
 	return app
+}
+
+func serverCORSConfig(env config.Config) middleware.CORSConfig {
+	return middleware.CORSConfig{
+		AllowOrigins:     parseCORSAllowOrigins(env.CorsAllowOrigins),
+		AllowMethods:     []string{http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete, http.MethodOptions},
+		AllowHeaders:     append([]string{env.CorsAllowHeaders}, tusCorsHeaders()...),
+		ExposeHeaders:    tusCorsExposeHeaders(),
+		AllowCredentials: *env.CorsAllowCredentials,
+		MaxAge:           7200,
+	}
+}
+
+func parseCORSAllowOrigins(value string) []string {
+	origins := make([]string, 0)
+	seen := make(map[string]struct{})
+
+	for _, entry := range strings.Split(value, ",") {
+		origin := strings.TrimSpace(entry)
+		if origin == "" {
+			continue
+		}
+		if _, exists := seen[origin]; exists {
+			continue
+		}
+		seen[origin] = struct{}{}
+		origins = append(origins, origin)
+	}
+
+	if len(origins) == 0 {
+		// Echo treats an empty AllowOrigins slice as "*". Keep empty or
+		// separator-only configuration fail-closed instead of allowing all.
+		return []string{""}
+	}
+
+	return origins
 }
 
 func tusCorsHeaders() []string {

--- a/inits/Server_cors_test.go
+++ b/inits/Server_cors_test.go
@@ -1,0 +1,96 @@
+package inits
+
+import (
+	"ch/kirari04/videocms/config"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+)
+
+func TestParseCORSAllowOrigins(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  []string
+	}{
+		{
+			name:  "wildcard",
+			value: "*",
+			want:  []string{"*"},
+		},
+		{
+			name:  "single origin",
+			value: "https://admin.example.com",
+			want:  []string{"https://admin.example.com"},
+		},
+		{
+			name:  "multiple origins with whitespace",
+			value: " https://admin.example.com,https://app.example.com , http://localhost:3000 ",
+			want: []string{
+				"https://admin.example.com",
+				"https://app.example.com",
+				"http://localhost:3000",
+			},
+		},
+		{
+			name:  "empty entries and duplicates",
+			value: "https://admin.example.com,, https://admin.example.com,",
+			want:  []string{"https://admin.example.com"},
+		},
+		{
+			name:  "only empty entries fails closed",
+			value: " , , ",
+			want:  []string{""},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := parseCORSAllowOrigins(test.value); !reflect.DeepEqual(got, test.want) {
+				t.Fatalf("parseCORSAllowOrigins(%q) = %#v, want %#v", test.value, got, test.want)
+			}
+		})
+	}
+}
+
+func TestServerCORSConfigAllowsEachConfiguredOrigin(t *testing.T) {
+	allowCredentials := true
+	env := config.Config{
+		CorsAllowOrigins:     " https://admin.example.com, https://app.example.com ",
+		CorsAllowHeaders:     "*",
+		CorsAllowCredentials: &allowCredentials,
+	}
+
+	app := echo.New()
+	app.Use(middleware.CORSWithConfig(serverCORSConfig(env)))
+	app.GET("/", func(c echo.Context) error {
+		return c.NoContent(http.StatusNoContent)
+	})
+
+	tests := []struct {
+		origin string
+		want   string
+	}{
+		{origin: "https://admin.example.com", want: "https://admin.example.com"},
+		{origin: "https://app.example.com", want: "https://app.example.com"},
+		{origin: "https://blocked.example.com", want: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.origin, func(t *testing.T) {
+			request := httptest.NewRequest(http.MethodGet, "/", nil)
+			request.Header.Set(echo.HeaderOrigin, test.origin)
+			response := httptest.NewRecorder()
+
+			app.ServeHTTP(response, request)
+
+			if got := response.Header().Get(echo.HeaderAccessControlAllowOrigin); got != test.want {
+				t.Fatalf("Access-Control-Allow-Origin = %q, want %q", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- split CorsAllowOrigins on commas before configuring Echo CORS
- trim whitespace, remove duplicates, and ignore empty list entries
- fail closed for empty or separator-only values instead of falling back to wildcard access

## Example
https://admin.example.com, https://app.example.com, http://localhost:3000

## Verification
- go test ./...
- go vet ./...
- request-level tests allow both configured origins and reject an unlisted origin