### PR TITLE
feat: add configurable video downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A self-hosted Content Management System for your videos. 🎞️
 - **⚡ HLS Multi-Quality:** Videos are converted into multiple qualities to ensure smooth playback for different connection speeds.
 - **🔊 Multi-Audio:** The player supports multiple audio tracks that are not stored inside the video, saving storage space.
 - **🚀 Fast Chunked Upload:** Allows the server to be behind a proxy without requiring high maximum post limits.
-- **📦 Dynamic MKV Download:** The server dynamically assembles subtitles, audio tracks, and video tracks during download without re-encoding.
+- **📦 Configurable Downloads:** Viewers can choose a ready quality and download MP4 with one audio track, or MKV with selectable audio and subtitle tracks. The server assembles the result without re-encoding.
 
 ## Documentation 📚
 

--- a/controllers/CaptchaController.go
+++ b/controllers/CaptchaController.go
@@ -10,6 +10,7 @@ type CaptchaViewData struct {
 	CaptchaType string
 	CaptchaKey  string
 	UUID        string
+	ReturnTo    string
 	Error       string
 }
 
@@ -22,6 +23,7 @@ func (h *Handlers) GetCaptchaChallenge(c echo.Context) error {
 	data := CaptchaViewData{
 		CaptchaType: h.Config().CaptchaType,
 		UUID:        uuid,
+		ReturnTo:    safeCaptchaReturn(c.QueryParam("return")),
 	}
 
 	switch h.Config().CaptchaType {
@@ -41,12 +43,14 @@ func (h *Handlers) VerifyCaptchaChallenge(c echo.Context) error {
 	if uuid == "" {
 		return c.Redirect(http.StatusSeeOther, "/")
 	}
+	returnTo := safeCaptchaReturn(c.FormValue("return"))
 
 	valid, err := h.Auth.CaptchaValid(c)
 	if err != nil || !valid {
 		data := CaptchaViewData{
 			CaptchaType: h.Config().CaptchaType,
 			UUID:        uuid,
+			ReturnTo:    returnTo,
 			Error:       "Captcha verification failed. Please try again.",
 		}
 		switch h.Config().CaptchaType {
@@ -75,5 +79,16 @@ func (h *Handlers) VerifyCaptchaChallenge(c echo.Context) error {
 	cookie.HttpOnly = true
 	c.SetCookie(cookie)
 
-	return c.Redirect(http.StatusSeeOther, "/v/"+uuid)
+	redirectPath := "/v/" + uuid
+	if returnTo == "download" {
+		redirectPath += "/download"
+	}
+	return c.Redirect(http.StatusSeeOther, redirectPath)
+}
+
+func safeCaptchaReturn(returnTo string) string {
+	if returnTo == "download" {
+		return returnTo
+	}
+	return ""
 }

--- a/controllers/CaptchaController_test.go
+++ b/controllers/CaptchaController_test.go
@@ -1,0 +1,14 @@
+package controllers
+
+import "testing"
+
+func TestSafeCaptchaReturn(t *testing.T) {
+	if got := safeCaptchaReturn("download"); got != "download" {
+		t.Fatalf("safeCaptchaReturn(download) = %q", got)
+	}
+	for _, unsafe := range []string{"https://example.com", "//example.com", "../admin", "player"} {
+		if got := safeCaptchaReturn(unsafe); got != "" {
+			t.Fatalf("safeCaptchaReturn(%q) = %q", unsafe, got)
+		}
+	}
+}

--- a/controllers/DownloadPageController.go
+++ b/controllers/DownloadPageController.go
@@ -1,0 +1,182 @@
+package controllers
+
+import (
+	"ch/kirari04/videocms/helpers"
+	"ch/kirari04/videocms/models"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+)
+
+type DownloadQualityOption struct {
+	Name       string
+	Dimensions string
+	Height     int64
+}
+
+type DownloadTrackOption struct {
+	UUID string
+	Name string
+	Lang string
+	Type string
+}
+
+func (h *Handlers) DownloadPageController(c echo.Context) error {
+	type Request struct {
+		UUID string `validate:"required,uuid_rfc4122" param:"UUID"`
+	}
+	var requestValidation Request
+	if status, err := helpers.Validate(c, &requestValidation); err != nil {
+		return c.Render(status, "error.html", echo.Map{
+			"Title": "Download error",
+			"Error": err.Error(),
+		})
+	}
+
+	if !h.downloadsEnabled() {
+		return c.Render(http.StatusForbidden, "error.html", echo.Map{
+			"Title": "Downloads disabled",
+			"Error": "Downloads are not enabled for this server.",
+		})
+	}
+
+	dbLink, err := h.loadPlayerLink(requestValidation.UUID)
+	if err != nil {
+		return c.Render(http.StatusNotFound, "404.html", echo.Map{})
+	}
+
+	if !h.playerCaptchaAllowed(c) {
+		return c.Redirect(
+			http.StatusSeeOther,
+			"/captcha/challenge?uuid="+dbLink.UUID+"&return=download",
+		)
+	}
+
+	mediaToken, mediaExpiration, err := h.Auth.GenerateMediaToken(buildMediaClaims(dbLink))
+	if err != nil {
+		return c.String(http.StatusInternalServerError, "Failed to generate media token")
+	}
+	c.SetCookie(h.mediaCookie(c, dbLink.UUID, mediaToken, mediaExpiration))
+
+	qualities := downloadQualityOptions(dbLink.File.Qualitys)
+	audios := downloadAudioOptions(dbLink.File.Audios)
+	subtitles := downloadSubtitleOptions(dbLink.File.Subtitles)
+
+	return c.Render(http.StatusOK, "download.html", echo.Map{
+		"Title":        fmt.Sprintf("Download %s - %s", dbLink.Name, h.Config().AppName),
+		"VideoTitle":   dbLink.Name,
+		"Thumbnail":    h.Logic.ResolvedThumbnailURL(*dbLink),
+		"Duration":     formatDownloadDuration(dbLink.File.Duration),
+		"UUID":         dbLink.UUID,
+		"AppName":      h.Config().AppName,
+		"DownloadBase": strings.TrimRight(h.Config().FolderVideoQualitysPub, "/") + "/" + dbLink.UUID,
+		"Qualities":    qualities,
+		"Audios":       audios,
+		"Subtitles":    subtitles,
+		"CanDownload":  len(qualities) > 0,
+		"CanUseMP4":    len(audios) > 0,
+	})
+}
+
+func (h *Handlers) downloadsEnabled() bool {
+	return h.Config().DownloadEnabled != nil && *h.Config().DownloadEnabled
+}
+
+func downloadQualityOptions(qualities []models.Quality) []DownloadQualityOption {
+	options := make([]DownloadQualityOption, 0, len(qualities))
+	for _, quality := range qualities {
+		if quality.Type != "hls" || !quality.Ready {
+			continue
+		}
+		options = append(options, DownloadQualityOption{
+			Name:       quality.Name,
+			Dimensions: fmt.Sprintf("%d × %d", quality.Width, quality.Height),
+			Height:     quality.Height,
+		})
+	}
+	sort.SliceStable(options, func(i, j int) bool {
+		return options[i].Height > options[j].Height
+	})
+	return options
+}
+
+func downloadAudioOptions(audios []models.Audio) []DownloadTrackOption {
+	ready := make([]models.Audio, 0, len(audios))
+	for _, audio := range audios {
+		if audio.Ready {
+			ready = append(ready, audio)
+		}
+	}
+	sort.SliceStable(ready, func(i, j int) bool {
+		return ready[i].Index < ready[j].Index
+	})
+
+	options := make([]DownloadTrackOption, 0, len(ready))
+	for _, audio := range ready {
+		options = append(options, DownloadTrackOption{
+			UUID: audio.UUID,
+			Name: audio.Name,
+			Lang: audio.Lang,
+			Type: strings.ToUpper(audio.Codec),
+		})
+	}
+	return options
+}
+
+func downloadSubtitleOptions(subtitles []models.Subtitle) []DownloadTrackOption {
+	preferred := preferredReadySubtitles(subtitles)
+	options := make([]DownloadTrackOption, 0, len(preferred))
+	for _, subtitle := range preferred {
+		options = append(options, DownloadTrackOption{
+			UUID: subtitle.UUID,
+			Name: subtitle.Name,
+			Lang: subtitle.Lang,
+			Type: strings.ToUpper(subtitle.Type),
+		})
+	}
+	return options
+}
+
+func preferredReadySubtitles(subtitles []models.Subtitle) []models.Subtitle {
+	byIndex := map[int]models.Subtitle{}
+	for _, subtitle := range subtitles {
+		if !subtitle.Ready {
+			continue
+		}
+		current, exists := byIndex[subtitle.Index]
+		if !exists || (current.Type != "ass" && subtitle.Type == "ass") {
+			byIndex[subtitle.Index] = subtitle
+		}
+	}
+
+	indexes := make([]int, 0, len(byIndex))
+	for index := range byIndex {
+		indexes = append(indexes, index)
+	}
+	sort.Ints(indexes)
+
+	preferred := make([]models.Subtitle, 0, len(indexes))
+	for _, index := range indexes {
+		preferred = append(preferred, byIndex[index])
+	}
+	return preferred
+}
+
+func formatDownloadDuration(seconds float64) string {
+	if seconds <= 0 {
+		return ""
+	}
+	if seconds < 60 {
+		return "< 1m"
+	}
+	totalMinutes := int(seconds) / 60
+	hours := totalMinutes / 60
+	minutes := totalMinutes % 60
+	if hours > 0 {
+		return fmt.Sprintf("%dh %02dm", hours, minutes)
+	}
+	return fmt.Sprintf("%dm", minutes)
+}

--- a/controllers/DownloadVideoController.go
+++ b/controllers/DownloadVideoController.go
@@ -3,21 +3,41 @@ package controllers
 import (
 	"ch/kirari04/videocms/helpers"
 	"ch/kirari04/videocms/models"
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 )
 
+const (
+	downloadContainerMKV = "mkv"
+	downloadContainerMP4 = "mp4"
+)
+
+var downloadQualityPattern = regexp.MustCompile(`^([0-9]{3,4}p|(h264))$`)
+
+type resolvedDownloadSelection struct {
+	Container string
+	Quality   models.Quality
+	Audios    []models.Audio
+	Subtitles []models.Subtitle
+}
+
 func (h *Handlers) DownloadVideoController(c echo.Context) error {
 	type Request struct {
 		UUID    string `validate:"required,uuid_rfc4122" param:"UUID"`
 		QUALITY string `validate:"required,min=1,max=10" param:"QUALITY"`
+		FILE    string `validate:"omitempty,min=1,max=20" param:"FILE"`
 		Stream  *bool  `validate:"omitempty,boolean" param:"STREAM"`
 	}
 	var requestValidation Request
@@ -25,157 +45,289 @@ func (h *Handlers) DownloadVideoController(c echo.Context) error {
 		return c.String(status, err.Error())
 	}
 
-	if requestValidation.Stream == nil {
-		requestValidation.Stream = new(bool)
-	}
-
-	reQUALITY := regexp.MustCompile(`^([0-9]{3,4}p|(h264))$`)
-	if !reQUALITY.MatchString(requestValidation.QUALITY) {
+	if !downloadQualityPattern.MatchString(requestValidation.QUALITY) {
 		return c.String(http.StatusBadRequest, "bad quality format")
 	}
-
-	if h.Config().DownloadEnabled == nil || !*h.Config().DownloadEnabled {
+	if !h.downloadsEnabled() {
 		return c.String(http.StatusBadRequest, "download disabled")
 	}
 
-	//translate link id to file id
+	streaming := requestValidation.Stream != nil && *requestValidation.Stream
+	container, err := requestedDownloadContainer(requestValidation.FILE, streaming)
+	if err != nil {
+		return c.String(http.StatusBadRequest, err.Error())
+	}
+
 	var dbLink models.Link
 	if dbRes := h.Deps.DB.
-		Model(&models.Link{}).
 		Preload("File").
 		Preload("File.Subtitles").
 		Preload("File.Audios").
 		Preload("File.Qualitys").
-		Where(&models.Link{
-			UUID: requestValidation.UUID,
-		}).
+		Where(&models.Link{UUID: requestValidation.UUID}).
 		First(&dbLink); dbRes.Error != nil {
 		return c.String(http.StatusBadRequest, "video doesn't exist")
 	}
-	files := []string{}
-	streamIndex := 0
 
-	if !*requestValidation.Stream {
-		// add subtitles
-		for _, subtitle := range dbLink.File.Subtitles {
-			files = append(files, "-i", fmt.Sprintf(
-				"%s/%s",
-				subtitle.Path,
-				subtitle.OutputFile,
-			))
-			streamIndex++
-		}
+	customSelection := c.QueryParam("selection") == "custom"
+	selection, err := resolveDownloadSelection(
+		&dbLink,
+		requestValidation.QUALITY,
+		container,
+		streaming,
+		customSelection,
+		c.QueryParams()["audio"],
+		c.QueryParams()["subtitle"],
+	)
+	if err != nil {
+		return c.String(http.StatusBadRequest, err.Error())
 	}
 
-	// add audios
-	if !*requestValidation.Stream {
-		for _, audio := range dbLink.File.Audios {
-			files = append(files, "-i", fmt.Sprintf(
-				"%s/%s",
-				audio.Path,
-				audio.OutputFile,
-			))
-			streamIndex++
-		}
-	} else {
-		if len(dbLink.File.Audios) > 0 {
-			files = append(files, "-i", fmt.Sprintf(
-				"%s/%s",
-				dbLink.File.Audios[0].Path,
-				dbLink.File.Audios[0].OutputFile,
-			))
-			streamIndex++
-		}
-	}
-
-	// add video
-	for _, quality := range dbLink.File.Qualitys {
-		if quality.Name == requestValidation.QUALITY {
-			files = append(files, "-i", fmt.Sprintf(
-				"%s/%s",
-				quality.Path,
-				quality.OutputFile,
-			))
-			streamIndex++
-		}
-	}
-
-	for i := 0; i < streamIndex; i++ {
-		files = append(files, "-map", fmt.Sprintf("%d", i))
-	}
-
-	tmpFilePath := fmt.Sprintf("%s/%s-tmp-enc.mp4", h.Config().FolderVideoUploadsPriv, uuid.NewString())
+	tmpFilePath := filepath.Join(
+		h.Config().FolderVideoUploadsPriv,
+		fmt.Sprintf("%s-download.%s", uuid.NewString(), selection.Container),
+	)
 	defer os.Remove(tmpFilePath)
-	var cmdString []string
-	if !*requestValidation.Stream {
-		cmdString = append(files, []string{"-c", "copy", "-f", "matroska", tmpFilePath}...)
-	} else {
-		cmdString = append(files, []string{"-c", "copy", "-f", "mp4", tmpFilePath}...)
-	}
-	cmd := exec.Command("ffmpeg", cmdString...)
 
-	if err := cmd.Start(); err != nil {
-		c.Logger().Error("Failed to run cmd", err)
-		return nil
-	}
-
-	if err := cmd.Wait(); err != nil {
-		c.Logger().Error("Failed to run cmd on wait", err)
-		return nil
-	}
-
-	// wait until file exists
-	var tmpFile *os.File
-	var fileName string
-
-	fileInfo, err := os.Stat(tmpFilePath)
-	if err == nil {
-		// find quality id
-		var qualityID uint
-		for _, q := range dbLink.File.Qualitys {
-			if q.Name == requestValidation.QUALITY {
-				qualityID = q.ID
-				break
-			}
-		}
-		h.Logic.TrackTraffic(dbLink.File.UserID, dbLink.FileID, qualityID, 0, uint64(fileInfo.Size()))
-	}
-
-	if *requestValidation.Stream {
-		f, err := os.Open(tmpFilePath)
-		if err != nil {
-			c.Logger().Error("Failed to open tmp file", err)
+	cmdArgs := downloadFFmpegArgs(selection, tmpFilePath)
+	cmd := exec.CommandContext(c.Request().Context(), "ffmpeg", cmdArgs...)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		if errors.Is(c.Request().Context().Err(), context.Canceled) {
 			return nil
 		}
-		tmpFile = f
-		fileName = fmt.Sprintf(
-			"%s[%s].mp4",
-			regexp.MustCompile(`[^a-zA-Z0-9]+`).ReplaceAllString(dbLink.Name, "-"),
-			requestValidation.QUALITY,
-		)
-	} else {
-		f, err := os.Open(tmpFilePath)
-		if err != nil {
-			c.Logger().Error("Failed to open tmp file", err)
-			return nil
-		}
-		tmpFile = f
-		fileName = fmt.Sprintf(
-			"%s[%s].mkv",
-			regexp.MustCompile(`[^a-zA-Z0-9]+`).ReplaceAllString(dbLink.Name, "-"),
-			requestValidation.QUALITY,
-		)
+		c.Logger().Errorf("Failed to assemble download: %v: %s", err, strings.TrimSpace(string(output)))
+		return c.String(http.StatusInternalServerError, "failed to prepare download")
+	}
+
+	tmpFile, err := os.Open(tmpFilePath)
+	if err != nil {
+		c.Logger().Error("Failed to open assembled download", err)
+		return c.String(http.StatusInternalServerError, "failed to open prepared download")
 	}
 	defer tmpFile.Close()
 
-	if !*requestValidation.Stream {
-		defer os.Remove(tmpFilePath)
-		c.Response().Header().Add("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, fileName))
-		return c.Stream(http.StatusOK, "video/x-matroska", tmpFile)
-	} else {
-		c.Response().Header().Add("Accept-Ranges", "bytes")
+	fileInfo, err := tmpFile.Stat()
+	if err != nil {
+		return c.String(http.StatusInternalServerError, "failed to inspect prepared download")
+	}
+	h.Logic.TrackTraffic(
+		dbLink.File.UserID,
+		dbLink.FileID,
+		selection.Quality.ID,
+		0,
+		uint64(fileInfo.Size()),
+	)
+
+	fileName := fmt.Sprintf(
+		"%s[%s].%s",
+		safeDownloadName(dbLink.Name),
+		requestValidation.QUALITY,
+		selection.Container,
+	)
+
+	if streaming {
+		c.Response().Header().Set("Accept-Ranges", "bytes")
 		http.ServeContent(c.Response(), c.Request(), fileName, time.Now(), tmpFile)
-		defer os.Remove(tmpFilePath)
 		return nil
 	}
+
+	contentType := "video/x-matroska"
+	if selection.Container == downloadContainerMP4 {
+		contentType = "video/mp4"
+	}
+	c.Response().Header().Set(
+		"Content-Disposition",
+		fmt.Sprintf(`attachment; filename="%s"`, fileName),
+	)
+	c.Response().Header().Set("Content-Length", strconv.FormatInt(fileInfo.Size(), 10))
+	return c.Stream(http.StatusOK, contentType, tmpFile)
+}
+
+func requestedDownloadContainer(fileName string, streaming bool) (string, error) {
+	if streaming {
+		return downloadContainerMP4, nil
+	}
+	switch fileName {
+	case "video.mkv":
+		return downloadContainerMKV, nil
+	case "video.mp4":
+		return downloadContainerMP4, nil
+	default:
+		return "", errors.New("unsupported download container")
+	}
+}
+
+func resolveDownloadSelection(
+	dbLink *models.Link,
+	qualityName string,
+	container string,
+	streaming bool,
+	customSelection bool,
+	audioUUIDs []string,
+	subtitleUUIDs []string,
+) (*resolvedDownloadSelection, error) {
+	selection := &resolvedDownloadSelection{Container: container}
+
+	qualityFound := false
+	for _, quality := range dbLink.File.Qualitys {
+		if quality.Name == qualityName && quality.Ready {
+			selection.Quality = quality
+			qualityFound = true
+			break
+		}
+	}
+	if !qualityFound {
+		return nil, errors.New("selected quality is not available")
+	}
+
+	readyAudios := make(map[string]models.Audio)
+	orderedReadyAudios := make([]models.Audio, 0, len(dbLink.File.Audios))
+	for _, audio := range dbLink.File.Audios {
+		if !audio.Ready {
+			continue
+		}
+		readyAudios[audio.UUID] = audio
+		orderedReadyAudios = append(orderedReadyAudios, audio)
+	}
+
+	if streaming {
+		if len(orderedReadyAudios) > 0 {
+			selection.Audios = []models.Audio{orderedReadyAudios[0]}
+		}
+		return selection, nil
+	}
+
+	if !customSelection {
+		return nil, errors.New("download selection is required")
+	}
+
+	if container == downloadContainerMP4 {
+		if len(subtitleUUIDs) > 0 {
+			return nil, errors.New("MP4 downloads do not support subtitle selection")
+		}
+		if len(audioUUIDs) != 1 {
+			return nil, errors.New("MP4 downloads require exactly one audio track")
+		}
+		audio, exists := readyAudios[audioUUIDs[0]]
+		if !exists {
+			return nil, errors.New("selected audio track is not available")
+		}
+		selection.Audios = []models.Audio{audio}
+		return selection, nil
+	}
+
+	if container != downloadContainerMKV {
+		return nil, errors.New("unsupported download container")
+	}
+
+	audios, err := selectedReadyAudios(audioUUIDs, readyAudios)
+	if err != nil {
+		return nil, err
+	}
+	subtitles, err := selectedReadySubtitles(subtitleUUIDs, dbLink.File.Subtitles)
+	if err != nil {
+		return nil, err
+	}
+	selection.Audios = audios
+	selection.Subtitles = subtitles
+	return selection, nil
+}
+
+func selectedReadyAudios(
+	uuids []string,
+	ready map[string]models.Audio,
+) ([]models.Audio, error) {
+	selected := make([]models.Audio, 0, len(uuids))
+	seen := map[string]bool{}
+	for _, selectedUUID := range uuids {
+		if seen[selectedUUID] {
+			continue
+		}
+		audio, exists := ready[selectedUUID]
+		if !exists {
+			return nil, errors.New("selected audio track is not available")
+		}
+		seen[selectedUUID] = true
+		selected = append(selected, audio)
+	}
+	return selected, nil
+}
+
+func selectedReadySubtitles(
+	uuids []string,
+	subtitles []models.Subtitle,
+) ([]models.Subtitle, error) {
+	ready := make(map[string]models.Subtitle)
+	for _, subtitle := range subtitles {
+		if subtitle.Ready {
+			ready[subtitle.UUID] = subtitle
+		}
+	}
+
+	selected := make([]models.Subtitle, 0, len(uuids))
+	seen := map[string]bool{}
+	for _, selectedUUID := range uuids {
+		if seen[selectedUUID] {
+			continue
+		}
+		subtitle, exists := ready[selectedUUID]
+		if !exists {
+			return nil, errors.New("selected subtitle track is not available")
+		}
+		seen[selectedUUID] = true
+		selected = append(selected, subtitle)
+	}
+	return selected, nil
+}
+
+func downloadFFmpegArgs(selection *resolvedDownloadSelection, outputPath string) []string {
+	args := []string{
+		"-hide_banner",
+		"-loglevel", "error",
+		"-y",
+		"-i", filepath.Join(selection.Quality.Path, selection.Quality.OutputFile),
+	}
+
+	for _, audio := range selection.Audios {
+		args = append(args, "-i", filepath.Join(audio.Path, audio.OutputFile))
+	}
+	for _, subtitle := range selection.Subtitles {
+		args = append(args, "-i", filepath.Join(subtitle.Path, subtitle.OutputFile))
+	}
+
+	args = append(args, "-map", "0:v:0")
+	inputIndex := 1
+	for audioIndex, audio := range selection.Audios {
+		args = append(args,
+			"-map", fmt.Sprintf("%d:a:0", inputIndex),
+			fmt.Sprintf("-metadata:s:a:%d", audioIndex), "language="+audio.Lang,
+			fmt.Sprintf("-metadata:s:a:%d", audioIndex), "title="+audio.Name,
+		)
+		inputIndex++
+	}
+	for subtitleIndex, subtitle := range selection.Subtitles {
+		args = append(args,
+			"-map", fmt.Sprintf("%d:s:0", inputIndex),
+			fmt.Sprintf("-metadata:s:s:%d", subtitleIndex), "language="+subtitle.Lang,
+			fmt.Sprintf("-metadata:s:s:%d", subtitleIndex), "title="+subtitle.Name,
+		)
+		inputIndex++
+	}
+
+	args = append(args, "-c", "copy")
+	if selection.Container == downloadContainerMP4 {
+		args = append(args, "-movflags", "+faststart", "-f", "mp4")
+	} else {
+		args = append(args, "-f", "matroska")
+	}
+	return append(args, outputPath)
+}
+
+func safeDownloadName(name string) string {
+	safe := regexp.MustCompile(`[^a-zA-Z0-9]+`).ReplaceAllString(name, "-")
+	safe = strings.Trim(safe, "-")
+	if safe == "" {
+		return "video"
+	}
+	return safe
 }

--- a/controllers/DownloadVideoController_test.go
+++ b/controllers/DownloadVideoController_test.go
@@ -1,0 +1,285 @@
+package controllers
+
+import (
+	"ch/kirari04/videocms/models"
+	"strings"
+	"testing"
+)
+
+func TestResolveMP4DownloadRequiresExactlyOneReadyAudio(t *testing.T) {
+	link := downloadSelectionTestLink()
+
+	for _, audioUUIDs := range [][]string{
+		nil,
+		{"audio-one", "audio-two"},
+		{"audio-pending"},
+		{"audio-unknown"},
+	} {
+		if _, err := resolveDownloadSelection(
+			link,
+			"720p",
+			downloadContainerMP4,
+			false,
+			true,
+			audioUUIDs,
+			nil,
+		); err == nil {
+			t.Fatalf("resolveDownloadSelection() accepted MP4 audio selection %v", audioUUIDs)
+		}
+	}
+
+	selection, err := resolveDownloadSelection(
+		link,
+		"720p",
+		downloadContainerMP4,
+		false,
+		true,
+		[]string{"audio-two"},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("resolveDownloadSelection() error = %v", err)
+	}
+	if len(selection.Audios) != 1 || selection.Audios[0].UUID != "audio-two" {
+		t.Fatalf("selected audios = %#v", selection.Audios)
+	}
+}
+
+func TestResolveMP4DownloadRejectsSubtitles(t *testing.T) {
+	link := downloadSelectionTestLink()
+	_, err := resolveDownloadSelection(
+		link,
+		"720p",
+		downloadContainerMP4,
+		false,
+		true,
+		[]string{"audio-one"},
+		[]string{"subtitle-ass"},
+	)
+	if err == nil || !strings.Contains(err.Error(), "do not support subtitle") {
+		t.Fatalf("resolveDownloadSelection() error = %v", err)
+	}
+}
+
+func TestResolveMKVDownloadUsesExplicitTrackSelection(t *testing.T) {
+	link := downloadSelectionTestLink()
+	selection, err := resolveDownloadSelection(
+		link,
+		"720p",
+		downloadContainerMKV,
+		false,
+		true,
+		[]string{"audio-two"},
+		[]string{"subtitle-vtt"},
+	)
+	if err != nil {
+		t.Fatalf("resolveDownloadSelection() error = %v", err)
+	}
+	if len(selection.Audios) != 1 || selection.Audios[0].UUID != "audio-two" {
+		t.Fatalf("selected audios = %#v", selection.Audios)
+	}
+	if len(selection.Subtitles) != 1 || selection.Subtitles[0].UUID != "subtitle-vtt" {
+		t.Fatalf("selected subtitles = %#v", selection.Subtitles)
+	}
+}
+
+func TestResolveDownloadRejectsMissingExplicitSelection(t *testing.T) {
+	link := downloadSelectionTestLink()
+	_, err := resolveDownloadSelection(
+		link,
+		"720p",
+		downloadContainerMKV,
+		false,
+		false,
+		nil,
+		nil,
+	)
+	if err == nil || !strings.Contains(err.Error(), "selection is required") {
+		t.Fatalf("resolveDownloadSelection() error = %v", err)
+	}
+}
+
+func TestRequestedDownloadContainerRejectsLegacyEmptyFile(t *testing.T) {
+	if _, err := requestedDownloadContainer("", false); err == nil {
+		t.Fatal("requestedDownloadContainer() accepted a download without an explicit output file")
+	}
+
+	for fileName, want := range map[string]string{
+		"video.mkv": downloadContainerMKV,
+		"video.mp4": downloadContainerMP4,
+	} {
+		got, err := requestedDownloadContainer(fileName, false)
+		if err != nil {
+			t.Fatalf("requestedDownloadContainer(%q) error = %v", fileName, err)
+		}
+		if got != want {
+			t.Fatalf("requestedDownloadContainer(%q) = %q, want %q", fileName, got, want)
+		}
+	}
+}
+
+func TestResolveDownloadRejectsUnavailableQuality(t *testing.T) {
+	link := downloadSelectionTestLink()
+	for _, quality := range []string{"1080p", "480p"} {
+		if _, err := resolveDownloadSelection(
+			link,
+			quality,
+			downloadContainerMKV,
+			false,
+			false,
+			nil,
+			nil,
+		); err == nil {
+			t.Fatalf("resolveDownloadSelection() accepted quality %q", quality)
+		}
+	}
+}
+
+func TestDownloadFFmpegArgsMapSelectedStreams(t *testing.T) {
+	link := downloadSelectionTestLink()
+	selection, err := resolveDownloadSelection(
+		link,
+		"720p",
+		downloadContainerMKV,
+		false,
+		true,
+		[]string{"audio-two"},
+		[]string{"subtitle-ass"},
+	)
+	if err != nil {
+		t.Fatalf("resolveDownloadSelection() error = %v", err)
+	}
+
+	args := downloadFFmpegArgs(selection, "/tmp/output.mkv")
+	joined := strings.Join(args, " ")
+	for _, expected := range []string{
+		"-i /quality/720p/video.m3u8",
+		"-i /audio/two/audio.m3u8",
+		"-i /subtitle/ass/out.ass",
+		"-map 0:v:0",
+		"-map 1:a:0",
+		"-map 2:s:0",
+		"-f matroska",
+		"/tmp/output.mkv",
+	} {
+		if !strings.Contains(joined, expected) {
+			t.Fatalf("downloadFFmpegArgs() missing %q in %q", expected, joined)
+		}
+	}
+}
+
+func TestDownloadPageOptionsSortQualityAndPreferASSSubtitles(t *testing.T) {
+	link := downloadSelectionTestLink()
+	qualities := downloadQualityOptions(link.File.Qualitys)
+	if len(qualities) != 1 || qualities[0].Name != "720p" {
+		t.Fatalf("downloadQualityOptions() = %#v", qualities)
+	}
+
+	subtitles := downloadSubtitleOptions(link.File.Subtitles)
+	if len(subtitles) != 1 || subtitles[0].UUID != "subtitle-ass" {
+		t.Fatalf("downloadSubtitleOptions() = %#v", subtitles)
+	}
+}
+
+func TestFormatDownloadDuration(t *testing.T) {
+	tests := map[string]struct {
+		seconds float64
+		want    string
+	}{
+		"unknown":      {seconds: 0, want: ""},
+		"under minute": {seconds: 49, want: "< 1m"},
+		"minutes":      {seconds: 125, want: "2m"},
+		"hours":        {seconds: 3720, want: "1h 02m"},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := formatDownloadDuration(test.seconds); got != test.want {
+				t.Fatalf("formatDownloadDuration(%v) = %q, want %q", test.seconds, got, test.want)
+			}
+		})
+	}
+}
+
+func downloadSelectionTestLink() *models.Link {
+	return &models.Link{
+		UUID: "link-uuid",
+		File: models.File{
+			Qualitys: []models.Quality{
+				{
+					Name:       "720p",
+					Type:       "hls",
+					Height:     720,
+					Width:      1280,
+					Path:       "/quality/720p",
+					OutputFile: "video.m3u8",
+					Ready:      true,
+				},
+				{
+					Name:       "480p",
+					Type:       "hls",
+					Height:     480,
+					Width:      854,
+					Path:       "/quality/480p",
+					OutputFile: "video.m3u8",
+					Ready:      false,
+				},
+			},
+			Audios: []models.Audio{
+				{
+					UUID:       "audio-one",
+					Name:       "English",
+					Lang:       "eng",
+					Index:      0,
+					Path:       "/audio/one",
+					OutputFile: "audio.m3u8",
+					Ready:      true,
+				},
+				{
+					UUID:       "audio-two",
+					Name:       "Commentary",
+					Lang:       "eng",
+					Index:      1,
+					Path:       "/audio/two",
+					OutputFile: "audio.m3u8",
+					Ready:      true,
+				},
+				{
+					UUID:  "audio-pending",
+					Name:  "Pending",
+					Index: 2,
+					Ready: false,
+				},
+			},
+			Subtitles: []models.Subtitle{
+				{
+					UUID:       "subtitle-vtt",
+					Name:       "English",
+					Lang:       "eng",
+					Type:       "vtt",
+					Index:      0,
+					Path:       "/subtitle/vtt",
+					OutputFile: "out.vtt",
+					Ready:      true,
+				},
+				{
+					UUID:       "subtitle-ass",
+					Name:       "English",
+					Lang:       "eng",
+					Type:       "ass",
+					Index:      0,
+					Path:       "/subtitle/ass",
+					OutputFile: "out.ass",
+					Ready:      true,
+				},
+				{
+					UUID:  "subtitle-pending",
+					Name:  "Pending",
+					Type:  "ass",
+					Index: 1,
+					Ready: false,
+				},
+			},
+		},
+	}
+}

--- a/controllers/PlayerController.go
+++ b/controllers/PlayerController.go
@@ -86,7 +86,7 @@ func (h *Handlers) PlayerController(c echo.Context) error {
 	for _, qualiItem := range dbLink.File.Qualitys {
 		if qualiItem.Type == "hls" && qualiItem.Ready {
 			jsonQualitys = append(jsonQualitys, map[string]string{
-				"url":    fmt.Sprintf("%s/%s/%s/download/video.mkv", h.Config().FolderVideoQualitysPub, dbLink.UUID, qualiItem.Name),
+				"url":    fmt.Sprintf("%s/%s/%s/1/stream/video.mp4", h.Config().FolderVideoQualitysPub, dbLink.UUID, qualiItem.Name),
 				"label":  qualiItem.Name,
 				"height": strconv.Itoa(int(qualiItem.Height)),
 				"width":  strconv.Itoa(int(qualiItem.Width)),

--- a/media_templates_test.go
+++ b/media_templates_test.go
@@ -1,10 +1,17 @@
 package main
 
 import (
+	"html/template"
 	"os"
 	"strings"
 	"testing"
 )
+
+func TestMediaTemplatesParse(t *testing.T) {
+	if _, err := template.ParseGlob("views/*.html"); err != nil {
+		t.Fatalf("template.ParseGlob() error = %v", err)
+	}
+}
 
 func TestPlayerTemplatesDoNotRenderQueryJWT(t *testing.T) {
 	for _, path := range []string{"views/player.html", "views/player_v2.html", "views/player.old.html"} {
@@ -45,6 +52,38 @@ func TestPlayerV2TemplateUsesViewportConstrainedAspectRatio(t *testing.T) {
 	} {
 		if !strings.Contains(content, expected) {
 			t.Fatalf("player_v2.html missing viewport sizing marker %q", expected)
+		}
+	}
+}
+
+func TestPlayerTemplatesOpenDownloadOptionsPage(t *testing.T) {
+	for _, path := range []string{"views/player.html", "views/player_v2.html"} {
+		content := string(readTemplateFile(t, path))
+		for _, expected := range []string{
+			"DOWNLOAD_PAGE_URL",
+			"`/v/${UUID}/download`",
+		} {
+			if !strings.Contains(content, expected) {
+				t.Fatalf("%s missing download page marker %q", path, expected)
+			}
+		}
+	}
+}
+
+func TestDownloadTemplateContainsSelectionRules(t *testing.T) {
+	content := string(readTemplateFile(t, "views/download.html"))
+	for _, expected := range []string{
+		`name="quality"`,
+		`name="container"`,
+		`value="mkv"`,
+		`value="mp4"`,
+		`name="audio"`,
+		`name="subtitle"`,
+		"MP4 requires exactly one audio track",
+		"Download manifest",
+	} {
+		if !strings.Contains(content, expected) {
+			t.Fatalf("download.html missing selection marker %q", expected)
 		}
 	}
 }

--- a/routes/web.go
+++ b/routes/web.go
@@ -19,6 +19,8 @@ func Web(app *echo.Echo, handlers *controllers.Handlers, middlewareFactory *midd
 
 	app.GET("/v/:UUID", handlers.PlayerController,
 		middleware.RateLimiterWithConfig(*middlewareFactory.LimiterConfig(rate.Limit(cfg.RatelimitRateWeb), cfg.RatelimitBurstWeb, time.Minute*5)))
+	app.GET("/v/:UUID/download", handlers.DownloadPageController,
+		middleware.RateLimiterWithConfig(*middlewareFactory.LimiterConfig(rate.Limit(cfg.RatelimitRateWeb), cfg.RatelimitBurstWeb, time.Minute*5)))
 	app.GET("/v/:UUID/status", handlers.PlayerStatusController,
 		middleware.RateLimiterWithConfig(*middlewareFactory.LimiterConfig(rate.Limit(cfg.RatelimitRateWeb), cfg.RatelimitBurstWeb, time.Minute*5)))
 
@@ -29,7 +31,7 @@ func Web(app *echo.Echo, handlers *controllers.Handlers, middlewareFactory *midd
 	videoData.GET("/:UUID/image/thumb/:FILE", handlers.GetThumbnailData)
 	videoData.GET("/:UUID/:SUBUUID/subtitle/:FILE", handlers.GetSubtitleData, middlewareFactory.MediaAuth())
 	videoData.GET("/:UUID/:AUDIOUUID/stream/master.m3u8", handlers.GetM3u8Data, middlewareFactory.MediaAuth())
-	videoData.GET("/:UUID/:QUALITY/download/video.mkv", handlers.DownloadVideoController, middlewareFactory.MediaAuth())
+	videoData.GET("/:UUID/:QUALITY/download/:FILE", handlers.DownloadVideoController, middlewareFactory.MediaAuth())
 	videoData.GET("/:UUID/:QUALITY/:STREAM/stream/video.mp4", handlers.DownloadVideoController, middlewareFactory.MediaAuth())
 	videoData.GET("/:UUID/:QUALITY/:FILE", handlers.GetVideoData, middlewareFactory.MediaAuth())
 	videoData.GET("/:UUID/:AUDIOUUID/audio/:FILE", handlers.GetAudioData, middlewareFactory.MediaAuth())

--- a/views/captcha.html
+++ b/views/captcha.html
@@ -28,6 +28,7 @@
         {{end}}
         <form action="/captcha/verify" method="POST">
             <input type="hidden" name="uuid" value="{{.UUID}}">
+            {{if .ReturnTo}}<input type="hidden" name="return" value="{{.ReturnTo}}">{{end}}
             
             <div style="display: flex; justify-content: center;">
                 {{if eq .CaptchaType "recaptcha"}}

--- a/views/download.html
+++ b/views/download.html
@@ -1,0 +1,940 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark" />
+    <title>{{.Title}}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <style>
+        :root {
+            color-scheme: dark;
+            --bg: #09090b;
+            --surface: #111115;
+            --surface-raised: #18181d;
+            --surface-hover: #202027;
+            --border: #2b2b33;
+            --border-strong: #3c3c47;
+            --text: #f4f4f5;
+            --muted: #a1a1aa;
+            --accent: #818cf8;
+            --accent-strong: #6366f1;
+            --accent-soft: rgba(99, 102, 241, 0.14);
+            --danger: #fca5a5;
+            --radius: 10px;
+            --focus: 0 0 0 3px rgba(129, 140, 248, 0.32);
+            font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        html {
+            background: var(--bg);
+        }
+
+        body {
+            min-width: 0;
+            min-height: 100vh;
+            margin: 0;
+            color: var(--text);
+            background:
+                radial-gradient(circle at 50% -20%, rgba(99, 102, 241, 0.13), transparent 38rem),
+                var(--bg);
+            font-family: inherit;
+            line-height: 1.5;
+        }
+
+        button,
+        input {
+            font: inherit;
+        }
+
+        button,
+        a,
+        label {
+            -webkit-tap-highlight-color: transparent;
+        }
+
+        a {
+            color: inherit;
+        }
+
+        .shell {
+            width: min(1120px, calc(100% - 32px));
+            margin: 0 auto;
+            padding: 24px 0 48px;
+        }
+
+        .topbar {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 16px;
+            margin-bottom: 28px;
+        }
+
+        .brand {
+            color: var(--muted);
+            font-size: 0.875rem;
+            font-weight: 600;
+            text-decoration: none;
+        }
+
+        .back-link {
+            display: inline-flex;
+            min-height: 40px;
+            align-items: center;
+            gap: 8px;
+            border-radius: 8px;
+            color: #d4d4d8;
+            font-size: 0.875rem;
+            font-weight: 500;
+            text-decoration: none;
+        }
+
+        .back-link:hover {
+            color: #fff;
+        }
+
+        .back-link:focus-visible,
+        button:focus-visible,
+        input:focus-visible + .choice {
+            outline: none;
+            box-shadow: var(--focus);
+        }
+
+        .video-context {
+            display: grid;
+            grid-template-columns: 176px minmax(0, 1fr);
+            align-items: center;
+            gap: 24px;
+            margin-bottom: 30px;
+        }
+
+        .poster {
+            aspect-ratio: 16 / 9;
+            width: 100%;
+            overflow: hidden;
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            background: var(--surface);
+        }
+
+        .poster img {
+            width: 100%;
+            height: 100%;
+            display: block;
+            object-fit: cover;
+        }
+
+        .video-copy {
+            min-width: 0;
+        }
+
+        .video-copy h1 {
+            max-width: 22ch;
+            margin: 0;
+            overflow-wrap: anywhere;
+            color: #fff;
+            font-size: clamp(1.55rem, 3vw, 2.25rem);
+            line-height: 1.15;
+            letter-spacing: -0.03em;
+            text-wrap: balance;
+        }
+
+        .video-copy p {
+            max-width: 62ch;
+            margin: 10px 0 0;
+            color: var(--muted);
+            font-size: 0.925rem;
+            text-wrap: pretty;
+        }
+
+        .video-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px 14px;
+            margin-top: 14px;
+            color: #d4d4d8;
+            font-size: 0.8rem;
+        }
+
+        .workspace {
+            display: grid;
+            grid-template-columns: minmax(0, 1fr) 304px;
+            align-items: start;
+            gap: 28px;
+        }
+
+        .options {
+            min-width: 0;
+            overflow: hidden;
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            background: var(--surface);
+        }
+
+        .step {
+            padding: 24px;
+        }
+
+        .step + .step {
+            border-top: 1px solid var(--border);
+        }
+
+        .step-heading {
+            display: flex;
+            align-items: flex-start;
+            gap: 12px;
+            margin-bottom: 17px;
+        }
+
+        .step-number {
+            display: inline-flex;
+            width: 26px;
+            height: 26px;
+            flex: 0 0 26px;
+            align-items: center;
+            justify-content: center;
+            border-radius: 50%;
+            background: var(--accent-soft);
+            color: #c7d2fe;
+            font-size: 0.75rem;
+            font-weight: 700;
+        }
+
+        .step-heading h2 {
+            margin: 1px 0 0;
+            font-size: 1rem;
+            line-height: 1.4;
+        }
+
+        .step-heading p {
+            margin: 3px 0 0;
+            color: var(--muted);
+            font-size: 0.82rem;
+        }
+
+        .choice-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+            gap: 10px;
+        }
+
+        .choice-input {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            overflow: hidden;
+            opacity: 0;
+            pointer-events: none;
+        }
+
+        .choice {
+            display: flex;
+            min-height: 70px;
+            cursor: pointer;
+            align-items: center;
+            justify-content: space-between;
+            gap: 14px;
+            border: 1px solid var(--border);
+            border-radius: 9px;
+            background: var(--surface-raised);
+            padding: 13px 14px;
+            transition: border-color 160ms ease, background-color 160ms ease;
+        }
+
+        .choice:hover {
+            border-color: var(--border-strong);
+            background: var(--surface-hover);
+        }
+
+        .choice-input:checked + .choice {
+            border-color: var(--accent);
+            background: var(--accent-soft);
+        }
+
+        .choice-input:disabled + .choice {
+            cursor: not-allowed;
+            opacity: 0.48;
+        }
+
+        .choice-main {
+            min-width: 0;
+        }
+
+        .choice-title {
+            display: block;
+            font-size: 0.9rem;
+            font-weight: 600;
+        }
+
+        .choice-detail {
+            display: block;
+            margin-top: 2px;
+            color: var(--muted);
+            font-size: 0.75rem;
+        }
+
+        .choice-mark {
+            width: 16px;
+            height: 16px;
+            flex: 0 0 16px;
+            border: 1px solid #52525b;
+            border-radius: 50%;
+            box-shadow: inset 0 0 0 4px var(--surface-raised);
+            background: transparent;
+        }
+
+        .choice-input:checked + .choice .choice-mark {
+            border-color: var(--accent);
+            background: var(--accent);
+        }
+
+        .track-block + .track-block {
+            margin-top: 22px;
+        }
+
+        .track-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            margin-bottom: 8px;
+        }
+
+        .track-header h3 {
+            margin: 0;
+            font-size: 0.875rem;
+            font-weight: 600;
+        }
+
+        .track-actions {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
+
+        .text-button {
+            min-height: 32px;
+            border: 0;
+            border-radius: 7px;
+            background: transparent;
+            padding: 0 8px;
+            color: #c7d2fe;
+            cursor: pointer;
+            font-size: 0.75rem;
+            font-weight: 600;
+        }
+
+        .text-button:hover {
+            background: var(--accent-soft);
+        }
+
+        .track-list {
+            overflow: hidden;
+            border: 1px solid var(--border);
+            border-radius: 9px;
+            background: var(--surface-raised);
+        }
+
+        .track-row {
+            display: grid;
+            grid-template-columns: 20px minmax(0, 1fr) auto;
+            align-items: center;
+            gap: 11px;
+            min-height: 48px;
+            padding: 9px 12px;
+            cursor: pointer;
+        }
+
+        .track-row + .track-row {
+            border-top: 1px solid var(--border);
+        }
+
+        .track-row:hover {
+            background: var(--surface-hover);
+        }
+
+        .track-row input {
+            width: 16px;
+            height: 16px;
+            margin: 0;
+            accent-color: var(--accent-strong);
+        }
+
+        .track-name {
+            min-width: 0;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            font-size: 0.84rem;
+            font-weight: 500;
+        }
+
+        .track-meta {
+            color: var(--muted);
+            font-size: 0.72rem;
+            text-align: right;
+        }
+
+        .empty {
+            margin: 0;
+            border: 1px dashed var(--border-strong);
+            border-radius: 9px;
+            padding: 13px;
+            color: var(--muted);
+            font-size: 0.82rem;
+        }
+
+        .format-note {
+            margin: 12px 0 0;
+            color: var(--muted);
+            font-size: 0.78rem;
+        }
+
+        .summary {
+            position: sticky;
+            top: 24px;
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            background: var(--surface);
+            padding: 20px;
+        }
+
+        .summary h2 {
+            margin: 0;
+            font-size: 0.95rem;
+        }
+
+        .manifest {
+            margin: 17px 0 18px;
+            border-top: 1px solid var(--border);
+        }
+
+        .manifest-row {
+            display: flex;
+            align-items: baseline;
+            justify-content: space-between;
+            gap: 18px;
+            border-bottom: 1px solid var(--border);
+            padding: 10px 0;
+            font-size: 0.8rem;
+        }
+
+        .manifest-row span:first-child {
+            color: var(--muted);
+        }
+
+        .manifest-row strong {
+            min-width: 0;
+            overflow: hidden;
+            color: #fff;
+            font-weight: 600;
+            text-align: right;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .download-button {
+            display: inline-flex;
+            width: 100%;
+            min-height: 44px;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            border: 0;
+            border-radius: 9px;
+            background: var(--accent-strong);
+            padding: 0 16px;
+            color: #fff;
+            cursor: pointer;
+            font-size: 0.875rem;
+            font-weight: 700;
+            transition: background-color 160ms ease, transform 160ms ease;
+        }
+
+        .download-button:hover {
+            background: #5558e8;
+        }
+
+        .download-button:active {
+            transform: translateY(1px);
+        }
+
+        .download-button:disabled {
+            cursor: not-allowed;
+            opacity: 0.55;
+        }
+
+        .summary-note {
+            margin: 12px 0 0;
+            color: var(--muted);
+            font-size: 0.72rem;
+            line-height: 1.5;
+            text-align: center;
+        }
+
+        .form-error {
+            min-height: 20px;
+            margin: 10px 0 0;
+            color: var(--danger);
+            font-size: 0.75rem;
+            text-align: center;
+        }
+
+        .not-ready {
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            background: var(--surface);
+            padding: 28px;
+        }
+
+        .not-ready h2 {
+            margin: 0 0 7px;
+            font-size: 1.05rem;
+        }
+
+        .not-ready p {
+            margin: 0;
+            color: var(--muted);
+            font-size: 0.875rem;
+        }
+
+        [hidden] {
+            display: none !important;
+        }
+
+        @media (max-width: 820px) {
+            .workspace {
+                grid-template-columns: minmax(0, 1fr);
+            }
+
+            .summary {
+                position: static;
+            }
+        }
+
+        @media (max-width: 560px) {
+            .shell {
+                width: min(100% - 24px, 1120px);
+                padding-top: 16px;
+            }
+
+            .topbar {
+                margin-bottom: 22px;
+            }
+
+            .video-context {
+                grid-template-columns: 96px minmax(0, 1fr);
+                gap: 14px;
+                margin-bottom: 22px;
+            }
+
+            .video-copy h1 {
+                font-size: 1.35rem;
+            }
+
+            .video-copy p {
+                display: none;
+            }
+
+            .video-meta {
+                margin-top: 8px;
+            }
+
+            .step {
+                padding: 18px 16px;
+            }
+
+            .choice-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .track-meta {
+                max-width: 78px;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+            }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            *,
+            *::before,
+            *::after {
+                scroll-behavior: auto !important;
+                transition-duration: 0.01ms !important;
+            }
+        }
+    </style>
+</head>
+<body>
+    <main class="shell">
+        <nav class="topbar" aria-label="Download navigation">
+            <a class="back-link" href="/v/{{.UUID}}">
+                <span aria-hidden="true">←</span>
+                Back to player
+            </a>
+            <a class="brand" href="/">{{.AppName}}</a>
+        </nav>
+
+        <header class="video-context">
+            <div class="poster">
+                <img src="{{.Thumbnail}}" alt="" />
+            </div>
+            <div class="video-copy">
+                <h1>{{.VideoTitle}}</h1>
+                <p>Choose the version and tracks you want. The server will assemble them without re-encoding the video.</p>
+                <div class="video-meta">
+                    {{if .Duration}}<span>{{.Duration}}</span>{{end}}
+                    <span>Original tracks preserved</span>
+                </div>
+            </div>
+        </header>
+
+        {{if .CanDownload}}
+        <form
+            id="download-form"
+            class="workspace"
+            method="GET"
+            data-download-base="{{.DownloadBase}}"
+        >
+            <input type="hidden" name="selection" value="custom" />
+            <div class="options">
+                <section class="step" aria-labelledby="quality-heading">
+                    <div class="step-heading">
+                        <span class="step-number" aria-hidden="true">1</span>
+                        <div>
+                            <h2 id="quality-heading">Choose video quality</h2>
+                            <p>The selected stream determines the picture resolution.</p>
+                        </div>
+                    </div>
+                    <div class="choice-grid">
+                        {{range $index, $quality := .Qualities}}
+                        <label>
+                            <input
+                                class="choice-input"
+                                type="radio"
+                                name="quality"
+                                value="{{$quality.Name}}"
+                                data-detail="{{$quality.Dimensions}}"
+                                aria-label="{{$quality.Name}}, {{$quality.Dimensions}}"
+                                {{if eq $index 0}}checked{{end}}
+                                required
+                            />
+                            <span class="choice">
+                                <span class="choice-main">
+                                    <span class="choice-title">{{$quality.Name}}</span>
+                                    <span class="choice-detail">{{$quality.Dimensions}}</span>
+                                </span>
+                                <span class="choice-mark" aria-hidden="true"></span>
+                            </span>
+                        </label>
+                        {{end}}
+                    </div>
+                </section>
+
+                <section class="step" aria-labelledby="container-heading">
+                    <div class="step-heading">
+                        <span class="step-number" aria-hidden="true">2</span>
+                        <div>
+                            <h2 id="container-heading">Choose container</h2>
+                            <p>MKV keeps multiple tracks. MP4 is simpler and more widely compatible.</p>
+                        </div>
+                    </div>
+                    <div class="choice-grid">
+                        <label>
+                            <input
+                                class="choice-input"
+                                type="radio"
+                                name="container"
+                                value="mkv"
+                                aria-label="MKV, multiple audio and subtitle tracks"
+                                checked
+                            />
+                            <span class="choice">
+                                <span class="choice-main">
+                                    <span class="choice-title">MKV</span>
+                                    <span class="choice-detail">Multiple audio and subtitle tracks</span>
+                                </span>
+                                <span class="choice-mark" aria-hidden="true"></span>
+                            </span>
+                        </label>
+                        <label>
+                            <input
+                                class="choice-input"
+                                type="radio"
+                                name="container"
+                                value="mp4"
+                                aria-label="MP4, one audio track and no subtitles"
+                                {{if not .CanUseMP4}}disabled{{end}}
+                            />
+                            <span class="choice">
+                                <span class="choice-main">
+                                    <span class="choice-title">MP4</span>
+                                    <span class="choice-detail">
+                                        {{if .CanUseMP4}}One audio track, no subtitles{{else}}No ready audio track{{end}}
+                                    </span>
+                                </span>
+                                <span class="choice-mark" aria-hidden="true"></span>
+                            </span>
+                        </label>
+                    </div>
+                </section>
+
+                <section class="step" aria-labelledby="tracks-heading">
+                    <div class="step-heading">
+                        <span class="step-number" aria-hidden="true">3</span>
+                        <div>
+                            <h2 id="tracks-heading">Choose tracks</h2>
+                            <p id="tracks-help">MKV can include any combination of ready audio and subtitle tracks.</p>
+                        </div>
+                    </div>
+
+                    <div data-mode="mkv">
+                        <div class="track-block">
+                            <div class="track-header">
+                                <h3>Audio</h3>
+                                {{if .Audios}}
+                                <div class="track-actions" aria-label="Audio selection controls">
+                                    <button class="text-button" type="button" data-select="audio" data-value="all">All</button>
+                                    <button class="text-button" type="button" data-select="audio" data-value="none">None</button>
+                                </div>
+                                {{end}}
+                            </div>
+                            {{if .Audios}}
+                            <div class="track-list">
+                                {{range .Audios}}
+                                <label class="track-row">
+                                    <input
+                                        type="checkbox"
+                                        name="audio"
+                                        value="{{.UUID}}"
+                                        data-track="audio-mkv"
+                                        aria-label="{{.Name}}, {{.Lang}}, {{.Type}}"
+                                        checked
+                                    />
+                                    <span class="track-name">{{.Name}}</span>
+                                    <span class="track-meta">{{.Lang}} · {{.Type}}</span>
+                                </label>
+                                {{end}}
+                            </div>
+                            {{else}}
+                            <p class="empty">No audio tracks are ready. The MKV will contain video only.</p>
+                            {{end}}
+                        </div>
+
+                        <div class="track-block">
+                            <div class="track-header">
+                                <h3>Subtitles</h3>
+                                {{if .Subtitles}}
+                                <div class="track-actions" aria-label="Subtitle selection controls">
+                                    <button class="text-button" type="button" data-select="subtitle" data-value="all">All</button>
+                                    <button class="text-button" type="button" data-select="subtitle" data-value="none">None</button>
+                                </div>
+                                {{end}}
+                            </div>
+                            {{if .Subtitles}}
+                            <div class="track-list">
+                                {{range .Subtitles}}
+                                <label class="track-row">
+                                    <input
+                                        type="checkbox"
+                                        name="subtitle"
+                                        value="{{.UUID}}"
+                                        data-track="subtitle-mkv"
+                                        aria-label="{{.Name}}, {{.Lang}}, {{.Type}}"
+                                        checked
+                                    />
+                                    <span class="track-name">{{.Name}}</span>
+                                    <span class="track-meta">{{.Lang}} · {{.Type}}</span>
+                                </label>
+                                {{end}}
+                            </div>
+                            {{else}}
+                            <p class="empty">No subtitle tracks are ready for this video.</p>
+                            {{end}}
+                        </div>
+                    </div>
+
+                    <div data-mode="mp4" hidden>
+                        {{if .Audios}}
+                        <div class="track-block">
+                            <div class="track-header">
+                                <h3>Audio</h3>
+                            </div>
+                            <div class="track-list">
+                                {{range $index, $audio := .Audios}}
+                                <label class="track-row">
+                                    <input
+                                        type="radio"
+                                        name="audio"
+                                        value="{{$audio.UUID}}"
+                                        data-track="audio-mp4"
+                                        aria-label="{{$audio.Name}}, {{$audio.Lang}}, {{$audio.Type}}"
+                                        {{if eq $index 0}}checked{{end}}
+                                        disabled
+                                    />
+                                    <span class="track-name">{{$audio.Name}}</span>
+                                    <span class="track-meta">{{$audio.Lang}} · {{$audio.Type}}</span>
+                                </label>
+                                {{end}}
+                            </div>
+                            <p class="format-note">MP4 requires exactly one audio track and does not include selectable subtitles.</p>
+                        </div>
+                        {{end}}
+                    </div>
+                </section>
+            </div>
+
+            <aside class="summary" aria-labelledby="summary-heading">
+                <h2 id="summary-heading">Download manifest</h2>
+                <div class="manifest" aria-live="polite">
+                    <div class="manifest-row">
+                        <span>Quality</span>
+                        <strong data-summary="quality">—</strong>
+                    </div>
+                    <div class="manifest-row">
+                        <span>Container</span>
+                        <strong data-summary="container">MKV</strong>
+                    </div>
+                    <div class="manifest-row">
+                        <span>Audio</span>
+                        <strong data-summary="audio">—</strong>
+                    </div>
+                    <div class="manifest-row">
+                        <span>Subtitles</span>
+                        <strong data-summary="subtitle">—</strong>
+                    </div>
+                </div>
+                <button class="download-button" type="submit" data-download-button>
+                    Prepare download
+                </button>
+                <p class="summary-note">Preparation time depends on the video length and selected track count.</p>
+                <p class="form-error" role="alert" data-form-error></p>
+            </aside>
+        </form>
+        {{else}}
+        <section class="not-ready">
+            <h2>No download quality is ready yet</h2>
+            <p>Return to the player and try again after the first video quality finishes encoding.</p>
+        </section>
+        {{end}}
+    </main>
+
+    {{if .CanDownload}}
+    <script>
+        (() => {
+            const form = document.getElementById("download-form");
+            const modeSections = Array.from(document.querySelectorAll("[data-mode]"));
+            const containerInputs = Array.from(document.querySelectorAll('input[name="container"]'));
+            const summary = {
+                quality: document.querySelector('[data-summary="quality"]'),
+                container: document.querySelector('[data-summary="container"]'),
+                audio: document.querySelector('[data-summary="audio"]'),
+                subtitle: document.querySelector('[data-summary="subtitle"]'),
+            };
+            const error = document.querySelector("[data-form-error]");
+            const submitButton = document.querySelector("[data-download-button]");
+            const tracksHelp = document.getElementById("tracks-help");
+
+            const activeContainer = () =>
+                document.querySelector('input[name="container"]:checked')?.value || "mkv";
+
+            const setTrackMode = () => {
+                const container = activeContainer();
+                modeSections.forEach((section) => {
+                    const active = section.dataset.mode === container;
+                    section.hidden = !active;
+                    section.querySelectorAll("input").forEach((input) => {
+                        input.disabled = !active;
+                    });
+                });
+                tracksHelp.textContent = container === "mp4"
+                    ? "MP4 requires one audio track. Subtitle selection is available with MKV."
+                    : "MKV can include any combination of ready audio and subtitle tracks.";
+                error.textContent = "";
+                updateSummary();
+            };
+
+            const selectedTrackCount = (selector) =>
+                document.querySelectorAll(`${selector}:checked:not(:disabled)`).length;
+
+            const countLabel = (count, singular) => `${count} ${count === 1 ? singular : singular + "s"}`;
+
+            const updateSummary = () => {
+                const quality = document.querySelector('input[name="quality"]:checked');
+                const container = activeContainer();
+                const audioCount = selectedTrackCount('input[name="audio"]');
+                const subtitleCount = selectedTrackCount('input[name="subtitle"]');
+
+                summary.quality.textContent = quality
+                    ? `${quality.value} · ${quality.dataset.detail}`
+                    : "—";
+                summary.container.textContent = container.toUpperCase();
+                summary.audio.textContent = countLabel(audioCount, "track");
+                summary.subtitle.textContent = container === "mp4"
+                    ? "Not included"
+                    : countLabel(subtitleCount, "track");
+            };
+
+            document.querySelectorAll("input").forEach((input) => {
+                input.addEventListener("change", () => {
+                    if (input.name === "container") {
+                        setTrackMode();
+                        return;
+                    }
+                    error.textContent = "";
+                    updateSummary();
+                });
+            });
+
+            document.querySelectorAll("[data-select]").forEach((button) => {
+                button.addEventListener("click", () => {
+                    const name = button.dataset.select;
+                    const checked = button.dataset.value === "all";
+                    document.querySelectorAll(`input[data-track="${name}-mkv"]`).forEach((input) => {
+                        input.checked = checked;
+                    });
+                    updateSummary();
+                });
+            });
+
+            form.addEventListener("submit", (event) => {
+                const quality = document.querySelector('input[name="quality"]:checked');
+                const container = activeContainer();
+                const audioCount = selectedTrackCount('input[name="audio"]');
+
+                if (!quality) {
+                    event.preventDefault();
+                    error.textContent = "Choose a video quality.";
+                    return;
+                }
+                if (container === "mp4" && audioCount !== 1) {
+                    event.preventDefault();
+                    error.textContent = "Choose exactly one audio track for MP4.";
+                    return;
+                }
+
+                form.action = `${form.dataset.downloadBase}/${encodeURIComponent(quality.value)}/download/video.${container}`;
+                submitButton.disabled = true;
+                submitButton.textContent = "Preparing…";
+                error.textContent = "";
+                window.setTimeout(() => {
+                    submitButton.disabled = false;
+                    submitButton.textContent = "Prepare download";
+                }, 1400);
+            });
+
+            setTrackMode();
+        })();
+    </script>
+    {{end}}
+</body>
+</html>

--- a/views/player.html
+++ b/views/player.html
@@ -543,6 +543,7 @@
         const WIDTH = parseFloat("{{ .Width }}");
         const RATIO = WIDTH / HEIGHT;
         const DOWNLOAD_ENABLED = "{{ .DownloadEnabled }}" === "true";
+        const DOWNLOAD_PAGE_URL = `/v/${UUID}/download`;
         const CONTINUE_WATCHING_POPUP_ENABLED = "{{ .ContinueWatchingPopupEnabled }}" === "true";
     </script>
     <script>
@@ -632,12 +633,12 @@
                 currentValue: "",
                 checkable: false,
                 items: DOWNLOAD_ENABLED ? [
-                    ...Qualitys.map((Quality, i) => ({
-                        name: `${Quality.label} - ${Quality.width}x${Quality.height}`,
+                    {
+                        name: "Choose quality, format, and tracks",
                         click: () => {
-                            downloadFile(Quality.url);
+                            openDownloadPage();
                         },
-                    })),
+                    },
                 ] : [
                     {
                         name: "Downloads are disabled",
@@ -916,8 +917,8 @@
             });
         }
 
-        function downloadFile(filePath) {
-            window.open(window.origin + filePath)
+        function openDownloadPage() {
+            window.open(DOWNLOAD_PAGE_URL, "_blank", "noopener");
         }
 
         function createVideoPlayer() {

--- a/views/player_v2.html
+++ b/views/player_v2.html
@@ -376,6 +376,7 @@
         const FOLDER = "{{.Folder}}";
         const THUMB = "{{ .Thumbnail }}";
         const DOWNLOAD_ENABLED = "{{ .DownloadEnabled }}" === "true";
+        const DOWNLOAD_PAGE_URL = `/v/${UUID}/download`;
         const CONTINUE_WATCHING_ENABLED = "{{ .ContinueWatchingPopupEnabled }}" === "true";
         const StreamIsReady = ("{{.StreamIsReady}}" === "true");
         
@@ -570,13 +571,27 @@
             const layout = document.querySelector('media-video-layout');
             if (!layout || Qualitys.length === 0) return;
 
-            // Use the built-in 'download' prop
-            // We provide the highest available quality (the last one)
-            const highestQuality = Qualitys[Qualitys.length - 1];
             layout.download = {
-                url: window.origin + highestQuality.url,
-                filename: (player.title || 'video') + '.mkv'
+                url: DOWNLOAD_PAGE_URL,
+                filename: 'download-options'
             };
+
+            const prepareDownloadLink = () => {
+                const link = document.querySelector('.vds-download-button');
+                if (!link) return false;
+                link.href = DOWNLOAD_PAGE_URL;
+                link.removeAttribute('download');
+                link.target = '_blank';
+                link.rel = 'noopener';
+                return true;
+            };
+
+            if (!prepareDownloadLink()) {
+                const observer = new MutationObserver(() => {
+                    if (prepareDownloadLink()) observer.disconnect();
+                });
+                observer.observe(layout, { childList: true, subtree: true });
+            }
         }
 
         // --- Position Tracking & Continue Watching ---


### PR DESCRIPTION
## Summary
- replace direct player downloads with a responsive download options page
- support quality and MKV/MP4 selection with server-validated audio/subtitle manifests
- require one audio track for MP4 and allow selectable tracks for MKV
- remove legacy implicit MKV selection behavior

## Verification
- go test ./...
- live desktop and iPhone SE responsive QA
- authenticated MP4 and MKV FFmpeg remux checks