### PR TITLE
Fix download page URL and branding

### DIFF
--- a/media_templates_test.go
+++ b/media_templates_test.go
@@ -70,6 +70,14 @@ func TestPlayerTemplatesOpenDownloadOptionsPage(t *testing.T) {
 	}
 }
 
+func TestPlayerV2UsesAbsoluteDownloadURLForVidstack(t *testing.T) {
+	content := string(readTemplateFile(t, "views/player_v2.html"))
+	expected := "new URL(`/v/${UUID}/download`, window.location.origin).href"
+	if !strings.Contains(content, expected) {
+		t.Fatalf("player_v2.html must pass Vidstack an absolute download URL")
+	}
+}
+
 func TestDownloadTemplateContainsSelectionRules(t *testing.T) {
 	content := string(readTemplateFile(t, "views/download.html"))
 	for _, expected := range []string{
@@ -81,6 +89,8 @@ func TestDownloadTemplateContainsSelectionRules(t *testing.T) {
 		`name="subtitle"`,
 		"MP4 requires exactly one audio track",
 		"Download manifest",
+		`class="brand-logo"`,
+		`src="/logo.png"`,
 	} {
 		if !strings.Contains(content, expected) {
 			t.Fatalf("download.html missing selection marker %q", expected)

--- a/views/download.html
+++ b/views/download.html
@@ -79,10 +79,26 @@
         }
 
         .brand {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            border-radius: 8px;
             color: var(--muted);
             font-size: 0.875rem;
             font-weight: 600;
             text-decoration: none;
+            transition: color 160ms ease;
+        }
+
+        .brand-logo {
+            width: 24px;
+            height: 24px;
+            flex: 0 0 auto;
+            object-fit: contain;
+        }
+
+        .brand:hover {
+            color: #fff;
         }
 
         .back-link {
@@ -101,6 +117,7 @@
             color: #fff;
         }
 
+        .brand:focus-visible,
         .back-link:focus-visible,
         button:focus-visible,
         input:focus-visible + .choice {
@@ -581,7 +598,10 @@
                 <span aria-hidden="true">←</span>
                 Back to player
             </a>
-            <a class="brand" href="/">{{.AppName}}</a>
+            <a class="brand" href="/">
+                <img class="brand-logo" src="/logo.png" alt="" />
+                <span>{{.AppName}}</span>
+            </a>
         </nav>
 
         <header class="video-context">

--- a/views/player_v2.html
+++ b/views/player_v2.html
@@ -376,7 +376,7 @@
         const FOLDER = "{{.Folder}}";
         const THUMB = "{{ .Thumbnail }}";
         const DOWNLOAD_ENABLED = "{{ .DownloadEnabled }}" === "true";
-        const DOWNLOAD_PAGE_URL = `/v/${UUID}/download`;
+        const DOWNLOAD_PAGE_URL = new URL(`/v/${UUID}/download`, window.location.origin).href;
         const CONTINUE_WATCHING_ENABLED = "{{ .ContinueWatchingPopupEnabled }}" === "true";
         const StreamIsReady = ("{{.StreamIsReady}}" === "true");
         


### PR DESCRIPTION
## Summary
- pass Vidstack an absolute same-origin download URL
- add the configured app name and existing logo to the download header
- cover both behaviors with template regression tests

## Validation
- go test ./...
- verified mobile and desktop download-page layouts in the browser