### PR TITLE
Introduce provider-neutral media storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ COPY middlewares ./middlewares
 COPY models ./models
 COPY routes ./routes
 COPY services ./services
+COPY storage ./storage
 
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
@@ -103,6 +104,7 @@ ENV Host=:3000
 ENV FolderVideoQualitysPriv=./videos/qualitys
 ENV FolderVideoQualitysPub=/videos/qualitys
 ENV FolderVideoUploadsPriv=./videos/uploads
+ENV StorageScratchDir=./videos/scratch
 ENV StatsDriveName=nvme0n1
 
 EXPOSE 3000

--- a/app/runtime.go
+++ b/app/runtime.go
@@ -6,6 +6,7 @@ import (
 
 	"ch/kirari04/videocms/config"
 	"ch/kirari04/videocms/models"
+	"ch/kirari04/videocms/storage"
 
 	"github.com/patrickmn/go-cache"
 	"gorm.io/gorm"
@@ -58,6 +59,7 @@ type Deps struct {
 	Snapshots   *SnapshotStore
 	Cache       *cache.Cache
 	RequestGate *RequestGate
+	Storage     *storage.Service
 }
 
 func (d *Deps) Config() config.Config {

--- a/auth/media.go
+++ b/auth/media.go
@@ -15,6 +15,7 @@ const mediaAudience = "videocms-media"
 type MediaClaims struct {
 	LinkUUID      string          `json:"link_uuid"`
 	FileUUID      string          `json:"file_uuid"`
+	StorageID     string          `json:"storage_id"`
 	UserID        uint            `json:"user_id"`
 	FileID        uint            `json:"file_id"`
 	QualityIDs    map[string]uint `json:"quality_ids"`

--- a/auth/media_test.go
+++ b/auth/media_test.go
@@ -15,6 +15,7 @@ func TestGenerateAndVerifyMediaToken(t *testing.T) {
 	tokenString, expires, err := authSvc.GenerateMediaToken(MediaClaims{
 		LinkUUID:      "link-uuid",
 		FileUUID:      "file-uuid",
+		StorageID:     "archive",
 		UserID:        1,
 		FileID:        2,
 		QualityIDs:    map[string]uint{"720p": 3},
@@ -37,6 +38,9 @@ func TestGenerateAndVerifyMediaToken(t *testing.T) {
 	}
 	if claims.LinkUUID != "link-uuid" || claims.FileUUID != "file-uuid" {
 		t.Fatalf("unexpected claims: %+v", claims)
+	}
+	if claims.StorageID != "archive" {
+		t.Fatalf("storage ID was not preserved: %q", claims.StorageID)
 	}
 	if claims.QualityIDs["720p"] != 3 {
 		t.Fatalf("quality id was not preserved: %+v", claims.QualityIDs)

--- a/cmd/ServeMain.go
+++ b/cmd/ServeMain.go
@@ -20,6 +20,13 @@ func ServeMain() {
 		log.Println("failed to initialize runtime:", err)
 		os.Exit(1)
 	}
+	if deps.Storage != nil {
+		defer func() {
+			if err := deps.Storage.Close(); err != nil {
+				log.Printf("failed to close storage: %v", err)
+			}
+		}()
+	}
 
 	// sync UserRequestAsync
 	deps.RequestGate.Sync(true)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -6,6 +6,7 @@ import (
 	"ch/kirari04/videocms/configdb"
 	"ch/kirari04/videocms/helpers"
 	"ch/kirari04/videocms/inits"
+	"ch/kirari04/videocms/storage"
 	"log"
 	"os"
 	"time"
@@ -41,11 +42,31 @@ func InitRuntime() (*app.Deps, error) {
 	if err := inits.EnsureFolders(snapshot.Config); err != nil {
 		return nil, err
 	}
+	localMediaStore, err := storage.NewLocalStore(snapshot.Config.FolderVideoQualitysPriv)
+	if err != nil {
+		return nil, err
+	}
+	workspace, err := storage.NewLocalWorkspace(snapshot.Config.StorageScratchDir)
+	if err != nil {
+		_ = localMediaStore.Close()
+		return nil, err
+	}
+	storageService, err := storage.NewServiceWithWorkspace(
+		"local",
+		storage.LegacyMediaLayout{},
+		workspace,
+		map[string]storage.Store{"local": localMediaStore},
+	)
+	if err != nil {
+		_ = localMediaStore.Close()
+		return nil, err
+	}
 
 	return &app.Deps{
 		DB:          db,
 		Snapshots:   app.NewSnapshotStore(snapshot),
 		Cache:       cache.New(5*time.Minute, 10*time.Minute),
 		RequestGate: app.NewRequestGate(),
+		Storage:     storageService,
 	}, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -81,6 +81,7 @@ type Config struct {
 	FolderVideoQualitysPub  string `validate:"required,min=1,max=255"`
 	FolderVideoQualitysPriv string `validate:"required,min=1,max=255"`
 	FolderVideoUploadsPriv  string `validate:"required,min=1,max=255"`
+	StorageScratchDir       string `validate:"required,min=1,max=255"`
 
 	CorsAllowOrigins     string
 	CorsAllowHeaders     string
@@ -241,6 +242,7 @@ func LoadEnv() Config {
 	env.FolderVideoQualitysPriv = getEnv("FolderVideoQualitysPriv", "./videos/qualitys")
 	env.FolderVideoQualitysPub = getEnv("FolderVideoQualitysPub", "/videos/qualitys")
 	env.FolderVideoUploadsPriv = getEnv("FolderVideoUploadsPriv", "./videos/uploads")
+	env.StorageScratchDir = getEnv("StorageScratchDir", "./videos/scratch")
 	env.StatsDriveName = getEnv("StatsDriveName", "nvme0n1")
 
 	return env

--- a/controllers/CreateFileController.go
+++ b/controllers/CreateFileController.go
@@ -46,9 +46,15 @@ func (h *Handlers) CreateFile(c echo.Context) error {
 		c.Logger().Error("Failed to open destination file", err)
 		return c.NoContent(http.StatusInternalServerError)
 	}
-	defer dst.Close()
 	if _, err = io.Copy(dst, src); err != nil {
+		dst.Close()
+		os.Remove(filePath)
 		c.Logger().Errorf("Failed to save file: %v", err)
+		return c.NoContent(http.StatusInternalServerError)
+	}
+	if err := dst.Close(); err != nil {
+		os.Remove(filePath)
+		c.Logger().Errorf("Failed to close uploaded file: %v", err)
 		return c.NoContent(http.StatusInternalServerError)
 	}
 

--- a/controllers/DownloadVideoController.go
+++ b/controllers/DownloadVideoController.go
@@ -10,12 +10,10 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 )
 
@@ -73,12 +71,30 @@ func (h *Handlers) DownloadVideoController(c echo.Context) error {
 	if err != nil {
 		return c.String(http.StatusBadRequest, err.Error())
 	}
+	cleanupInputs, err := downloadsvc.MaterializeSelection(c.Request().Context(), h.Deps.Storage, &dbLink.File, selection)
+	if err != nil {
+		c.Logger().Errorf("Failed to materialize download inputs: %v", err)
+		return c.String(http.StatusInternalServerError, "failed to prepare download inputs")
+	}
+	defer cleanupInputs()
 
-	tmpFilePath := filepath.Join(
-		h.Config().FolderVideoUploadsPriv,
-		fmt.Sprintf("%s-download.%s", uuid.NewString(), selection.Container),
+	if h.Deps.Storage == nil || h.Deps.Storage.Workspace() == nil {
+		return c.String(http.StatusInternalServerError, "download workspace is unavailable")
+	}
+	tmpOutput, cleanupOutput, err := h.Deps.Storage.Workspace().TempFile(
+		c.Request().Context(),
+		"stream-download",
+		"."+selection.Container,
 	)
-	defer os.Remove(tmpFilePath)
+	if err != nil {
+		return c.String(http.StatusInternalServerError, "failed to prepare download output")
+	}
+	tmpFilePath := tmpOutput.Name()
+	if err := tmpOutput.Close(); err != nil {
+		_ = cleanupOutput()
+		return c.String(http.StatusInternalServerError, "failed to prepare download output")
+	}
+	defer cleanupOutput()
 
 	cmdArgs := downloadFFmpegArgs(selection, tmpFilePath)
 	cmd := exec.CommandContext(c.Request().Context(), "ffmpeg", cmdArgs...)

--- a/controllers/GetAudioDataController.go
+++ b/controllers/GetAudioDataController.go
@@ -37,7 +37,7 @@ func (h *Handlers) GetAudioData(c echo.Context) error {
 	if err != nil {
 		return c.String(http.StatusBadRequest, "bad media key")
 	}
-	return h.serveMediaObject(c, key, "Audio doesn't exist", mediaTraffic{
+	return h.serveMediaObject(c, claims.StorageID, key, "Audio doesn't exist", mediaTraffic{
 		userID:  claims.UserID,
 		fileID:  claims.FileID,
 		audioID: audioID,

--- a/controllers/GetAudioDataController.go
+++ b/controllers/GetAudioDataController.go
@@ -4,9 +4,7 @@ import (
 	"ch/kirari04/videocms/helpers"
 	"ch/kirari04/videocms/middlewares"
 	"ch/kirari04/videocms/models"
-	"fmt"
 	"net/http"
-	"os"
 	"regexp"
 
 	"github.com/labstack/echo/v4"
@@ -32,14 +30,16 @@ func (h *Handlers) GetAudioData(c echo.Context) error {
 		return c.String(http.StatusNotFound, "Audio doesn't exist")
 	}
 
-	filePath := fmt.Sprintf("%s/%s/%s/%s", h.Config().FolderVideoQualitysPriv, claims.FileUUID, requestValidation.AUDIOUUID, requestValidation.FILE)
-	fileInfo, err := os.Stat(filePath)
-	if err == nil {
-		h.Logic.TrackTraffic(claims.UserID, claims.FileID, 0, audioID, uint64(fileInfo.Size()))
+	if h.Deps.Storage == nil || h.Deps.Storage.Layout() == nil {
+		return c.NoContent(http.StatusInternalServerError)
 	}
-
-	if err := c.File(filePath); err != nil {
-		return c.String(http.StatusNotFound, "Audio doesn't exist")
+	key, err := h.Deps.Storage.Layout().Audio(claims.FileUUID, requestValidation.AUDIOUUID, requestValidation.FILE)
+	if err != nil {
+		return c.String(http.StatusBadRequest, "bad media key")
 	}
-	return nil
+	return h.serveMediaObject(c, key, "Audio doesn't exist", mediaTraffic{
+		userID:  claims.UserID,
+		fileID:  claims.FileID,
+		audioID: audioID,
+	})
 }

--- a/controllers/GetSubtitleDataController.go
+++ b/controllers/GetSubtitleDataController.go
@@ -3,9 +3,7 @@ package controllers
 import (
 	"ch/kirari04/videocms/helpers"
 	"ch/kirari04/videocms/middlewares"
-	"fmt"
 	"net/http"
-	"os"
 	"regexp"
 
 	"github.com/labstack/echo/v4"
@@ -35,16 +33,17 @@ func (h *Handlers) GetSubtitleData(c echo.Context) error {
 		return c.String(http.StatusNotFound, "Subtitle doesn't exist")
 	}
 
-	filePath := fmt.Sprintf("%s/%s/%s/%s", h.Config().FolderVideoQualitysPriv, claims.FileUUID, requestValidation.SUBUUID, requestValidation.FILE)
-	fileInfo, err := os.Stat(filePath)
-	if err == nil {
-		h.Logic.TrackTraffic(claims.UserID, claims.FileID, 0, 0, uint64(fileInfo.Size()))
+	if h.Deps.Storage == nil || h.Deps.Storage.Layout() == nil {
+		return c.NoContent(http.StatusInternalServerError)
 	}
-
-	if err := c.File(filePath); err != nil {
-		return c.String(http.StatusNotFound, "Subtitle file not found")
+	key, err := h.Deps.Storage.Layout().Subtitle(claims.FileUUID, requestValidation.SUBUUID, requestValidation.FILE)
+	if err != nil {
+		return c.String(http.StatusBadRequest, "bad media key")
 	}
-	return nil
+	return h.serveMediaObject(c, key, "Subtitle file not found", mediaTraffic{
+		userID: claims.UserID,
+		fileID: claims.FileID,
+	})
 }
 
 func subtitleAllowed(subtitleUUIDs []string, subtitleUUID string) bool {

--- a/controllers/GetSubtitleDataController.go
+++ b/controllers/GetSubtitleDataController.go
@@ -40,7 +40,7 @@ func (h *Handlers) GetSubtitleData(c echo.Context) error {
 	if err != nil {
 		return c.String(http.StatusBadRequest, "bad media key")
 	}
-	return h.serveMediaObject(c, key, "Subtitle file not found", mediaTraffic{
+	return h.serveMediaObject(c, claims.StorageID, key, "Subtitle file not found", mediaTraffic{
 		userID: claims.UserID,
 		fileID: claims.FileID,
 	})

--- a/controllers/GetThumbnailDataController.go
+++ b/controllers/GetThumbnailDataController.go
@@ -17,16 +17,16 @@ func (h *Handlers) GetThumbnailData(c echo.Context) error {
 		return c.String(status, err.Error())
 	}
 
-	_, fileUUID, userID, fileID, err := h.Logic.ResolveThumbnailData(requestValidation.FILE, requestValidation.UUID)
+	_, object, err := h.Logic.ResolveThumbnailObject(requestValidation.FILE, requestValidation.UUID)
 	if err != nil {
 		return c.NoContent(http.StatusNotFound)
 	}
 	if h.Deps.Storage == nil || h.Deps.Storage.Layout() == nil {
 		return c.NoContent(http.StatusInternalServerError)
 	}
-	key, err := h.Deps.Storage.Layout().Thumbnail(fileUUID, requestValidation.FILE)
+	key, err := h.Deps.Storage.Layout().Thumbnail(object.FileUUID, requestValidation.FILE)
 	if err != nil {
 		return c.NoContent(http.StatusBadRequest)
 	}
-	return h.serveMediaObject(c, key, "", mediaTraffic{userID: userID, fileID: fileID})
+	return h.serveMediaObject(c, object.StoreID, key, "", mediaTraffic{userID: object.UserID, fileID: object.FileID})
 }

--- a/controllers/GetThumbnailDataController.go
+++ b/controllers/GetThumbnailDataController.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"ch/kirari04/videocms/helpers"
 	"net/http"
-	"os"
 
 	"github.com/labstack/echo/v4"
 )
@@ -18,18 +17,16 @@ func (h *Handlers) GetThumbnailData(c echo.Context) error {
 		return c.String(status, err.Error())
 	}
 
-	_, filePath, userID, fileID, err := h.Logic.GetThumbnailData(requestValidation.FILE, requestValidation.UUID)
+	_, fileUUID, userID, fileID, err := h.Logic.ResolveThumbnailData(requestValidation.FILE, requestValidation.UUID)
 	if err != nil {
 		return c.NoContent(http.StatusNotFound)
 	}
-
-	fileInfo, err := os.Stat(*filePath)
-	if err == nil {
-		h.Logic.TrackTraffic(userID, fileID, 0, 0, uint64(fileInfo.Size()))
+	if h.Deps.Storage == nil || h.Deps.Storage.Layout() == nil {
+		return c.NoContent(http.StatusInternalServerError)
 	}
-
-	if err := c.File(*filePath); err != nil {
-		return c.NoContent(http.StatusNotFound)
+	key, err := h.Deps.Storage.Layout().Thumbnail(fileUUID, requestValidation.FILE)
+	if err != nil {
+		return c.NoContent(http.StatusBadRequest)
 	}
-	return nil
+	return h.serveMediaObject(c, key, "", mediaTraffic{userID: userID, fileID: fileID})
 }

--- a/controllers/GetVideoDataController.go
+++ b/controllers/GetVideoDataController.go
@@ -3,9 +3,7 @@ package controllers
 import (
 	"ch/kirari04/videocms/helpers"
 	"ch/kirari04/videocms/middlewares"
-	"fmt"
 	"net/http"
-	"os"
 	"regexp"
 
 	"github.com/labstack/echo/v4"
@@ -40,14 +38,16 @@ func (h *Handlers) GetVideoData(c echo.Context) error {
 		return c.String(http.StatusNotFound, "Video doesn't exist")
 	}
 
-	filePath := fmt.Sprintf("%s/%s/%s/%s", h.Config().FolderVideoQualitysPriv, claims.FileUUID, requestValidation.QUALITY, requestValidation.FILE)
-	fileInfo, err := os.Stat(filePath)
-	if err == nil {
-		h.Logic.TrackTraffic(claims.UserID, claims.FileID, qualityID, 0, uint64(fileInfo.Size()))
+	if h.Deps.Storage == nil || h.Deps.Storage.Layout() == nil {
+		return c.NoContent(http.StatusInternalServerError)
 	}
-
-	if err := c.File(filePath); err != nil {
-		return c.String(http.StatusNotFound, "Video doesn't exist")
+	key, err := h.Deps.Storage.Layout().Video(claims.FileUUID, requestValidation.QUALITY, requestValidation.FILE)
+	if err != nil {
+		return c.String(http.StatusBadRequest, "bad media key")
 	}
-	return nil
+	return h.serveMediaObject(c, key, "Video doesn't exist", mediaTraffic{
+		userID:    claims.UserID,
+		fileID:    claims.FileID,
+		qualityID: qualityID,
+	})
 }

--- a/controllers/GetVideoDataController.go
+++ b/controllers/GetVideoDataController.go
@@ -45,7 +45,7 @@ func (h *Handlers) GetVideoData(c echo.Context) error {
 	if err != nil {
 		return c.String(http.StatusBadRequest, "bad media key")
 	}
-	return h.serveMediaObject(c, key, "Video doesn't exist", mediaTraffic{
+	return h.serveMediaObject(c, claims.StorageID, key, "Video doesn't exist", mediaTraffic{
 		userID:    claims.UserID,
 		fileID:    claims.FileID,
 		qualityID: qualityID,

--- a/controllers/MediaFiles_test.go
+++ b/controllers/MediaFiles_test.go
@@ -50,6 +50,38 @@ func TestGetVideoDataUsesMediaClaims(t *testing.T) {
 	}
 }
 
+func TestGetVideoDataUsesClaimedNamedStore(t *testing.T) {
+	defaultRoot := t.TempDir()
+	archiveRoot := t.TempDir()
+	h := mediaTestHandlersWithStores(t, defaultRoot, map[string]string{
+		"local":   defaultRoot,
+		"archive": archiveRoot,
+	}, true)
+	mustWriteFile(t, filepath.Join(archiveRoot, "file-uuid", "720p", "out0.ts"), []byte("archive"))
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/videos/qualitys/"+testLinkUUID+"/720p/out0.ts", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("UUID", "QUALITY", "FILE")
+	c.SetParamValues(testLinkUUID, "720p", "out0.ts")
+	c.Set(middlewares.MediaClaimsContextKey, &auth.MediaClaims{
+		LinkUUID:   testLinkUUID,
+		FileUUID:   "file-uuid",
+		StorageID:  "archive",
+		UserID:     1,
+		FileID:     2,
+		QualityIDs: map[string]uint{"720p": 3},
+	})
+
+	if err := h.GetVideoData(c); err != nil {
+		t.Fatalf("GetVideoData() error = %v", err)
+	}
+	if rec.Code != http.StatusOK || rec.Body.String() != "archive" {
+		t.Fatalf("response = %d %q, want archive object", rec.Code, rec.Body.String())
+	}
+}
+
 func TestGetVideoDataSupportsRangesAndTracksDeliveredBytes(t *testing.T) {
 	h := mediaTestHandlers(t, t.TempDir(), true)
 	mediaPath := filepath.Join(h.Config().FolderVideoQualitysPriv, "file-uuid", "720p", "out0.ts")
@@ -177,6 +209,10 @@ func TestDownloadVideoHonorsDownloadEnabledBeforeDatabaseLookup(t *testing.T) {
 }
 
 func mediaTestHandlers(t *testing.T, root string, downloadEnabled bool) *Handlers {
+	return mediaTestHandlersWithStores(t, root, map[string]string{"local": root}, downloadEnabled)
+}
+
+func mediaTestHandlersWithStores(t *testing.T, root string, roots map[string]string, downloadEnabled bool) *Handlers {
 	t.Helper()
 	db, err := gorm.Open(sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"), &gorm.Config{})
 	if err != nil {
@@ -185,14 +221,18 @@ func mediaTestHandlers(t *testing.T, root string, downloadEnabled bool) *Handler
 	if err := db.AutoMigrate(&models.TrafficLog{}); err != nil {
 		t.Fatalf("migrate test db: %v", err)
 	}
-	localStore, err := storage.NewLocalStore(root)
-	if err != nil {
-		t.Fatalf("create local store: %v", err)
+	stores := make(map[string]storage.Store, len(roots))
+	for id, storeRoot := range roots {
+		localStore, err := storage.NewLocalStore(storeRoot)
+		if err != nil {
+			t.Fatalf("create %s store: %v", id, err)
+		}
+		stores[id] = localStore
 	}
 	storageService, err := storage.NewService(
 		"local",
 		storage.LegacyMediaLayout{},
-		map[string]storage.Store{"local": localStore},
+		stores,
 	)
 	if err != nil {
 		t.Fatalf("create storage service: %v", err)

--- a/controllers/MediaFiles_test.go
+++ b/controllers/MediaFiles_test.go
@@ -7,6 +7,7 @@ import (
 	"ch/kirari04/videocms/logic"
 	"ch/kirari04/videocms/middlewares"
 	"ch/kirari04/videocms/models"
+	"ch/kirari04/videocms/storage"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -46,6 +47,45 @@ func TestGetVideoDataUsesMediaClaims(t *testing.T) {
 	}
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+func TestGetVideoDataSupportsRangesAndTracksDeliveredBytes(t *testing.T) {
+	h := mediaTestHandlers(t, t.TempDir(), true)
+	mediaPath := filepath.Join(h.Config().FolderVideoQualitysPriv, "file-uuid", "720p", "out0.ts")
+	mustWriteFile(t, mediaPath, []byte("0123456789"))
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/videos/qualitys/"+testLinkUUID+"/720p/out0.ts", nil)
+	req.Header.Set("Range", "bytes=2-5")
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("UUID", "QUALITY", "FILE")
+	c.SetParamValues(testLinkUUID, "720p", "out0.ts")
+	c.Set(middlewares.MediaClaimsContextKey, &auth.MediaClaims{
+		LinkUUID:   testLinkUUID,
+		FileUUID:   "file-uuid",
+		UserID:     1,
+		FileID:     2,
+		QualityIDs: map[string]uint{"720p": 3},
+	})
+
+	if err := h.GetVideoData(c); err != nil {
+		t.Fatalf("GetVideoData() error = %v", err)
+	}
+	if rec.Code != http.StatusPartialContent {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusPartialContent)
+	}
+	if rec.Body.String() != "2345" {
+		t.Fatalf("body = %q, want %q", rec.Body.String(), "2345")
+	}
+
+	var traffic models.TrafficLog
+	if err := h.Deps.DB.First(&traffic).Error; err != nil {
+		t.Fatalf("load traffic log: %v", err)
+	}
+	if traffic.Bytes != 4 || traffic.UserID != 1 || traffic.FileID != 2 || traffic.QualityID != 3 {
+		t.Fatalf("traffic log = %#v, want four delivered bytes for the selected quality", traffic)
 	}
 }
 
@@ -145,6 +185,19 @@ func mediaTestHandlers(t *testing.T, root string, downloadEnabled bool) *Handler
 	if err := db.AutoMigrate(&models.TrafficLog{}); err != nil {
 		t.Fatalf("migrate test db: %v", err)
 	}
+	localStore, err := storage.NewLocalStore(root)
+	if err != nil {
+		t.Fatalf("create local store: %v", err)
+	}
+	storageService, err := storage.NewService(
+		"local",
+		storage.LegacyMediaLayout{},
+		map[string]storage.Store{"local": localStore},
+	)
+	if err != nil {
+		t.Fatalf("create storage service: %v", err)
+	}
+	t.Cleanup(func() { _ = storageService.Close() })
 	deps := &app.Deps{
 		DB: db,
 		Snapshots: app.NewSnapshotStore(app.Snapshot{Config: config.Config{
@@ -153,6 +206,7 @@ func mediaTestHandlers(t *testing.T, root string, downloadEnabled bool) *Handler
 			DownloadEnabled:         &downloadEnabled,
 		}}),
 		RequestGate: app.NewRequestGate(),
+		Storage:     storageService,
 	}
 	logicSvc := logic.NewService(deps)
 	authSvc := auth.NewService(deps)
@@ -161,10 +215,15 @@ func mediaTestHandlers(t *testing.T, root string, downloadEnabled bool) *Handler
 
 func mustWriteEmptyFile(t *testing.T, path string) {
 	t.Helper()
+	mustWriteFile(t, path, nil)
+}
+
+func mustWriteFile(t *testing.T, path string, data []byte) {
+	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("MkdirAll() error = %v", err)
 	}
-	if err := os.WriteFile(path, nil, 0o644); err != nil {
+	if err := os.WriteFile(path, data, 0o644); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
 }

--- a/controllers/MediaStorage.go
+++ b/controllers/MediaStorage.go
@@ -18,11 +18,11 @@ type mediaTraffic struct {
 	audioID   uint
 }
 
-func (h *Handlers) readMediaObject(c echo.Context, key storage.Key, maxBytes int64) ([]byte, error) {
+func (h *Handlers) readMediaObject(c echo.Context, storeID string, key storage.Key, maxBytes int64) ([]byte, error) {
 	if h == nil || h.Deps == nil || h.Deps.Storage == nil {
 		return nil, storage.ErrStoreNotConfigured
 	}
-	store, err := h.Deps.Storage.Default()
+	store, err := h.Deps.Storage.StoreOrDefault(storeID)
 	if err != nil {
 		return nil, err
 	}
@@ -48,12 +48,12 @@ func (h *Handlers) readMediaObject(c echo.Context, key storage.Key, maxBytes int
 	return data, nil
 }
 
-func (h *Handlers) serveMediaObject(c echo.Context, key storage.Key, notFoundMessage string, traffic mediaTraffic) error {
+func (h *Handlers) serveMediaObject(c echo.Context, storeID string, key storage.Key, notFoundMessage string, traffic mediaTraffic) error {
 	if h == nil || h.Deps == nil || h.Deps.Storage == nil {
 		c.Logger().Error("media storage is not configured")
 		return mediaStorageResponse(c, http.StatusInternalServerError, "")
 	}
-	store, err := h.Deps.Storage.Default()
+	store, err := h.Deps.Storage.StoreOrDefault(storeID)
 	if err != nil {
 		c.Logger().Error("failed to resolve media storage", err)
 		return mediaStorageResponse(c, http.StatusInternalServerError, "")

--- a/controllers/MediaStorage.go
+++ b/controllers/MediaStorage.go
@@ -1,0 +1,97 @@
+package controllers
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"ch/kirari04/videocms/storage"
+
+	"github.com/labstack/echo/v4"
+)
+
+type mediaTraffic struct {
+	userID    uint
+	fileID    uint
+	qualityID uint
+	audioID   uint
+}
+
+func (h *Handlers) readMediaObject(c echo.Context, key storage.Key, maxBytes int64) ([]byte, error) {
+	if h == nil || h.Deps == nil || h.Deps.Storage == nil {
+		return nil, storage.ErrStoreNotConfigured
+	}
+	store, err := h.Deps.Storage.Default()
+	if err != nil {
+		return nil, err
+	}
+	object, err := store.Open(c.Request().Context(), key)
+	if err != nil {
+		return nil, err
+	}
+	defer object.Body.Close()
+	if maxBytes > 0 && object.Info.Size > maxBytes {
+		return nil, fmt.Errorf("media object %s exceeds read limit", key.String())
+	}
+	reader := io.Reader(object.Body)
+	if maxBytes > 0 {
+		reader = io.LimitReader(object.Body, maxBytes+1)
+	}
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, err
+	}
+	if maxBytes > 0 && int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("media object %s exceeds read limit", key.String())
+	}
+	return data, nil
+}
+
+func (h *Handlers) serveMediaObject(c echo.Context, key storage.Key, notFoundMessage string, traffic mediaTraffic) error {
+	if h == nil || h.Deps == nil || h.Deps.Storage == nil {
+		c.Logger().Error("media storage is not configured")
+		return mediaStorageResponse(c, http.StatusInternalServerError, "")
+	}
+	store, err := h.Deps.Storage.Default()
+	if err != nil {
+		c.Logger().Error("failed to resolve media storage", err)
+		return mediaStorageResponse(c, http.StatusInternalServerError, "")
+	}
+	object, err := store.Open(c.Request().Context(), key)
+	if err != nil {
+		if !errors.Is(err, storage.ErrNotFound) {
+			c.Logger().Errorf("failed to open media object %s: %v", key.String(), err)
+			return mediaStorageResponse(c, http.StatusInternalServerError, "")
+		}
+		return mediaStorageResponse(c, http.StatusNotFound, notFoundMessage)
+	}
+	defer object.Body.Close()
+
+	if object.Info.ContentType != "" {
+		c.Response().Header().Set("Content-Type", object.Info.ContentType)
+	}
+	if object.Info.CacheControl != "" {
+		c.Response().Header().Set("Cache-Control", object.Info.CacheControl)
+	}
+
+	counter := &countingResponseWriter{ResponseWriter: c.Response().Writer}
+	http.ServeContent(counter, c.Request(), key.String(), object.Info.ModTime, object.Body)
+	if counter.bytes > 0 && (counter.status == http.StatusOK || counter.status == http.StatusPartialContent) {
+		h.Logic.TrackTraffic(
+			traffic.userID,
+			traffic.fileID,
+			traffic.qualityID,
+			traffic.audioID,
+			counter.bytes,
+		)
+	}
+	return nil
+}
+
+func mediaStorageResponse(c echo.Context, status int, message string) error {
+	if message == "" {
+		return c.NoContent(status)
+	}
+	return c.String(status, message)
+}

--- a/controllers/PlayerController.go
+++ b/controllers/PlayerController.go
@@ -11,7 +11,6 @@ import (
 	"log"
 	"math"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -99,15 +98,17 @@ func (h *Handlers) PlayerController(c echo.Context) error {
 
 	// List subtitles
 	for _, subItem := range dbLink.File.Subtitles {
-		if subItem.Ready {
-			subPath := fmt.Sprintf("%s/%s/%s/%s", h.Config().FolderVideoQualitysPriv, dbLink.File.UUID, subItem.UUID, subItem.OutputFile)
-			if subContent, err := os.ReadFile(subPath); err == nil {
-				jsonSubtitles = append(jsonSubtitles, map[string]string{
-					"data": base64.StdEncoding.EncodeToString(subContent),
-					"type": subItem.Type,
-					"name": subItem.Name,
-					"lang": subItem.Lang,
-				})
+		if subItem.Ready && h.Deps.Storage != nil && h.Deps.Storage.Layout() != nil {
+			key, keyErr := h.Deps.Storage.Layout().Subtitle(dbLink.File.UUID, subItem.UUID, subItem.OutputFile)
+			if keyErr == nil {
+				if subContent, err := h.readMediaObject(c, key, 16*1024*1024); err == nil {
+					jsonSubtitles = append(jsonSubtitles, map[string]string{
+						"data": base64.StdEncoding.EncodeToString(subContent),
+						"type": subItem.Type,
+						"name": subItem.Name,
+						"lang": subItem.Lang,
+					})
+				}
 			}
 		}
 	}

--- a/controllers/PlayerController.go
+++ b/controllers/PlayerController.go
@@ -101,7 +101,7 @@ func (h *Handlers) PlayerController(c echo.Context) error {
 		if subItem.Ready && h.Deps.Storage != nil && h.Deps.Storage.Layout() != nil {
 			key, keyErr := h.Deps.Storage.Layout().Subtitle(dbLink.File.UUID, subItem.UUID, subItem.OutputFile)
 			if keyErr == nil {
-				if subContent, err := h.readMediaObject(c, key, 16*1024*1024); err == nil {
+				if subContent, err := h.readMediaObject(c, dbLink.File.StorageID, key, 16*1024*1024); err == nil {
 					jsonSubtitles = append(jsonSubtitles, map[string]string{
 						"data": base64.StdEncoding.EncodeToString(subContent),
 						"type": subItem.Type,
@@ -437,6 +437,7 @@ func buildMediaClaims(dbLink *models.Link) auth.MediaClaims {
 	return auth.MediaClaims{
 		LinkUUID:      dbLink.UUID,
 		FileUUID:      dbLink.File.UUID,
+		StorageID:     dbLink.File.StorageID,
 		UserID:        dbLink.UserID,
 		FileID:        dbLink.FileID,
 		QualityIDs:    qualityIDs,

--- a/download/materialize.go
+++ b/download/materialize.go
@@ -1,0 +1,76 @@
+package download
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"ch/kirari04/videocms/models"
+	"ch/kirari04/videocms/storage"
+)
+
+// MaterializeSelection resolves every selected rendition to a local directory
+// so path-oriented assemblers such as FFmpeg remain independent of the
+// durable storage adapter.
+func MaterializeSelection(ctx context.Context, service *storage.Service, file *models.File, selection *Selection) (func() error, error) {
+	if service == nil {
+		return func() error { return nil }, nil
+	}
+	if file == nil || selection == nil || service.Layout() == nil {
+		return nil, storage.ErrStoreNotConfigured
+	}
+
+	cleanups := make([]func() error, 0, 1+len(selection.Audios)+len(selection.Subtitles))
+	cleanupAll := func() error {
+		var cleanupErr error
+		for index := len(cleanups) - 1; index >= 0; index-- {
+			cleanupErr = errors.Join(cleanupErr, cleanups[index]())
+		}
+		return cleanupErr
+	}
+	fail := func(err error) (func() error, error) {
+		_ = cleanupAll()
+		return nil, err
+	}
+
+	qualityPrefix, err := service.Layout().VideoPrefix(file.UUID, selection.Quality.Name)
+	if err != nil {
+		return fail(err)
+	}
+	qualityPath, cleanup, err := service.MaterializePrefix(ctx, file.StorageID, qualityPrefix, "download-quality")
+	if err != nil {
+		return fail(fmt.Errorf("materialize quality %s: %w", selection.Quality.Name, err))
+	}
+	cleanups = append(cleanups, cleanup)
+	selection.Quality.Path = qualityPath
+
+	for index := range selection.Audios {
+		audio := &selection.Audios[index]
+		prefix, err := service.Layout().AudioPrefix(file.UUID, audio.UUID)
+		if err != nil {
+			return fail(err)
+		}
+		localPath, cleanup, err := service.MaterializePrefix(ctx, file.StorageID, prefix, "download-audio")
+		if err != nil {
+			return fail(fmt.Errorf("materialize audio %s: %w", audio.UUID, err))
+		}
+		cleanups = append(cleanups, cleanup)
+		audio.Path = localPath
+	}
+
+	for index := range selection.Subtitles {
+		subtitle := &selection.Subtitles[index]
+		prefix, err := service.Layout().SubtitlePrefix(file.UUID, subtitle.UUID)
+		if err != nil {
+			return fail(err)
+		}
+		localPath, cleanup, err := service.MaterializePrefix(ctx, file.StorageID, prefix, "download-subtitle")
+		if err != nil {
+			return fail(fmt.Errorf("materialize subtitle %s: %w", subtitle.UUID, err))
+		}
+		cleanups = append(cleanups, cleanup)
+		subtitle.Path = localPath
+	}
+
+	return cleanupAll, nil
+}

--- a/download/materialize_test.go
+++ b/download/materialize_test.go
@@ -1,0 +1,79 @@
+package download
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"ch/kirari04/videocms/models"
+	"ch/kirari04/videocms/storage"
+)
+
+type remoteLikeStore struct{ storage.Store }
+
+func TestMaterializeSelectionPreservesRenditionTrees(t *testing.T) {
+	ctx := context.Background()
+	store, err := storage.NewLocalStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace, err := storage.NewLocalWorkspace(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service, err := storage.NewServiceWithWorkspace(
+		"remote",
+		storage.LegacyMediaLayout{},
+		workspace,
+		map[string]storage.Store{"remote": remoteLikeStore{Store: store}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	objects := map[string]string{
+		"file/720p/out.m3u8":    "video manifest",
+		"file/720p/out0.ts":     "video segment",
+		"file/audio/audio.m3u8": "audio manifest",
+		"file/audio/audio0.ts":  "audio segment",
+		"file/subtitle/out.vtt": "subtitle",
+	}
+	for rawKey, value := range objects {
+		key, err := storage.ParseKey(rawKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := store.Put(ctx, key, strings.NewReader(value), storage.PutOptions{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	file := models.File{UUID: "file", StorageID: "remote"}
+	selection := &Selection{
+		Quality:   models.Quality{Name: "720p", OutputFile: "out.m3u8"},
+		Audios:    []models.Audio{{UUID: "audio", OutputFile: "audio.m3u8"}},
+		Subtitles: []models.Subtitle{{UUID: "subtitle", OutputFile: "out.vtt"}},
+	}
+	cleanup, err := MaterializeSelection(ctx, service, &file, selection)
+	if err != nil {
+		t.Fatal(err)
+	}
+	qualityPath := selection.Quality.Path
+	if data, err := os.ReadFile(filepath.Join(qualityPath, "out0.ts")); err != nil || string(data) != "video segment" {
+		t.Fatalf("materialized quality segment = %q, %v", data, err)
+	}
+	if data, err := os.ReadFile(filepath.Join(selection.Audios[0].Path, "audio0.ts")); err != nil || string(data) != "audio segment" {
+		t.Fatalf("materialized audio segment = %q, %v", data, err)
+	}
+	if data, err := os.ReadFile(filepath.Join(selection.Subtitles[0].Path, "out.vtt")); err != nil || string(data) != "subtitle" {
+		t.Fatalf("materialized subtitle = %q, %v", data, err)
+	}
+	if err := cleanup(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(qualityPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("materialized quality was not cleaned up: %v", err)
+	}
+}

--- a/inits/Folders.go
+++ b/inits/Folders.go
@@ -9,7 +9,7 @@ import (
 
 func EnsureFolders(env config.Config) error {
 	// create folders
-	createFolders := []string{"./database", env.FolderVideoQualitysPriv, env.FolderVideoUploadsPriv, "./logs"}
+	createFolders := []string{"./database", env.FolderVideoQualitysPriv, env.FolderVideoUploadsPriv, env.StorageScratchDir, "./logs"}
 	for _, createFolder := range createFolders {
 		if fileInfo, err := os.Stat(createFolder); err != nil || !fileInfo.IsDir() {
 			if err := os.MkdirAll(createFolder, 0766); err != nil {

--- a/inits/Models.go
+++ b/inits/Models.go
@@ -85,6 +85,11 @@ func MigrateModels(gormDB *gorm.DB) error {
 		Update("source", models.TrafficSourcePlayer).Error; err != nil {
 		return fmt.Errorf("failed to backfill traffic source: %w", err)
 	}
+	if err := gormDB.Model(&models.File{}).
+		Where("storage_id IS NULL OR storage_id = ''").
+		Update("storage_id", "local").Error; err != nil {
+		return fmt.Errorf("failed to backfill file storage IDs: %w", err)
+	}
 
 	if !hadWebPageFormat {
 		if err := gormDB.Model(&models.WebPage{}).

--- a/inits/Models.go
+++ b/inits/Models.go
@@ -85,7 +85,7 @@ func MigrateModels(gormDB *gorm.DB) error {
 		Update("source", models.TrafficSourcePlayer).Error; err != nil {
 		return fmt.Errorf("failed to backfill traffic source: %w", err)
 	}
-	if err := gormDB.Model(&models.File{}).
+	if err := gormDB.Unscoped().Model(&models.File{}).
 		Where("storage_id IS NULL OR storage_id = ''").
 		Update("storage_id", "local").Error; err != nil {
 		return fmt.Errorf("failed to backfill file storage IDs: %w", err)

--- a/inits/Models_test.go
+++ b/inits/Models_test.go
@@ -17,6 +17,16 @@ type legacyWebPage struct {
 	ListInFooter bool
 }
 
+type legacyStoredFile struct {
+	models.Model
+	UUID string
+	Path string
+}
+
+func (legacyStoredFile) TableName() string {
+	return "files"
+}
+
 func (legacyWebPage) TableName() string {
 	return "web_pages"
 }
@@ -85,5 +95,35 @@ func TestMigrateModelsPreservesLegacyWebPages(t *testing.T) {
 	}
 	if traffic.Source != models.TrafficSourcePlayer || traffic.Bytes != 512 {
 		t.Fatalf("migrated traffic = %#v, want player source with 512 bytes", traffic)
+	}
+}
+
+func TestMigrateModelsBackfillsLegacyFileStorageID(t *testing.T) {
+	db, err := gorm.Open(
+		sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"),
+		&gorm.Config{},
+	)
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	if err := db.AutoMigrate(&legacyStoredFile{}); err != nil {
+		t.Fatalf("migrate legacy file: %v", err)
+	}
+	if err := db.Create(&legacyStoredFile{UUID: "legacy-file", Path: "/legacy/source.mp4"}).Error; err != nil {
+		t.Fatalf("create legacy file: %v", err)
+	}
+	if err := MigrateModels(db); err != nil {
+		t.Fatalf("MigrateModels() error = %v", err)
+	}
+
+	var file models.File
+	if err := db.Where("uuid = ?", "legacy-file").First(&file).Error; err != nil {
+		t.Fatalf("load migrated file: %v", err)
+	}
+	if file.StorageID != "local" {
+		t.Fatalf("storage ID = %q, want local", file.StorageID)
+	}
+	if file.SourceKey != "" || file.Path != "/legacy/source.mp4" {
+		t.Fatalf("legacy source fields changed unexpectedly: %#v", file)
 	}
 }

--- a/inits/Models_test.go
+++ b/inits/Models_test.go
@@ -112,6 +112,13 @@ func TestMigrateModelsBackfillsLegacyFileStorageID(t *testing.T) {
 	if err := db.Create(&legacyStoredFile{UUID: "legacy-file", Path: "/legacy/source.mp4"}).Error; err != nil {
 		t.Fatalf("create legacy file: %v", err)
 	}
+	deletedFile := legacyStoredFile{UUID: "deleted-legacy-file", Path: "/legacy/deleted.mp4"}
+	if err := db.Create(&deletedFile).Error; err != nil {
+		t.Fatalf("create deleted legacy file: %v", err)
+	}
+	if err := db.Delete(&deletedFile).Error; err != nil {
+		t.Fatalf("soft-delete legacy file: %v", err)
+	}
 	if err := MigrateModels(db); err != nil {
 		t.Fatalf("MigrateModels() error = %v", err)
 	}
@@ -125,5 +132,12 @@ func TestMigrateModelsBackfillsLegacyFileStorageID(t *testing.T) {
 	}
 	if file.SourceKey != "" || file.Path != "/legacy/source.mp4" {
 		t.Fatalf("legacy source fields changed unexpectedly: %#v", file)
+	}
+	var deleted models.File
+	if err := db.Unscoped().Where("uuid = ?", "deleted-legacy-file").First(&deleted).Error; err != nil {
+		t.Fatalf("load migrated deleted file: %v", err)
+	}
+	if deleted.StorageID != "local" || !deleted.DeletedAt.Valid {
+		t.Fatalf("deleted file migration = %#v, want soft-deleted local record", deleted)
 	}
 }

--- a/logic/CreateFile.go
+++ b/logic/CreateFile.go
@@ -4,6 +4,7 @@ import (
 	"ch/kirari04/videocms/config"
 	"ch/kirari04/videocms/helpers"
 	"ch/kirari04/videocms/models"
+	"ch/kirari04/videocms/storage"
 	"context"
 	"errors"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 	"math"
 	"net/http"
 	"os"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -52,17 +54,20 @@ func (s *Service) CreateFile(fromFile *string, toFolder uint, fileName string, f
 	// run file through ffmpeg so the metadata is more accurate
 	nameSplits := strings.Split(fileName, ".")
 	fileExt := nameSplits[len(nameSplits)-1]
-	oldOutPath := *fromFile
-	newOutPath := fmt.Sprintf("%s.%s", *fromFile, fileExt)
-	fromFile = &newOutPath
 
 	// check if file extension is supported
 	if !slices.Contains(config.EXTENSIONS, strings.ToLower(fileExt)) {
 		return http.StatusBadRequest, nil, false, errors.New("Video extension is not supported")
 	}
 
-	if err := os.Rename(oldOutPath, newOutPath); err != nil {
-		log.Printf("Failed to delete oldInputEncoding File %s: %v\n", oldOutPath, err.Error())
+	if !strings.EqualFold(filepath.Ext(*fromFile), "."+fileExt) {
+		oldOutPath := *fromFile
+		newOutPath := fmt.Sprintf("%s.%s", oldOutPath, fileExt)
+		if err := os.Rename(oldOutPath, newOutPath); err != nil {
+			log.Printf("Failed to name imported source file %s: %v\n", oldOutPath, err)
+			return http.StatusInternalServerError, nil, false, echo.ErrInternalServerError
+		}
+		*fromFile = newOutPath
 	}
 
 	// ffprobe context
@@ -155,22 +160,30 @@ func (s *Service) CreateFile(fromFile *string, toFolder uint, fileName string, f
 		return http.StatusInternalServerError, nil, false, echo.ErrInternalServerError
 	}
 
-	thumbnailFileName := "4x4.webp"
-	go func() {
-		if avgFramerate > 0 {
-			if _, err := s.CreateThumbnail(
-				4,
-				*fromFile,
-				1080,
-				thumbnailFileName,
-				fileId,
-				videoDuration,
-				avgFramerate,
-			); err != nil {
-				log.Printf("Failed to generate thumbnail from file %v: %v", fromFile, err)
+	if s.Deps == nil || s.Deps.Storage == nil || s.Deps.Storage.Layout() == nil {
+		return http.StatusInternalServerError, nil, false, storage.ErrStoreNotConfigured
+	}
+	storeID := s.Deps.Storage.DefaultStoreID()
+	sourceFileName := "original." + strings.ToLower(fileExt)
+	sourceKey, err := s.Deps.Storage.Layout().Source(fileId, sourceFileName)
+	if err != nil {
+		return http.StatusInternalServerError, nil, false, err
+	}
+	storageCtx := context.Background()
+	if _, err := s.Deps.Storage.PublishFile(storageCtx, storeID, sourceKey, *fromFile, storage.PutOptions{}); err != nil {
+		log.Printf("Failed to publish source file: %v", err)
+		return http.StatusInternalServerError, nil, false, echo.ErrInternalServerError
+	}
+	sourceOwnedByRecord := false
+	defer func() {
+		if !sourceOwnedByRecord {
+			if store, storeErr := s.Deps.Storage.StoreOrDefault(storeID); storeErr == nil {
+				_ = store.Delete(context.Background(), sourceKey)
 			}
 		}
 	}()
+
+	thumbnailFileName := "4x4.webp"
 	var dbFile models.File
 	var dbLink models.Link
 	// create an transaction consisting of the file and its link
@@ -180,7 +193,8 @@ func (s *Service) CreateFile(fromFile *string, toFolder uint, fileName string, f
 			UUID:         fileId,
 			Hash:         FileHash,
 			Thumbnail:    thumbnailFileName,
-			Path:         *fromFile,
+			StorageID:    storeID,
+			SourceKey:    sourceKey.String(),
 			Folder:       fmt.Sprintf("%s/%s", s.Config().FolderVideoQualitysPriv, fileId),
 			UserID:       userId,
 			Height:       int64(videoHeight),
@@ -207,6 +221,36 @@ func (s *Service) CreateFile(fromFile *string, toFolder uint, fileName string, f
 		log.Printf("Error saving file & link in database: %v", err)
 		return http.StatusInternalServerError, nil, false, echo.ErrInternalServerError
 	}
+	sourceOwnedByRecord = true
+	go func() {
+		if avgFramerate <= 0 {
+			return
+		}
+		materialized, cleanup, err := s.Deps.Storage.Materialize(
+			context.Background(),
+			storeID,
+			sourceKey,
+			"thumbnail-source",
+			filepath.Ext(sourceFileName),
+		)
+		if err != nil {
+			log.Printf("Failed to materialize thumbnail source %s: %v", sourceKey.String(), err)
+			return
+		}
+		defer cleanup()
+		if _, err := s.CreateThumbnailInStore(
+			4,
+			materialized,
+			1080,
+			thumbnailFileName,
+			fileId,
+			storeID,
+			videoDuration,
+			avgFramerate,
+		); err != nil {
+			log.Printf("Failed to generate thumbnail for file %s: %v", fileId, err)
+		}
+	}()
 
 	// save subtitle data to database so they can be converted later
 	for index, subtitleStream := range subtitleStreams {
@@ -365,6 +409,13 @@ func (s *Service) CreateFile(fromFile *string, toFolder uint, fileName string, f
 					return http.StatusInternalServerError, nil, false, echo.ErrInternalServerError
 				}
 			}
+		}
+	}
+
+	if err := os.Remove(*fromFile); err != nil && !errors.Is(err, os.ErrNotExist) {
+		log.Printf("Failed to remove imported source path %s: %v", *fromFile, err)
+		if updateErr := s.Deps.DB.Model(&dbFile).Update("path", *fromFile).Error; updateErr != nil {
+			log.Printf("Failed to retain source cleanup path for file %d: %v", dbFile.ID, updateErr)
 		}
 	}
 

--- a/logic/CreateFile.go
+++ b/logic/CreateFile.go
@@ -163,7 +163,7 @@ func (s *Service) CreateFile(fromFile *string, toFolder uint, fileName string, f
 				*fromFile,
 				1080,
 				thumbnailFileName,
-				fmt.Sprintf("%s/%s", s.Config().FolderVideoQualitysPriv, fileId),
+				fileId,
 				videoDuration,
 				avgFramerate,
 			); err != nil {

--- a/logic/GetThumbnailData.go
+++ b/logic/GetThumbnailData.go
@@ -7,6 +7,13 @@ import (
 	"net/http"
 )
 
+type ThumbnailObject struct {
+	FileUUID string
+	StoreID  string
+	UserID   uint
+	FileID   uint
+}
+
 func (s *Service) GetThumbnailData(fileName string, UUID string) (status int, filePath *string, userID uint, fileID uint, err error) {
 	status, fileUUID, userID, fileID, err := s.ResolveThumbnailData(fileName, UUID)
 	if err != nil {
@@ -19,6 +26,14 @@ func (s *Service) GetThumbnailData(fileName string, UUID string) (status int, fi
 // ResolveThumbnailData authorizes a thumbnail name and returns its logical
 // file identity without exposing a storage-provider path.
 func (s *Service) ResolveThumbnailData(fileName string, UUID string) (status int, fileUUID string, userID uint, fileID uint, err error) {
+	status, object, err := s.ResolveThumbnailObject(fileName, UUID)
+	if err != nil {
+		return status, "", 0, 0, err
+	}
+	return status, object.FileUUID, object.UserID, object.FileID, nil
+}
+
+func (s *Service) ResolveThumbnailObject(fileName string, UUID string) (status int, object ThumbnailObject, err error) {
 	//translate link id to file id
 	var dbLink models.Link
 	if dbRes := s.Deps.DB.
@@ -28,12 +43,17 @@ func (s *Service) ResolveThumbnailData(fileName string, UUID string) (status int
 			UUID: UUID,
 		}).
 		First(&dbLink); dbRes.Error != nil {
-		return http.StatusNotFound, "", 0, 0, errors.New("thumbnail doesn't exist")
+		return http.StatusNotFound, ThumbnailObject{}, errors.New("thumbnail doesn't exist")
 	}
 
 	if !s.thumbnailFileAllowedForLink(fileName, dbLink) {
-		return http.StatusNotFound, "", 0, 0, errors.New("thumbnail doesn't exist")
+		return http.StatusNotFound, ThumbnailObject{}, errors.New("thumbnail doesn't exist")
 	}
 
-	return http.StatusOK, dbLink.File.UUID, dbLink.UserID, dbLink.FileID, nil
+	return http.StatusOK, ThumbnailObject{
+		FileUUID: dbLink.File.UUID,
+		StoreID:  dbLink.File.StorageID,
+		UserID:   dbLink.UserID,
+		FileID:   dbLink.FileID,
+	}, nil
 }

--- a/logic/GetThumbnailData.go
+++ b/logic/GetThumbnailData.go
@@ -8,6 +8,17 @@ import (
 )
 
 func (s *Service) GetThumbnailData(fileName string, UUID string) (status int, filePath *string, userID uint, fileID uint, err error) {
+	status, fileUUID, userID, fileID, err := s.ResolveThumbnailData(fileName, UUID)
+	if err != nil {
+		return status, nil, 0, 0, err
+	}
+	fileRes := fmt.Sprintf("%s/%s/%s", s.Config().FolderVideoQualitysPriv, fileUUID, fileName)
+	return status, &fileRes, userID, fileID, nil
+}
+
+// ResolveThumbnailData authorizes a thumbnail name and returns its logical
+// file identity without exposing a storage-provider path.
+func (s *Service) ResolveThumbnailData(fileName string, UUID string) (status int, fileUUID string, userID uint, fileID uint, err error) {
 	//translate link id to file id
 	var dbLink models.Link
 	if dbRes := s.Deps.DB.
@@ -17,14 +28,12 @@ func (s *Service) GetThumbnailData(fileName string, UUID string) (status int, fi
 			UUID: UUID,
 		}).
 		First(&dbLink); dbRes.Error != nil {
-		return http.StatusNotFound, nil, 0, 0, errors.New("thumbnail doesn't exist")
+		return http.StatusNotFound, "", 0, 0, errors.New("thumbnail doesn't exist")
 	}
 
 	if !s.thumbnailFileAllowedForLink(fileName, dbLink) {
-		return http.StatusNotFound, nil, 0, 0, errors.New("thumbnail doesn't exist")
+		return http.StatusNotFound, "", 0, 0, errors.New("thumbnail doesn't exist")
 	}
 
-	fileRes := fmt.Sprintf("%s/%s/%s", s.Config().FolderVideoQualitysPriv, dbLink.File.UUID, fileName)
-
-	return http.StatusOK, &fileRes, dbLink.UserID, dbLink.FileID, nil
+	return http.StatusOK, dbLink.File.UUID, dbLink.UserID, dbLink.FileID, nil
 }

--- a/logic/LinkThumbnail.go
+++ b/logic/LinkThumbnail.go
@@ -2,6 +2,8 @@ package logic
 
 import (
 	"ch/kirari04/videocms/models"
+	"ch/kirari04/videocms/storage"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -9,7 +11,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -58,19 +59,25 @@ func (s *Service) UpdateLinkThumbnail(linkID uint, userID uint, isAdmin bool, in
 		return http.StatusBadRequest, errors.New("thumbnail must be a JPEG, PNG, or WebP image")
 	}
 
-	outputFolder := filepath.Join(s.Config().FolderVideoQualitysPriv, dbLink.File.UUID)
-	if err := os.MkdirAll(outputFolder, 0o777); err != nil {
-		log.Printf("Failed to create thumbnail folder: %v", err)
+	store, layout, err := s.mediaStorage()
+	if err != nil {
+		log.Printf("Failed to resolve thumbnail storage: %v", err)
+		return http.StatusInternalServerError, echo.ErrInternalServerError
+	}
+	ctx := context.Background()
+	workspace := s.Deps.Storage.Workspace()
+	if workspace == nil {
+		log.Printf("Failed to resolve thumbnail workspace")
 		return http.StatusInternalServerError, echo.ErrInternalServerError
 	}
 
-	tmpInput, err := os.CreateTemp(outputFolder, "thumbnail-input-*")
+	tmpInput, cleanupInput, err := workspace.TempFile(ctx, "thumbnail-input", "")
 	if err != nil {
 		log.Printf("Failed to create temporary thumbnail input: %v", err)
 		return http.StatusInternalServerError, echo.ErrInternalServerError
 	}
 	tmpInputPath := tmpInput.Name()
-	defer os.Remove(tmpInputPath)
+	defer cleanupInput()
 
 	written, err := io.Copy(tmpInput, io.LimitReader(input, maxBytes+1))
 	closeErr := tmpInput.Close()
@@ -86,53 +93,62 @@ func (s *Service) UpdateLinkThumbnail(linkID uint, userID uint, isAdmin bool, in
 		return http.StatusRequestEntityTooLarge, fmt.Errorf("exceeded max thumbnail filesize: %d", maxBytes)
 	}
 
-	tmpOutput, err := os.CreateTemp(outputFolder, "thumbnail-output-*.webp")
+	tmpOutput, cleanupOutput, err := workspace.TempFile(ctx, "thumbnail-output", ".webp")
 	if err != nil {
 		log.Printf("Failed to create temporary thumbnail output: %v", err)
 		return http.StatusInternalServerError, echo.ErrInternalServerError
 	}
 	tmpOutputPath := tmpOutput.Name()
 	tmpOutput.Close()
-	defer os.Remove(tmpOutputPath)
+	defer cleanupOutput()
 
 	if err := s.convertThumbnailToWebP(tmpInputPath, tmpOutputPath); err != nil {
 		log.Printf("Failed to convert custom thumbnail for link %s: %v", dbLink.UUID, err)
 		return http.StatusBadRequest, errors.New("failed to process thumbnail image")
 	}
 
-	thumbnailFileName := s.LinkThumbnailFilename(dbLink.UUID)
-	finalPath := filepath.Join(outputFolder, thumbnailFileName)
-	backupPath := ""
-	if _, err := os.Stat(finalPath); err == nil {
-		backupPath = filepath.Join(outputFolder, fmt.Sprintf(".%s.%s.bak", thumbnailFileName, uuid.NewString()))
-		if err := os.Rename(finalPath, backupPath); err != nil {
-			log.Printf("Failed to backup existing custom thumbnail: %v", err)
-			return http.StatusInternalServerError, echo.ErrInternalServerError
-		}
+	thumbnailFileName := fmt.Sprintf("link-%s-%s.webp", dbLink.UUID, uuid.NewString())
+	thumbnailKey, err := layout.Thumbnail(dbLink.File.UUID, thumbnailFileName)
+	if err != nil {
+		log.Printf("Failed to build custom thumbnail key: %v", err)
+		return http.StatusInternalServerError, echo.ErrInternalServerError
 	}
-
-	restoreBackup := func() {
-		os.Remove(finalPath)
-		if backupPath != "" {
-			if err := os.Rename(backupPath, finalPath); err != nil {
-				log.Printf("Failed to restore previous custom thumbnail: %v", err)
-			}
-		}
+	output, err := os.Open(tmpOutputPath)
+	if err != nil {
+		log.Printf("Failed to open converted custom thumbnail: %v", err)
+		return http.StatusInternalServerError, echo.ErrInternalServerError
 	}
-
-	if err := os.Rename(tmpOutputPath, finalPath); err != nil {
-		restoreBackup()
-		log.Printf("Failed to promote custom thumbnail: %v", err)
+	outputInfo, err := output.Stat()
+	if err != nil {
+		output.Close()
+		log.Printf("Failed to inspect converted custom thumbnail: %v", err)
+		return http.StatusInternalServerError, echo.ErrInternalServerError
+	}
+	expectedSize := outputInfo.Size()
+	_, putErr := store.Put(ctx, thumbnailKey, output, storage.PutOptions{
+		ContentType:  "image/webp",
+		CacheControl: "public, max-age=31536000, immutable",
+		ExpectedSize: &expectedSize,
+	})
+	closeErr = output.Close()
+	if putErr != nil || closeErr != nil {
+		log.Printf("Failed to publish custom thumbnail: put=%v close=%v", putErr, closeErr)
 		return http.StatusInternalServerError, echo.ErrInternalServerError
 	}
 
+	previousThumbnail := dbLink.Thumbnail
 	if res := s.Deps.DB.Model(&dbLink).Update("thumbnail", thumbnailFileName); res.Error != nil {
-		restoreBackup()
+		_ = store.Delete(ctx, thumbnailKey)
 		log.Printf("Failed to save custom thumbnail: %v", res.Error)
 		return http.StatusInternalServerError, echo.ErrInternalServerError
 	}
-	if backupPath != "" {
-		os.Remove(backupPath)
+	if previousThumbnail != "" {
+		previousKey, keyErr := layout.Thumbnail(dbLink.File.UUID, previousThumbnail)
+		if keyErr != nil {
+			log.Printf("Failed to build previous custom thumbnail key: %v", keyErr)
+		} else if deleteErr := store.Delete(ctx, previousKey); deleteErr != nil {
+			log.Printf("Failed to delete previous custom thumbnail: %v", deleteErr)
+		}
 	}
 
 	return http.StatusOK, nil
@@ -147,13 +163,27 @@ func (s *Service) ResetLinkThumbnail(linkID uint, userID uint, isAdmin bool) (st
 		return http.StatusOK, nil
 	}
 
-	thumbnailPath := s.linkThumbnailPath(dbLink)
+	store, layout, storageErr := s.mediaStorage()
+	if storageErr != nil {
+		log.Printf("Failed to resolve thumbnail storage: %v", storageErr)
+		return http.StatusInternalServerError, echo.ErrInternalServerError
+	}
+	ctx := context.Background()
+	thumbnailKey, keyErr := layout.Thumbnail(dbLink.File.UUID, dbLink.Thumbnail)
+	if keyErr != nil {
+		log.Printf("Failed to build custom thumbnail key: %v", keyErr)
+		return http.StatusInternalServerError, echo.ErrInternalServerError
+	}
+	previousThumbnail := dbLink.Thumbnail
 	if res := s.Deps.DB.Model(&dbLink).Update("thumbnail", ""); res.Error != nil {
 		log.Printf("Failed to clear custom thumbnail: %v", res.Error)
 		return http.StatusInternalServerError, echo.ErrInternalServerError
 	}
 
-	if err := os.Remove(thumbnailPath); err != nil && !os.IsNotExist(err) {
+	if err := store.Delete(ctx, thumbnailKey); err != nil {
+		if restoreErr := s.Deps.DB.Model(&dbLink).Update("thumbnail", previousThumbnail).Error; restoreErr != nil {
+			log.Printf("Failed to restore custom thumbnail reference after delete failure: %v", restoreErr)
+		}
 		log.Printf("Failed to delete custom thumbnail: %v", err)
 		return http.StatusInternalServerError, echo.ErrInternalServerError
 	}
@@ -172,7 +202,18 @@ func (s *Service) RemoveLinkThumbnailFile(link models.Link) {
 	if link.Thumbnail == "" {
 		return
 	}
-	if err := os.Remove(s.linkThumbnailPath(link)); err != nil && !os.IsNotExist(err) {
+	store, layout, err := s.mediaStorage()
+	if err != nil {
+		log.Printf("Failed to resolve custom thumbnail storage for link %s: %v", link.UUID, err)
+		return
+	}
+	ctx := context.Background()
+	key, err := layout.Thumbnail(link.File.UUID, link.Thumbnail)
+	if err != nil {
+		log.Printf("Failed to build custom thumbnail key for link %s: %v", link.UUID, err)
+		return
+	}
+	if err := store.Delete(ctx, key); err != nil {
 		log.Printf("Failed to delete custom thumbnail for link %s: %v", link.UUID, err)
 	}
 }
@@ -188,10 +229,6 @@ func (s *Service) loadThumbnailLink(linkID uint, userID uint, isAdmin bool) (mod
 		return models.Link{}, http.StatusForbidden, errors.New("unauthorized access to file")
 	}
 	return dbLink, http.StatusOK, nil
-}
-
-func (s *Service) linkThumbnailPath(link models.Link) string {
-	return filepath.Join(s.Config().FolderVideoQualitysPriv, link.File.UUID, link.Thumbnail)
 }
 
 func (s *Service) convertThumbnailToWebP(inputPath string, outputPath string) error {

--- a/logic/LinkThumbnail.go
+++ b/logic/LinkThumbnail.go
@@ -59,7 +59,7 @@ func (s *Service) UpdateLinkThumbnail(linkID uint, userID uint, isAdmin bool, in
 		return http.StatusBadRequest, errors.New("thumbnail must be a JPEG, PNG, or WebP image")
 	}
 
-	store, layout, err := s.mediaStorage()
+	store, layout, err := s.mediaStorage(dbLink.File.StorageID)
 	if err != nil {
 		log.Printf("Failed to resolve thumbnail storage: %v", err)
 		return http.StatusInternalServerError, echo.ErrInternalServerError
@@ -163,7 +163,7 @@ func (s *Service) ResetLinkThumbnail(linkID uint, userID uint, isAdmin bool) (st
 		return http.StatusOK, nil
 	}
 
-	store, layout, storageErr := s.mediaStorage()
+	store, layout, storageErr := s.mediaStorage(dbLink.File.StorageID)
 	if storageErr != nil {
 		log.Printf("Failed to resolve thumbnail storage: %v", storageErr)
 		return http.StatusInternalServerError, echo.ErrInternalServerError
@@ -202,7 +202,7 @@ func (s *Service) RemoveLinkThumbnailFile(link models.Link) {
 	if link.Thumbnail == "" {
 		return
 	}
-	store, layout, err := s.mediaStorage()
+	store, layout, err := s.mediaStorage(link.File.StorageID)
 	if err != nil {
 		log.Printf("Failed to resolve custom thumbnail storage for link %s: %v", link.UUID, err)
 		return

--- a/logic/LinkThumbnail_test.go
+++ b/logic/LinkThumbnail_test.go
@@ -4,6 +4,7 @@ import (
 	"ch/kirari04/videocms/app"
 	"ch/kirari04/videocms/config"
 	"ch/kirari04/videocms/models"
+	"ch/kirari04/videocms/storage"
 	"errors"
 	"net/http"
 	"os"
@@ -205,6 +206,18 @@ func writeThumbnailTestFile(t *testing.T, root string, fileUUID string, fileName
 }
 
 func thumbnailService(db *gorm.DB, privateRoot string, publicRoot string) *Service {
+	localStore, err := storage.NewLocalStore(privateRoot)
+	if err != nil {
+		panic(err)
+	}
+	storageService, err := storage.NewService(
+		"local",
+		storage.LegacyMediaLayout{},
+		map[string]storage.Store{"local": localStore},
+	)
+	if err != nil {
+		panic(err)
+	}
 	return NewService(&app.Deps{
 		DB: db,
 		Snapshots: app.NewSnapshotStore(app.Snapshot{
@@ -215,5 +228,6 @@ func thumbnailService(db *gorm.DB, privateRoot string, publicRoot string) *Servi
 			},
 		}),
 		RequestGate: app.NewRequestGate(),
+		Storage:     storageService,
 	})
 }

--- a/logic/Storage.go
+++ b/logic/Storage.go
@@ -4,11 +4,11 @@ import (
 	"ch/kirari04/videocms/storage"
 )
 
-func (s *Service) mediaStorage() (storage.Store, storage.MediaLayout, error) {
+func (s *Service) mediaStorage(storeID string) (storage.Store, storage.MediaLayout, error) {
 	if s == nil || s.Deps == nil || s.Deps.Storage == nil || s.Deps.Storage.Layout() == nil {
 		return nil, nil, storage.ErrStoreNotConfigured
 	}
-	store, err := s.Deps.Storage.Default()
+	store, err := s.Deps.Storage.StoreOrDefault(storeID)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/logic/Storage.go
+++ b/logic/Storage.go
@@ -1,0 +1,16 @@
+package logic
+
+import (
+	"ch/kirari04/videocms/storage"
+)
+
+func (s *Service) mediaStorage() (storage.Store, storage.MediaLayout, error) {
+	if s == nil || s.Deps == nil || s.Deps.Storage == nil || s.Deps.Storage.Layout() == nil {
+		return nil, nil, storage.ErrStoreNotConfigured
+	}
+	store, err := s.Deps.Storage.Default()
+	if err != nil {
+		return nil, nil, err
+	}
+	return store, s.Deps.Storage.Layout(), nil
+}

--- a/logic/Thumbnail.go
+++ b/logic/Thumbnail.go
@@ -1,6 +1,8 @@
 package logic
 
 import (
+	"ch/kirari04/videocms/storage"
+	"context"
 	"fmt"
 	"log"
 	"math"
@@ -12,18 +14,19 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
-func (s *Service) CreateThumbnail(imageCountAxis int, inputFile string, height int, outputFile string, outputFolder string, videoDuration float64, fps float64) (status int, err error) {
-	// read file & folder
-	absOutputFolder, err := filepath.Abs(outputFolder)
-	if err != nil {
-		return http.StatusBadRequest, err
-	}
-	os.MkdirAll(absOutputFolder, 0777)
-
+func (s *Service) CreateThumbnail(imageCountAxis int, inputFile string, height int, outputFile string, fileUUID string, videoDuration float64, fps float64) (status int, err error) {
 	absInputFile, err := filepath.Abs(inputFile)
 	if err != nil {
 		return http.StatusBadRequest, err
 	}
+	if s.Deps == nil || s.Deps.Storage == nil || s.Deps.Storage.Workspace() == nil {
+		return http.StatusInternalServerError, storage.ErrStoreNotConfigured
+	}
+	tempOutputFolder, cleanupOutput, err := s.Deps.Storage.Workspace().TempDir(context.Background(), "generated-thumbnail")
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+	defer cleanupOutput()
 
 	// build ffmpeg command
 	imageCount := imageCountAxis * imageCountAxis
@@ -71,15 +74,15 @@ func (s *Service) CreateThumbnail(imageCountAxis int, inputFile string, height i
 
 	ffmpegCommand += filterComplex
 
-	ffmpegCommand += fmt.Sprintf("%s/%s -y", absOutputFolder, outputFile)
+	outputPath := filepath.Join(tempOutputFolder, outputFile)
+	ffmpegCommand += fmt.Sprintf("%s -y", outputPath)
 
 	ffmpegCommandSimpleImage := fmt.Sprintf(
-		`ffmpeg -i %s -ss %.2f -vf scale=-1:%d -vframes 1 %s/%s -y`,
+		`ffmpeg -i %s -ss %.2f -vf scale=-1:%d -vframes 1 %s -y`,
 		absInputFile,
 		videoDuration/2,
 		imageFullHeight,
-		absOutputFolder,
-		outputFile,
+		outputPath,
 	)
 
 	cmd := exec.Command(
@@ -102,6 +105,32 @@ func (s *Service) CreateThumbnail(imageCountAxis int, inputFile string, height i
 			return http.StatusInternalServerError, echo.ErrInternalServerError
 		}
 
+	}
+
+	store, layout, err := s.mediaStorage()
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+	key, err := layout.Thumbnail(fileUUID, outputFile)
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+	output, err := os.Open(outputPath)
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+	defer output.Close()
+	info, err := output.Stat()
+	if err != nil {
+		return http.StatusInternalServerError, err
+	}
+	expectedSize := info.Size()
+	if _, err := store.Put(context.Background(), key, output, storage.PutOptions{
+		ContentType:  "image/webp",
+		CacheControl: "public, max-age=3600",
+		ExpectedSize: &expectedSize,
+	}); err != nil {
+		return http.StatusInternalServerError, err
 	}
 
 	return http.StatusOK, nil

--- a/logic/Thumbnail.go
+++ b/logic/Thumbnail.go
@@ -15,6 +15,10 @@ import (
 )
 
 func (s *Service) CreateThumbnail(imageCountAxis int, inputFile string, height int, outputFile string, fileUUID string, videoDuration float64, fps float64) (status int, err error) {
+	return s.CreateThumbnailInStore(imageCountAxis, inputFile, height, outputFile, fileUUID, "", videoDuration, fps)
+}
+
+func (s *Service) CreateThumbnailInStore(imageCountAxis int, inputFile string, height int, outputFile string, fileUUID string, storeID string, videoDuration float64, fps float64) (status int, err error) {
 	absInputFile, err := filepath.Abs(inputFile)
 	if err != nil {
 		return http.StatusBadRequest, err
@@ -107,7 +111,7 @@ func (s *Service) CreateThumbnail(imageCountAxis int, inputFile string, height i
 
 	}
 
-	store, layout, err := s.mediaStorage()
+	store, layout, err := s.mediaStorage(storeID)
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}

--- a/models/File.go
+++ b/models/File.go
@@ -10,6 +10,8 @@ type File struct {
 	AvgFrameRate float64
 	Height       int64
 	Width        int64
+	StorageID    string `gorm:"size:64;index" json:"-"`
+	SourceKey    string `gorm:"size:1024" json:"-"`
 	Path         string `gorm:"size:120;" json:"-"`
 	Folder       string `gorm:"size:120;" json:"-"`
 	User         User   `json:"-"`

--- a/services/Deleter.go
+++ b/services/Deleter.go
@@ -2,10 +2,13 @@ package services
 
 import (
 	"ch/kirari04/videocms/models"
+	"ch/kirari04/videocms/storage"
 	"context"
 	"log"
 	"os"
 	"time"
+
+	"gorm.io/gorm"
 )
 
 func (w *WorkerGroup) Deleter(ctx context.Context) {
@@ -100,60 +103,25 @@ func (w *WorkerGroup) runDeleter() {
 			continue
 		}
 
-		// delete related stuff
-		if res := w.deps.DB.
-			Unscoped().
-			Where(&models.Subtitle{
-				FileID: todo.ID,
-			}).
-			Delete(&models.Subtitle{}); res.Error != nil {
-			log.Printf("Failed to delete Subtitles from database: %v", res.Error)
+		if err := w.deleteStoredFile(todo); err != nil {
+			log.Printf("Failed to delete stored data for file %d: %v", todo.ID, err)
+			skippingDeletion++
 			continue
 		}
 
-		if res := w.deps.DB.
-			Unscoped().
-			Where(&models.Audio{
-				FileID: todo.ID,
-			}).
-			Delete(&models.Audio{}); res.Error != nil {
-			log.Printf("Failed to delete Audios from database: %v", res.Error)
-			continue
-		}
-
-		if res := w.deps.DB.
-			Unscoped().
-			Where(&models.Quality{
-				FileID: todo.ID,
-			}).
-			Delete(&models.Quality{}); res.Error != nil {
-			log.Printf("Failed to delete Qualities from database: %v", res.Error)
-			continue
-		}
-
-		/**
-		 * First delete the original file (it might still exists if some error happend or it didn't finished encoding yet)
-		 * Then we can delete the folder too
-		 */
-		if todo.Path != "" {
-			if stats, err := os.Stat(todo.Path); !os.IsNotExist(err) && !stats.IsDir() {
-				if err := os.Remove(todo.Path); err != nil {
-					log.Printf("Failed to delete original file: %v", err)
-				}
+		if err := w.deps.DB.Transaction(func(tx *gorm.DB) error {
+			if err := tx.Unscoped().Where("file_id = ?", todo.ID).Delete(&models.Subtitle{}).Error; err != nil {
+				return err
 			}
-		}
-
-		if stats, err := os.Stat(todo.Folder); !os.IsNotExist(err) && stats.IsDir() {
-			if err := os.RemoveAll(todo.Folder); err != nil {
-				log.Printf("Failed to delete folder of file: %v", err)
+			if err := tx.Unscoped().Where("file_id = ?", todo.ID).Delete(&models.Audio{}).Error; err != nil {
+				return err
 			}
-		}
-
-		// delete file from database
-		if res := w.deps.DB.
-			Unscoped().
-			Delete(&todo); res.Error != nil {
-			log.Printf("Failed to delete File from database: %v", res.Error)
+			if err := tx.Unscoped().Where("file_id = ?", todo.ID).Delete(&models.Quality{}).Error; err != nil {
+				return err
+			}
+			return tx.Unscoped().Delete(&todo).Error
+		}); err != nil {
+			log.Printf("Failed to delete file %d from database: %v", todo.ID, err)
 			continue
 		}
 		successDeletion++
@@ -163,5 +131,46 @@ func (w *WorkerGroup) runDeleter() {
 	}
 	if successDeletion > 0 {
 		log.Printf("Successfully deleted %d files", successDeletion)
+	}
+}
+
+func (w *WorkerGroup) deleteStoredFile(file models.File) error {
+	if file.Path != "" {
+		info, err := os.Stat(file.Path)
+		switch {
+		case err == nil && !info.IsDir():
+			if err := os.Remove(file.Path); err != nil {
+				return err
+			}
+		case err != nil && !os.IsNotExist(err):
+			return err
+		}
+	}
+
+	if w.deps.Storage != nil && w.deps.Storage.Layout() != nil {
+		store, err := w.deps.Storage.Default()
+		if err != nil {
+			return err
+		}
+		prefix, err := w.deps.Storage.Layout().FilePrefix(file.UUID)
+		if err != nil {
+			return err
+		}
+		return storage.DeletePrefix(context.Background(), store, prefix)
+	}
+
+	if file.Folder == "" {
+		return nil
+	}
+	info, err := os.Stat(file.Folder)
+	switch {
+	case os.IsNotExist(err):
+		return nil
+	case err != nil:
+		return err
+	case !info.IsDir():
+		return nil
+	default:
+		return os.RemoveAll(file.Folder)
 	}
 }

--- a/services/Deleter.go
+++ b/services/Deleter.go
@@ -148,7 +148,7 @@ func (w *WorkerGroup) deleteStoredFile(file models.File) error {
 	}
 
 	if w.deps.Storage != nil && w.deps.Storage.Layout() != nil {
-		store, err := w.deps.Storage.Default()
+		store, err := w.deps.Storage.StoreOrDefault(file.StorageID)
 		if err != nil {
 			return err
 		}

--- a/services/Deleter_test.go
+++ b/services/Deleter_test.go
@@ -13,15 +13,21 @@ import (
 )
 
 func TestDeleteStoredFileUsesMediaStoreAndRemovesSource(t *testing.T) {
-	mediaRoot := t.TempDir()
-	localStore, err := storage.NewLocalStore(mediaRoot)
+	defaultStore, err := storage.NewLocalStore(t.TempDir())
 	if err != nil {
 		t.Fatalf("NewLocalStore() error = %v", err)
+	}
+	archiveStore, err := storage.NewLocalStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewLocalStore() archive error = %v", err)
 	}
 	storageService, err := storage.NewService(
 		"local",
 		storage.LegacyMediaLayout{},
-		map[string]storage.Store{"local": localStore},
+		map[string]storage.Store{
+			"local":   defaultStore,
+			"archive": archiveStore,
+		},
 	)
 	if err != nil {
 		t.Fatalf("NewService() error = %v", err)
@@ -33,8 +39,11 @@ func TestDeleteStoredFileUsesMediaStoreAndRemovesSource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Video() error = %v", err)
 	}
-	if _, err := localStore.Put(context.Background(), mediaKey, strings.NewReader("segment"), storage.PutOptions{}); err != nil {
+	if _, err := archiveStore.Put(context.Background(), mediaKey, strings.NewReader("segment"), storage.PutOptions{}); err != nil {
 		t.Fatalf("Put() error = %v", err)
+	}
+	if _, err := defaultStore.Put(context.Background(), mediaKey, strings.NewReader("keep"), storage.PutOptions{}); err != nil {
+		t.Fatalf("Put() default error = %v", err)
 	}
 
 	sourcePath := filepath.Join(t.TempDir(), "source.tmp")
@@ -42,13 +51,16 @@ func TestDeleteStoredFileUsesMediaStoreAndRemovesSource(t *testing.T) {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
 	worker := &WorkerGroup{deps: &app.Deps{Storage: storageService}}
-	if err := worker.deleteStoredFile(models.File{UUID: fileUUID, Path: sourcePath}); err != nil {
+	if err := worker.deleteStoredFile(models.File{UUID: fileUUID, StorageID: "archive", Path: sourcePath}); err != nil {
 		t.Fatalf("deleteStoredFile() error = %v", err)
 	}
 	if _, err := os.Stat(sourcePath); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("source still exists or stat failed unexpectedly: %v", err)
 	}
-	if _, err := localStore.Stat(context.Background(), mediaKey); !errors.Is(err, storage.ErrNotFound) {
+	if _, err := archiveStore.Stat(context.Background(), mediaKey); !errors.Is(err, storage.ErrNotFound) {
 		t.Fatalf("media object still exists or stat failed unexpectedly: %v", err)
+	}
+	if _, err := defaultStore.Stat(context.Background(), mediaKey); err != nil {
+		t.Fatalf("default-store object was removed: %v", err)
 	}
 }

--- a/services/Deleter_test.go
+++ b/services/Deleter_test.go
@@ -1,0 +1,54 @@
+package services
+
+import (
+	"ch/kirari04/videocms/app"
+	"ch/kirari04/videocms/models"
+	"ch/kirari04/videocms/storage"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDeleteStoredFileUsesMediaStoreAndRemovesSource(t *testing.T) {
+	mediaRoot := t.TempDir()
+	localStore, err := storage.NewLocalStore(mediaRoot)
+	if err != nil {
+		t.Fatalf("NewLocalStore() error = %v", err)
+	}
+	storageService, err := storage.NewService(
+		"local",
+		storage.LegacyMediaLayout{},
+		map[string]storage.Store{"local": localStore},
+	)
+	if err != nil {
+		t.Fatalf("NewService() error = %v", err)
+	}
+	t.Cleanup(func() { _ = storageService.Close() })
+
+	fileUUID := "550e8400-e29b-41d4-a716-446655440300"
+	mediaKey, err := storageService.Layout().Video(fileUUID, "720p", "out0.ts")
+	if err != nil {
+		t.Fatalf("Video() error = %v", err)
+	}
+	if _, err := localStore.Put(context.Background(), mediaKey, strings.NewReader("segment"), storage.PutOptions{}); err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+
+	sourcePath := filepath.Join(t.TempDir(), "source.tmp")
+	if err := os.WriteFile(sourcePath, []byte("source"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	worker := &WorkerGroup{deps: &app.Deps{Storage: storageService}}
+	if err := worker.deleteStoredFile(models.File{UUID: fileUUID, Path: sourcePath}); err != nil {
+		t.Fatalf("deleteStoredFile() error = %v", err)
+	}
+	if _, err := os.Stat(sourcePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("source still exists or stat failed unexpectedly: %v", err)
+	}
+	if _, err := localStore.Stat(context.Background(), mediaKey); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("media object still exists or stat failed unexpectedly: %v", err)
+	}
+}

--- a/services/DownloadPreparer.go
+++ b/services/DownloadPreparer.go
@@ -199,6 +199,12 @@ func (w *WorkerGroup) processDownloadPreparation(parentCtx context.Context, job 
 	timeout := w.preparationTimeout(job.MediaDuration)
 	jobCtx, cancelTimeout := context.WithTimeout(parentCtx, timeout)
 	defer cancelTimeout()
+	cleanupInputs, err := downloadsvc.MaterializeSelection(jobCtx, w.deps.Storage, &link.File, selection)
+	if err != nil {
+		w.failDownloadJob(&job, "source_unavailable", "The selected tracks could not be prepared.", err)
+		return
+	}
+	defer cleanupInputs()
 
 	var progressMu sync.Mutex
 	lastProgress := float64(0)

--- a/services/Encoder.go
+++ b/services/Encoder.go
@@ -224,7 +224,26 @@ func (w *WorkerGroup) runEncodeQuality(ctx context.Context, encodingTask models.
 	// log.Printf("Start encoding %s %s\n", encodingTask.File.UUID, encodingTask.Name)
 
 	totalDuration := encodingTask.File.Duration
-	os.MkdirAll(encodingTask.Path, 0777)
+	absFileInput, cleanupInput, err := w.materializeEncodingSource(ctx, encodingTask.File)
+	if err != nil {
+		encodingTask.Ready = false
+		encodingTask.Encoding = false
+		encodingTask.Failed = true
+		encodingTask.Error = fmt.Sprintf("Failed to prepare source: %v", err)
+		w.deps.DB.Save(&encodingTask)
+		return
+	}
+	defer cleanupInput()
+	absFolderOutput, cleanupOutput, err := w.encodingOutputDirectory(ctx, "encode-quality", encodingTask.Path)
+	if err != nil {
+		encodingTask.Ready = false
+		encodingTask.Encoding = false
+		encodingTask.Failed = true
+		encodingTask.Error = fmt.Sprintf("Failed to prepare output: %v", err)
+		w.deps.DB.Save(&encodingTask)
+		return
+	}
+	defer cleanupOutput()
 
 	var frameRateString string
 	var segmenDuration int = 4
@@ -232,8 +251,6 @@ func (w *WorkerGroup) runEncodeQuality(ctx context.Context, encodingTask models.
 		frameRateString = fmt.Sprintf("-r %.4f", encodingTask.AvgFrameRate)
 	}
 
-	absFileInput, _ := filepath.Abs(encodingTask.File.Path)
-	absFolderOutput, _ := filepath.Abs(encodingTask.Path)
 	encFilePath := fmt.Sprintf("%s/%s", absFolderOutput, encodingTask.OutputFile)
 
 	var ffmpegCommand string = "echo Encoding type didnt match && exit 1"
@@ -308,6 +325,20 @@ func (w *WorkerGroup) runEncodeQuality(ctx context.Context, encodingTask models.
 		log.Println(ffmpegCommand)
 		return
 	}
+	if w.deps.Storage != nil && w.deps.Storage.Layout() != nil {
+		prefix, err := w.deps.Storage.Layout().VideoPrefix(encodingTask.File.UUID, encodingTask.Name)
+		if err == nil {
+			err = w.publishEncodingOutput(ctx, encodingTask.File, prefix, absFolderOutput)
+		}
+		if err != nil {
+			encodingTask.Ready = false
+			encodingTask.Encoding = false
+			encodingTask.Failed = true
+			encodingTask.Error = fmt.Sprintf("Failed to publish output: %v", err)
+			w.deps.DB.Save(&encodingTask)
+			return
+		}
+	}
 	duration := time.Since(start).Seconds()
 	w.logic.TrackEncoding(encodingTask.File.UserID, encodingTask.FileID, "quality", duration)
 
@@ -319,6 +350,7 @@ func (w *WorkerGroup) runEncodeQuality(ctx context.Context, encodingTask models.
 	encodingTask.Size = qualitySize
 	encodingTask.Encoding = false
 	encodingTask.Ready = true
+	encodingTask.Error = ""
 	w.deps.DB.Save(&encodingTask)
 }
 
@@ -336,10 +368,26 @@ func (w *WorkerGroup) runEncodeAudio(ctx context.Context, encodingTask models.Au
 	// log.Printf("Start encoding %s %s\n", encodingTask.File.UUID, encodingTask.Name)
 
 	totalDuration := encodingTask.File.Duration
-	os.MkdirAll(encodingTask.Path, 0777)
-
-	absFileInput, _ := filepath.Abs(encodingTask.File.Path)
-	absFolderOutput, _ := filepath.Abs(encodingTask.Path)
+	absFileInput, cleanupInput, err := w.materializeEncodingSource(ctx, encodingTask.File)
+	if err != nil {
+		encodingTask.Ready = false
+		encodingTask.Encoding = false
+		encodingTask.Failed = true
+		encodingTask.Error = fmt.Sprintf("Failed to prepare source: %v", err)
+		w.deps.DB.Save(&encodingTask)
+		return
+	}
+	defer cleanupInput()
+	absFolderOutput, cleanupOutput, err := w.encodingOutputDirectory(ctx, "encode-audio", encodingTask.Path)
+	if err != nil {
+		encodingTask.Ready = false
+		encodingTask.Encoding = false
+		encodingTask.Failed = true
+		encodingTask.Error = fmt.Sprintf("Failed to prepare output: %v", err)
+		w.deps.DB.Save(&encodingTask)
+		return
+	}
+	defer cleanupOutput()
 
 	var ffmpegCommand string = "echo Audioencoding type didnt match && exit 1"
 	switch encodingTask.Type {
@@ -405,11 +453,26 @@ func (w *WorkerGroup) runEncodeAudio(ctx context.Context, encodingTask models.Au
 		log.Println(ffmpegCommand)
 		return
 	}
+	if w.deps.Storage != nil && w.deps.Storage.Layout() != nil {
+		prefix, err := w.deps.Storage.Layout().AudioPrefix(encodingTask.File.UUID, encodingTask.UUID)
+		if err == nil {
+			err = w.publishEncodingOutput(ctx, encodingTask.File, prefix, absFolderOutput)
+		}
+		if err != nil {
+			encodingTask.Ready = false
+			encodingTask.Encoding = false
+			encodingTask.Failed = true
+			encodingTask.Error = fmt.Sprintf("Failed to publish output: %v", err)
+			w.deps.DB.Save(&encodingTask)
+			return
+		}
+	}
 	duration := time.Since(start).Seconds()
 	w.logic.TrackEncoding(encodingTask.File.UserID, encodingTask.FileID, "audio", duration)
 
 	encodingTask.Encoding = false
 	encodingTask.Ready = true
+	encodingTask.Error = ""
 	w.deps.DB.Save(&encodingTask)
 }
 
@@ -427,10 +490,26 @@ func (w *WorkerGroup) runEncodeSub(ctx context.Context, encodingTask models.Subt
 	// log.Printf("Start encoding %s %s\n", encodingTask.File.UUID, encodingTask.Name)
 
 	totalDuration := encodingTask.File.Duration
-	os.MkdirAll(encodingTask.Path, 0777)
-
-	absFileInput, _ := filepath.Abs(encodingTask.File.Path)
-	absFolderOutput, _ := filepath.Abs(encodingTask.Path)
+	absFileInput, cleanupInput, err := w.materializeEncodingSource(ctx, encodingTask.File)
+	if err != nil {
+		encodingTask.Ready = false
+		encodingTask.Encoding = false
+		encodingTask.Failed = true
+		encodingTask.Error = fmt.Sprintf("Failed to prepare source: %v", err)
+		w.deps.DB.Save(&encodingTask)
+		return
+	}
+	defer cleanupInput()
+	absFolderOutput, cleanupOutput, err := w.encodingOutputDirectory(ctx, "encode-subtitle", encodingTask.Path)
+	if err != nil {
+		encodingTask.Ready = false
+		encodingTask.Encoding = false
+		encodingTask.Failed = true
+		encodingTask.Error = fmt.Sprintf("Failed to prepare output: %v", err)
+		w.deps.DB.Save(&encodingTask)
+		return
+	}
+	defer cleanupOutput()
 
 	var ffmpegCommand string = "echo Subencoding type didnt match && exit 1"
 
@@ -546,11 +625,26 @@ func (w *WorkerGroup) runEncodeSub(ctx context.Context, encodingTask models.Subt
 		log.Println(ffmpegCommand)
 		return
 	}
+	if w.deps.Storage != nil && w.deps.Storage.Layout() != nil {
+		prefix, err := w.deps.Storage.Layout().SubtitlePrefix(encodingTask.File.UUID, encodingTask.UUID)
+		if err == nil {
+			err = w.publishEncodingOutput(ctx, encodingTask.File, prefix, absFolderOutput)
+		}
+		if err != nil {
+			encodingTask.Ready = false
+			encodingTask.Encoding = false
+			encodingTask.Failed = true
+			encodingTask.Error = fmt.Sprintf("Failed to publish output: %v", err)
+			w.deps.DB.Save(&encodingTask)
+			return
+		}
+	}
 	duration := time.Since(start).Seconds()
 	w.logic.TrackEncoding(encodingTask.File.UserID, encodingTask.FileID, "sub", duration)
 
 	encodingTask.Encoding = false
 	encodingTask.Ready = true
+	encodingTask.Error = ""
 	w.deps.DB.Save(&encodingTask)
 }
 

--- a/services/EncoderCleanup.go
+++ b/services/EncoderCleanup.go
@@ -109,8 +109,9 @@ func (w *WorkerGroup) runEncoderCleanup() {
 			newSize, err := w.storedFileSize(context.Background(), dbReadyFile)
 			if err != nil {
 				log.Printf("Failed to calculate stored size after cleanup: %v", err)
+			} else {
+				dbReadyFile.Size = newSize
 			}
-			dbReadyFile.Size = newSize
 			dbReadyFile.Path = ""
 			dbReadyFile.SourceKey = ""
 			w.deps.DB.Save(&dbReadyFile)

--- a/services/EncoderCleanup.go
+++ b/services/EncoderCleanup.go
@@ -2,7 +2,9 @@ package services
 
 import (
 	"ch/kirari04/videocms/models"
+	"ch/kirari04/videocms/storage"
 	"context"
+	"errors"
 	"log"
 	"os"
 	"time"
@@ -29,9 +31,7 @@ func (w *WorkerGroup) runEncoderCleanup() {
 		Preload("Qualitys").
 		Preload("Subtitles").
 		Preload("Audios").
-		Not(&models.File{
-			Path: "",
-		}, "Path").
+		Where("path <> '' OR source_key <> ''").
 		Find(&dbReadyFiles); res.Error != nil {
 		log.Printf("Failed to get PossibleDeleteTargets: %v", res.Error)
 		return
@@ -78,19 +78,62 @@ func (w *WorkerGroup) runEncoderCleanup() {
 		if qualityAmount == int64(len(dbReadyFile.Qualitys)) &&
 			subtitleAmount == int64(len(dbReadyFile.Subtitles)) &&
 			audioAmount == int64(len(dbReadyFile.Audios)) {
-			if err := os.Remove(dbReadyFile.Path); err != nil {
-				log.Printf("Failed to delete file from path (%v): %v", dbReadyFile.Path, err)
-				continue
+			if dbReadyFile.SourceKey != "" {
+				if w.deps.Storage == nil {
+					log.Printf("Failed to delete source object for file %d: storage is not configured", dbReadyFile.ID)
+					continue
+				}
+				store, err := w.deps.Storage.StoreOrDefault(dbReadyFile.StorageID)
+				if err != nil {
+					log.Printf("Failed to resolve source store for file %d: %v", dbReadyFile.ID, err)
+					continue
+				}
+				key, err := storage.ParseKey(dbReadyFile.SourceKey)
+				if err != nil {
+					log.Printf("Failed to parse source key for file %d: %v", dbReadyFile.ID, err)
+					continue
+				}
+				if err := store.Delete(context.Background(), key); err != nil {
+					log.Printf("Failed to delete source object %s: %v", dbReadyFile.SourceKey, err)
+					continue
+				}
+			}
+			if dbReadyFile.Path != "" {
+				if err := os.Remove(dbReadyFile.Path); err != nil && !errors.Is(err, os.ErrNotExist) {
+					log.Printf("Failed to delete file from path (%v): %v", dbReadyFile.Path, err)
+					continue
+				}
 			}
 
 			// overwrite total filesize in file
-			newSize, err := dirSize(dbReadyFile.Folder)
+			newSize, err := w.storedFileSize(context.Background(), dbReadyFile)
 			if err != nil {
-				log.Printf("Failed to calc folder size after cleenup: %v", err)
+				log.Printf("Failed to calculate stored size after cleanup: %v", err)
 			}
 			dbReadyFile.Size = newSize
 			dbReadyFile.Path = ""
+			dbReadyFile.SourceKey = ""
 			w.deps.DB.Save(&dbReadyFile)
 		}
 	}
+}
+
+func (w *WorkerGroup) storedFileSize(ctx context.Context, file models.File) (int64, error) {
+	if w.deps.Storage == nil || w.deps.Storage.Layout() == nil {
+		return dirSize(file.Folder)
+	}
+	store, err := w.deps.Storage.StoreOrDefault(file.StorageID)
+	if err != nil {
+		return 0, err
+	}
+	prefix, err := w.deps.Storage.Layout().FilePrefix(file.UUID)
+	if err != nil {
+		return 0, err
+	}
+	var size int64
+	err = store.Walk(ctx, prefix, func(info storage.ObjectInfo) error {
+		size += info.Size
+		return nil
+	})
+	return size, err
 }

--- a/services/EncoderCleanup_test.go
+++ b/services/EncoderCleanup_test.go
@@ -14,6 +14,14 @@ import (
 	"gorm.io/gorm"
 )
 
+type walkFailStore struct {
+	storage.Store
+}
+
+func (walkFailStore) Walk(context.Context, storage.Key, func(storage.ObjectInfo) error) error {
+	return errors.New("injected walk failure")
+}
+
 func TestEncoderCleanupDeletesSourceFromNamedStoreAndKeepsOutputs(t *testing.T) {
 	db, err := gorm.Open(
 		sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"),
@@ -94,5 +102,67 @@ func TestEncoderCleanupDeletesSourceFromNamedStoreAndKeepsOutputs(t *testing.T) 
 	}
 	if _, err := defaultStore.Stat(context.Background(), sourceKey); err != nil {
 		t.Fatalf("default-store source was removed: %v", err)
+	}
+}
+
+func TestEncoderCleanupKeepsRecordedSizeWhenStoredSizeCannotBeCalculated(t *testing.T) {
+	db, err := gorm.Open(
+		sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"),
+		&gorm.Config{
+			DisableForeignKeyConstraintWhenMigrating: true,
+			IgnoreRelationshipsWhenMigrating:         true,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.File{}, &models.Quality{}, &models.Audio{}, &models.Subtitle{}); err != nil {
+		t.Fatal(err)
+	}
+	archiveStore, err := storage.NewLocalStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	storageService, err := storage.NewService("archive", storage.LegacyMediaLayout{}, map[string]storage.Store{
+		"archive": walkFailStore{Store: archiveStore},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = storageService.Close() })
+
+	fileUUID := "550e8400-e29b-41d4-a716-446655440302"
+	sourceKey, err := storageService.Layout().Source(fileUUID, "original.mp4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := archiveStore.Put(context.Background(), sourceKey, strings.NewReader("source"), storage.PutOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	file := models.File{
+		UUID:      fileUUID,
+		StorageID: "archive",
+		SourceKey: sourceKey.String(),
+		Size:      100,
+	}
+	if err := db.Create(&file).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	worker := &WorkerGroup{deps: &app.Deps{DB: db, Storage: storageService}}
+	worker.runEncoderCleanup()
+
+	var updated models.File
+	if err := db.First(&updated, file.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if updated.SourceKey != "" {
+		t.Fatalf("source reference was not cleared: %#v", updated)
+	}
+	if updated.Size != file.Size {
+		t.Fatalf("stored size = %d, want previous value %d", updated.Size, file.Size)
+	}
+	if _, err := archiveStore.Stat(context.Background(), sourceKey); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("archive source still exists: %v", err)
 	}
 }

--- a/services/EncoderCleanup_test.go
+++ b/services/EncoderCleanup_test.go
@@ -1,0 +1,98 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"ch/kirari04/videocms/app"
+	"ch/kirari04/videocms/models"
+	"ch/kirari04/videocms/storage"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestEncoderCleanupDeletesSourceFromNamedStoreAndKeepsOutputs(t *testing.T) {
+	db, err := gorm.Open(
+		sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"),
+		&gorm.Config{
+			DisableForeignKeyConstraintWhenMigrating: true,
+			IgnoreRelationshipsWhenMigrating:         true,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.File{}, &models.Quality{}, &models.Audio{}, &models.Subtitle{}); err != nil {
+		t.Fatal(err)
+	}
+	defaultStore, err := storage.NewLocalStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	archiveStore, err := storage.NewLocalStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	storageService, err := storage.NewService("local", storage.LegacyMediaLayout{}, map[string]storage.Store{
+		"local":   defaultStore,
+		"archive": archiveStore,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = storageService.Close() })
+
+	fileUUID := "550e8400-e29b-41d4-a716-446655440301"
+	sourceKey, err := storageService.Layout().Source(fileUUID, "original.mp4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	outputKey, err := storageService.Layout().Video(fileUUID, "720p", "out0.ts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := archiveStore.Put(context.Background(), sourceKey, strings.NewReader("source"), storage.PutOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := archiveStore.Put(context.Background(), outputKey, strings.NewReader("segment"), storage.PutOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := defaultStore.Put(context.Background(), sourceKey, strings.NewReader("keep"), storage.PutOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	file := models.File{
+		UUID:      fileUUID,
+		StorageID: "archive",
+		SourceKey: sourceKey.String(),
+		Size:      100,
+	}
+	if err := db.Create(&file).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	worker := &WorkerGroup{deps: &app.Deps{DB: db, Storage: storageService}}
+	worker.runEncoderCleanup()
+
+	var updated models.File
+	if err := db.First(&updated, file.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if updated.SourceKey != "" || updated.Path != "" {
+		t.Fatalf("source references were not cleared: %#v", updated)
+	}
+	if updated.Size != int64(len("segment")) {
+		t.Fatalf("stored size = %d, want %d", updated.Size, len("segment"))
+	}
+	if _, err := archiveStore.Stat(context.Background(), sourceKey); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("archive source still exists: %v", err)
+	}
+	if _, err := archiveStore.Stat(context.Background(), outputKey); err != nil {
+		t.Fatalf("encoded output was removed: %v", err)
+	}
+	if _, err := defaultStore.Stat(context.Background(), sourceKey); err != nil {
+		t.Fatalf("default-store source was removed: %v", err)
+	}
+}

--- a/services/Storage.go
+++ b/services/Storage.go
@@ -1,0 +1,63 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"ch/kirari04/videocms/models"
+	"ch/kirari04/videocms/storage"
+)
+
+func (w *WorkerGroup) materializeEncodingSource(ctx context.Context, file models.File) (string, func() error, error) {
+	if file.SourceKey != "" {
+		if w.deps == nil || w.deps.Storage == nil {
+			return "", nil, storage.ErrStoreNotConfigured
+		}
+		key, err := storage.ParseKey(file.SourceKey)
+		if err != nil {
+			return "", nil, err
+		}
+		return w.deps.Storage.Materialize(ctx, file.StorageID, key, "encoder-source", filepath.Ext(key.String()))
+	}
+	if file.Path == "" {
+		return "", nil, fmt.Errorf("%w: source for file %s", storage.ErrNotFound, file.UUID)
+	}
+	path, err := filepath.Abs(file.Path)
+	if err != nil {
+		return "", nil, err
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return "", nil, fmt.Errorf("source is not a regular file: %s", path)
+	}
+	return path, func() error { return nil }, nil
+}
+
+func (w *WorkerGroup) encodingOutputDirectory(ctx context.Context, purpose, legacyPath string) (string, func() error, error) {
+	if w.deps != nil && w.deps.Storage != nil && w.deps.Storage.Workspace() != nil {
+		return w.deps.Storage.Workspace().TempDir(ctx, purpose)
+	}
+	path, err := filepath.Abs(legacyPath)
+	if err != nil {
+		return "", nil, err
+	}
+	if err := os.MkdirAll(path, 0o777); err != nil {
+		return "", nil, err
+	}
+	return path, func() error { return nil }, nil
+}
+
+func (w *WorkerGroup) publishEncodingOutput(ctx context.Context, file models.File, prefix storage.Key, directory string) error {
+	if w.deps == nil || w.deps.Storage == nil {
+		return nil
+	}
+	_, err := w.deps.Storage.PublishPrefix(ctx, file.StorageID, prefix, directory, storage.PutOptions{
+		CacheControl: "public, max-age=3600",
+	})
+	return err
+}

--- a/storage/key.go
+++ b/storage/key.go
@@ -1,0 +1,51 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"path"
+	"strings"
+)
+
+var ErrInvalidKey = errors.New("invalid storage key")
+
+// Key is a validated, slash-separated object key. Keys are always relative to
+// the root configured by a storage adapter.
+type Key struct {
+	value string
+}
+
+func ParseKey(value string) (Key, error) {
+	if value == "" || strings.ContainsRune(value, 0) || strings.Contains(value, `\`) {
+		return Key{}, fmt.Errorf("%w: %q", ErrInvalidKey, value)
+	}
+	if strings.HasPrefix(value, "/") || path.Clean(value) != value {
+		return Key{}, fmt.Errorf("%w: %q", ErrInvalidKey, value)
+	}
+	for _, segment := range strings.Split(value, "/") {
+		if segment == "" || segment == "." || segment == ".." {
+			return Key{}, fmt.Errorf("%w: %q", ErrInvalidKey, value)
+		}
+	}
+	return Key{value: value}, nil
+}
+
+func JoinKey(segments ...string) (Key, error) {
+	if len(segments) == 0 {
+		return Key{}, fmt.Errorf("%w: no segments", ErrInvalidKey)
+	}
+	for _, segment := range segments {
+		if segment == "" || strings.ContainsAny(segment, `/\`) || segment == "." || segment == ".." {
+			return Key{}, fmt.Errorf("%w: segment %q", ErrInvalidKey, segment)
+		}
+	}
+	return ParseKey(strings.Join(segments, "/"))
+}
+
+func (k Key) String() string {
+	return k.value
+}
+
+func (k Key) IsZero() bool {
+	return k.value == ""
+}

--- a/storage/key_test.go
+++ b/storage/key_test.go
@@ -1,0 +1,57 @@
+package storage
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestParseKeyRejectsUnsafeValues(t *testing.T) {
+	for _, value := range []string{
+		"",
+		"/absolute/file",
+		"../outside",
+		"safe/../outside",
+		"safe//file",
+		`safe\file`,
+		"safe/./file",
+	} {
+		t.Run(value, func(t *testing.T) {
+			if _, err := ParseKey(value); !errors.Is(err, ErrInvalidKey) {
+				t.Fatalf("ParseKey(%q) error = %v, want ErrInvalidKey", value, err)
+			}
+		})
+	}
+}
+
+func TestLegacyMediaLayoutMatchesExistingTree(t *testing.T) {
+	layout := LegacyMediaLayout{}
+	video, videoErr := layout.Video("file", "720p", "out0.ts")
+	audio, audioErr := layout.Audio("file", "audio", "audio0.ts")
+	subtitle, subtitleErr := layout.Subtitle("file", "subtitle", "out.vtt")
+	thumbnail, thumbnailErr := layout.Thumbnail("file", "4x4.webp")
+	tests := []struct {
+		name string
+		key  Key
+		want string
+	}{
+		{name: "video", key: mustLayoutKey(t, video, videoErr), want: "file/720p/out0.ts"},
+		{name: "audio", key: mustLayoutKey(t, audio, audioErr), want: "file/audio/audio0.ts"},
+		{name: "subtitle", key: mustLayoutKey(t, subtitle, subtitleErr), want: "file/subtitle/out.vtt"},
+		{name: "thumbnail", key: mustLayoutKey(t, thumbnail, thumbnailErr), want: "file/4x4.webp"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.key.String() != test.want {
+				t.Fatalf("key = %q, want %q", test.key.String(), test.want)
+			}
+		})
+	}
+}
+
+func mustLayoutKey(t *testing.T, key Key, err error) Key {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("layout key error = %v", err)
+	}
+	return key
+}

--- a/storage/key_test.go
+++ b/storage/key_test.go
@@ -25,7 +25,9 @@ func TestParseKeyRejectsUnsafeValues(t *testing.T) {
 
 func TestLegacyMediaLayoutMatchesExistingTree(t *testing.T) {
 	layout := LegacyMediaLayout{}
+	source, sourceErr := layout.Source("file", "original.mp4")
 	video, videoErr := layout.Video("file", "720p", "out0.ts")
+	videoPrefix, videoPrefixErr := layout.VideoPrefix("file", "720p")
 	audio, audioErr := layout.Audio("file", "audio", "audio0.ts")
 	subtitle, subtitleErr := layout.Subtitle("file", "subtitle", "out.vtt")
 	thumbnail, thumbnailErr := layout.Thumbnail("file", "4x4.webp")
@@ -34,7 +36,9 @@ func TestLegacyMediaLayoutMatchesExistingTree(t *testing.T) {
 		key  Key
 		want string
 	}{
+		{name: "source", key: mustLayoutKey(t, source, sourceErr), want: "file/source/original.mp4"},
 		{name: "video", key: mustLayoutKey(t, video, videoErr), want: "file/720p/out0.ts"},
+		{name: "video prefix", key: mustLayoutKey(t, videoPrefix, videoPrefixErr), want: "file/720p"},
 		{name: "audio", key: mustLayoutKey(t, audio, audioErr), want: "file/audio/audio0.ts"},
 		{name: "subtitle", key: mustLayoutKey(t, subtitle, subtitleErr), want: "file/subtitle/out.vtt"},
 		{name: "thumbnail", key: mustLayoutKey(t, thumbnail, thumbnailErr), want: "file/4x4.webp"},

--- a/storage/layout.go
+++ b/storage/layout.go
@@ -1,0 +1,34 @@
+package storage
+
+// MediaLayout centralizes the mapping between domain identifiers and object
+// keys. The initial layout matches the existing on-disk tree so introducing
+// the abstraction does not move any user data.
+type MediaLayout interface {
+	Video(fileUUID, quality, fileName string) (Key, error)
+	Audio(fileUUID, audioUUID, fileName string) (Key, error)
+	Subtitle(fileUUID, subtitleUUID, fileName string) (Key, error)
+	Thumbnail(fileUUID, fileName string) (Key, error)
+	FilePrefix(fileUUID string) (Key, error)
+}
+
+type LegacyMediaLayout struct{}
+
+func (LegacyMediaLayout) Video(fileUUID, quality, fileName string) (Key, error) {
+	return JoinKey(fileUUID, quality, fileName)
+}
+
+func (LegacyMediaLayout) Audio(fileUUID, audioUUID, fileName string) (Key, error) {
+	return JoinKey(fileUUID, audioUUID, fileName)
+}
+
+func (LegacyMediaLayout) Subtitle(fileUUID, subtitleUUID, fileName string) (Key, error) {
+	return JoinKey(fileUUID, subtitleUUID, fileName)
+}
+
+func (LegacyMediaLayout) Thumbnail(fileUUID, fileName string) (Key, error) {
+	return JoinKey(fileUUID, fileName)
+}
+
+func (LegacyMediaLayout) FilePrefix(fileUUID string) (Key, error) {
+	return JoinKey(fileUUID)
+}

--- a/storage/layout.go
+++ b/storage/layout.go
@@ -4,25 +4,45 @@ package storage
 // keys. The initial layout matches the existing on-disk tree so introducing
 // the abstraction does not move any user data.
 type MediaLayout interface {
+	Source(fileUUID, fileName string) (Key, error)
 	Video(fileUUID, quality, fileName string) (Key, error)
+	VideoPrefix(fileUUID, quality string) (Key, error)
 	Audio(fileUUID, audioUUID, fileName string) (Key, error)
+	AudioPrefix(fileUUID, audioUUID string) (Key, error)
 	Subtitle(fileUUID, subtitleUUID, fileName string) (Key, error)
+	SubtitlePrefix(fileUUID, subtitleUUID string) (Key, error)
 	Thumbnail(fileUUID, fileName string) (Key, error)
 	FilePrefix(fileUUID string) (Key, error)
 }
 
 type LegacyMediaLayout struct{}
 
+func (LegacyMediaLayout) Source(fileUUID, fileName string) (Key, error) {
+	return JoinKey(fileUUID, "source", fileName)
+}
+
 func (LegacyMediaLayout) Video(fileUUID, quality, fileName string) (Key, error) {
 	return JoinKey(fileUUID, quality, fileName)
+}
+
+func (LegacyMediaLayout) VideoPrefix(fileUUID, quality string) (Key, error) {
+	return JoinKey(fileUUID, quality)
 }
 
 func (LegacyMediaLayout) Audio(fileUUID, audioUUID, fileName string) (Key, error) {
 	return JoinKey(fileUUID, audioUUID, fileName)
 }
 
+func (LegacyMediaLayout) AudioPrefix(fileUUID, audioUUID string) (Key, error) {
+	return JoinKey(fileUUID, audioUUID)
+}
+
 func (LegacyMediaLayout) Subtitle(fileUUID, subtitleUUID, fileName string) (Key, error) {
 	return JoinKey(fileUUID, subtitleUUID, fileName)
+}
+
+func (LegacyMediaLayout) SubtitlePrefix(fileUUID, subtitleUUID string) (Key, error) {
+	return JoinKey(fileUUID, subtitleUUID)
 }
 
 func (LegacyMediaLayout) Thumbnail(fileUUID, fileName string) (Key, error) {

--- a/storage/local.go
+++ b/storage/local.go
@@ -16,6 +16,23 @@ type LocalStore struct {
 	root string
 }
 
+// LocalPath exposes a read-only path optimization to the storage service.
+// It is intentionally not part of Store because remote adapters cannot
+// provide this capability.
+func (s *LocalStore) LocalPath(ctx context.Context, key Key) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	objectPath, err := s.pathFor(key)
+	if err != nil {
+		return "", err
+	}
+	if _, err := os.Stat(objectPath); err != nil {
+		return "", normalizeLocalError(key, err)
+	}
+	return objectPath, nil
+}
+
 func NewLocalStore(root string) (*LocalStore, error) {
 	if strings.TrimSpace(root) == "" {
 		return nil, errors.New("local storage root is empty")

--- a/storage/local.go
+++ b/storage/local.go
@@ -1,0 +1,258 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"mime"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type LocalStore struct {
+	root string
+}
+
+func NewLocalStore(root string) (*LocalStore, error) {
+	if strings.TrimSpace(root) == "" {
+		return nil, errors.New("local storage root is empty")
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("resolve local storage root: %w", err)
+	}
+	if err := os.MkdirAll(absRoot, 0o766); err != nil {
+		return nil, fmt.Errorf("create local storage root: %w", err)
+	}
+	info, err := os.Stat(absRoot)
+	if err != nil {
+		return nil, fmt.Errorf("inspect local storage root: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("local storage root is not a directory: %s", absRoot)
+	}
+	return &LocalStore{root: absRoot}, nil
+}
+
+func (s *LocalStore) Open(ctx context.Context, key Key) (*Object, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	objectPath, err := s.pathFor(key)
+	if err != nil {
+		return nil, err
+	}
+	file, err := os.Open(objectPath)
+	if err != nil {
+		return nil, normalizeLocalError(key, err)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		file.Close()
+		return nil, normalizeLocalError(key, err)
+	}
+	if !info.Mode().IsRegular() {
+		file.Close()
+		return nil, fmt.Errorf("%w: %s", ErrNotFound, key.String())
+	}
+	return &Object{
+		Body: file,
+		Info: localObjectInfo(key, info),
+	}, nil
+}
+
+func (s *LocalStore) Put(ctx context.Context, key Key, src io.Reader, opts PutOptions) (ObjectInfo, error) {
+	if err := ctx.Err(); err != nil {
+		return ObjectInfo{}, err
+	}
+	objectPath, err := s.pathFor(key)
+	if err != nil {
+		return ObjectInfo{}, err
+	}
+	if err := os.MkdirAll(filepath.Dir(objectPath), 0o766); err != nil {
+		return ObjectInfo{}, fmt.Errorf("create object directory: %w", err)
+	}
+	tempFile, err := os.CreateTemp(filepath.Dir(objectPath), ".videocms-put-*")
+	if err != nil {
+		return ObjectInfo{}, fmt.Errorf("create temporary object: %w", err)
+	}
+	tempPath := tempFile.Name()
+	keepTemp := false
+	defer func() {
+		if !keepTemp {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	written, copyErr := copyWithContext(ctx, tempFile, src)
+	closeErr := tempFile.Close()
+	if copyErr != nil {
+		return ObjectInfo{}, fmt.Errorf("write object %s: %w", key.String(), copyErr)
+	}
+	if closeErr != nil {
+		return ObjectInfo{}, fmt.Errorf("close object %s: %w", key.String(), closeErr)
+	}
+	if opts.ExpectedSize != nil && written != *opts.ExpectedSize {
+		return ObjectInfo{}, fmt.Errorf("object %s size mismatch: wrote %d, expected %d", key.String(), written, *opts.ExpectedSize)
+	}
+	if err := os.Chmod(tempPath, 0o644); err != nil {
+		return ObjectInfo{}, fmt.Errorf("set object permissions: %w", err)
+	}
+	if err := os.Rename(tempPath, objectPath); err != nil {
+		return ObjectInfo{}, fmt.Errorf("publish object %s: %w", key.String(), err)
+	}
+	keepTemp = true
+	return s.Stat(ctx, key)
+}
+
+func (s *LocalStore) Stat(ctx context.Context, key Key) (ObjectInfo, error) {
+	if err := ctx.Err(); err != nil {
+		return ObjectInfo{}, err
+	}
+	objectPath, err := s.pathFor(key)
+	if err != nil {
+		return ObjectInfo{}, err
+	}
+	info, err := os.Stat(objectPath)
+	if err != nil {
+		return ObjectInfo{}, normalizeLocalError(key, err)
+	}
+	if !info.Mode().IsRegular() {
+		return ObjectInfo{}, fmt.Errorf("%w: %s", ErrNotFound, key.String())
+	}
+	return localObjectInfo(key, info), nil
+}
+
+func (s *LocalStore) Delete(ctx context.Context, key Key) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	objectPath, err := s.pathFor(key)
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(objectPath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("delete object %s: %w", key.String(), err)
+	}
+	s.pruneEmptyParents(filepath.Dir(objectPath))
+	return nil
+}
+
+func (s *LocalStore) Walk(ctx context.Context, prefix Key, fn func(ObjectInfo) error) error {
+	if fn == nil {
+		return errors.New("storage walk callback is nil")
+	}
+	prefixPath, err := s.pathFor(prefix)
+	if err != nil {
+		return err
+	}
+	err = filepath.WalkDir(prefixPath, func(currentPath string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			if errors.Is(walkErr, os.ErrNotExist) && currentPath == prefixPath {
+				return fs.SkipAll
+			}
+			return walkErr
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		relative, err := filepath.Rel(s.root, currentPath)
+		if err != nil {
+			return err
+		}
+		key, err := ParseKey(filepath.ToSlash(relative))
+		if err != nil {
+			return err
+		}
+		return fn(localObjectInfo(key, info))
+	})
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+func (s *LocalStore) Close() error {
+	return nil
+}
+
+func (s *LocalStore) pruneEmptyParents(directory string) {
+	for directory != s.root {
+		if err := os.Remove(directory); err != nil {
+			return
+		}
+		directory = filepath.Dir(directory)
+	}
+}
+
+func (s *LocalStore) pathFor(key Key) (string, error) {
+	if s == nil || s.root == "" {
+		return "", ErrStoreNotConfigured
+	}
+	validated, err := ParseKey(key.String())
+	if err != nil {
+		return "", err
+	}
+	candidate := filepath.Join(s.root, filepath.FromSlash(validated.String()))
+	relative, err := filepath.Rel(s.root, candidate)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("%w: %s", ErrInvalidKey, key.String())
+	}
+	return candidate, nil
+}
+
+func localObjectInfo(key Key, info fs.FileInfo) ObjectInfo {
+	return ObjectInfo{
+		Key:         key,
+		Size:        info.Size(),
+		ModTime:     info.ModTime(),
+		ContentType: mime.TypeByExtension(filepath.Ext(key.String())),
+	}
+}
+
+func normalizeLocalError(key Key, err error) error {
+	if errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("%w: %s", ErrNotFound, key.String())
+	}
+	return err
+}
+
+func copyWithContext(ctx context.Context, dst io.Writer, src io.Reader) (int64, error) {
+	buffer := make([]byte, 128*1024)
+	var written int64
+	for {
+		if err := ctx.Err(); err != nil {
+			return written, err
+		}
+		read, readErr := src.Read(buffer)
+		if read > 0 {
+			count, writeErr := dst.Write(buffer[:read])
+			written += int64(count)
+			if writeErr != nil {
+				return written, writeErr
+			}
+			if count != read {
+				return written, io.ErrShortWrite
+			}
+		}
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				return written, nil
+			}
+			return written, readErr
+		}
+	}
+}

--- a/storage/local_test.go
+++ b/storage/local_test.go
@@ -36,12 +36,30 @@ func TestLocalStoreConformance(t *testing.T) {
 		t.Fatalf("Seek() error = %v", err)
 	}
 	data, err := io.ReadAll(object.Body)
-	object.Body.Close()
 	if err != nil {
 		t.Fatalf("ReadAll() error = %v", err)
 	}
 	if string(data) != "data" {
 		t.Fatalf("read data = %q, want %q", data, "data")
+	}
+	if _, err := object.Body.Seek(0, io.SeekStart); err != nil {
+		t.Fatalf("second Seek() error = %v", err)
+	}
+	first := make([]byte, 7)
+	if _, err := io.ReadFull(object.Body, first); err != nil {
+		t.Fatalf("ReadFull() after second seek error = %v", err)
+	}
+	if string(first) != "segment" {
+		t.Fatalf("second read data = %q, want segment", first)
+	}
+	if offset, err := object.Body.Seek(0, io.SeekEnd); err != nil || offset != expectedSize {
+		t.Fatalf("SeekEnd() = %d, %v, want %d", offset, err, expectedSize)
+	}
+	object.Body.Close()
+
+	outsidePrefix := mustParseKey(t, "file-other/720p/out0.ts")
+	if _, err := store.Put(ctx, outsidePrefix, strings.NewReader("other"), PutOptions{}); err != nil {
+		t.Fatalf("Put() outside prefix error = %v", err)
 	}
 
 	prefix := mustParseKey(t, "file")
@@ -54,6 +72,11 @@ func TestLocalStoreConformance(t *testing.T) {
 	}
 	if len(walked) != 1 || walked[0] != key.String() {
 		t.Fatalf("Walk() = %v, want [%s]", walked, key.String())
+	}
+	canceled, cancel := context.WithCancel(ctx)
+	cancel()
+	if _, err := store.Open(canceled, key); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Open() canceled error = %v, want context.Canceled", err)
 	}
 
 	if err := store.Delete(ctx, key); err != nil {

--- a/storage/local_test.go
+++ b/storage/local_test.go
@@ -1,0 +1,115 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLocalStoreConformance(t *testing.T) {
+	store, err := NewLocalStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewLocalStore() error = %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	ctx := context.Background()
+	key := mustParseKey(t, "file/720p/out0.ts")
+	expectedSize := int64(len("segment-data"))
+	info, err := store.Put(ctx, key, strings.NewReader("segment-data"), PutOptions{ExpectedSize: &expectedSize})
+	if err != nil {
+		t.Fatalf("Put() error = %v", err)
+	}
+	if info.Size != expectedSize {
+		t.Fatalf("Put() size = %d, want %d", info.Size, expectedSize)
+	}
+
+	object, err := store.Open(ctx, key)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	if _, err := object.Body.Seek(8, io.SeekStart); err != nil {
+		t.Fatalf("Seek() error = %v", err)
+	}
+	data, err := io.ReadAll(object.Body)
+	object.Body.Close()
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if string(data) != "data" {
+		t.Fatalf("read data = %q, want %q", data, "data")
+	}
+
+	prefix := mustParseKey(t, "file")
+	var walked []string
+	if err := store.Walk(ctx, prefix, func(info ObjectInfo) error {
+		walked = append(walked, info.Key.String())
+		return nil
+	}); err != nil {
+		t.Fatalf("Walk() error = %v", err)
+	}
+	if len(walked) != 1 || walked[0] != key.String() {
+		t.Fatalf("Walk() = %v, want [%s]", walked, key.String())
+	}
+
+	if err := store.Delete(ctx, key); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if err := store.Delete(ctx, key); err != nil {
+		t.Fatalf("second Delete() error = %v", err)
+	}
+	if _, err := store.Open(ctx, key); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Open() after delete error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestLocalStoreRejectsSizeMismatchWithoutPublishing(t *testing.T) {
+	store, err := NewLocalStore(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewLocalStore() error = %v", err)
+	}
+	key := mustParseKey(t, "file/object")
+	expected := int64(100)
+	if _, err := store.Put(context.Background(), key, strings.NewReader("short"), PutOptions{ExpectedSize: &expected}); err == nil {
+		t.Fatal("Put() error = nil, want size mismatch")
+	}
+	if _, err := store.Stat(context.Background(), key); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Stat() error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestDeletePrefixRemovesObjectsAndEmptyDirectories(t *testing.T) {
+	root := t.TempDir()
+	store, err := NewLocalStore(root)
+	if err != nil {
+		t.Fatalf("NewLocalStore() error = %v", err)
+	}
+	ctx := context.Background()
+	for _, value := range []string{"file/720p/out.m3u8", "file/720p/out0.ts", "file/audio/audio0.ts"} {
+		if _, err := store.Put(ctx, mustParseKey(t, value), strings.NewReader(value), PutOptions{}); err != nil {
+			t.Fatalf("Put(%q) error = %v", value, err)
+		}
+	}
+	if err := DeletePrefix(ctx, store, mustParseKey(t, "file")); err != nil {
+		t.Fatalf("DeletePrefix() error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "file")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("media directory still exists or stat failed unexpectedly: %v", err)
+	}
+	if err := DeletePrefix(ctx, store, mustParseKey(t, "missing")); err != nil {
+		t.Fatalf("DeletePrefix() for missing prefix error = %v", err)
+	}
+}
+
+func mustParseKey(t *testing.T, value string) Key {
+	t.Helper()
+	key, err := ParseKey(value)
+	if err != nil {
+		t.Fatalf("ParseKey(%q) error = %v", value, err)
+	}
+	return key
+}

--- a/storage/service.go
+++ b/storage/service.go
@@ -1,0 +1,105 @@
+package storage
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+)
+
+var ErrStoreNotConfigured = errors.New("storage store not configured")
+
+// Service is the runtime registry for named stores and the active media key
+// layout. Named stores allow records to retain their original location during
+// a gradual migration to another backend.
+type Service struct {
+	defaultStoreID string
+	stores         map[string]Store
+	layout         MediaLayout
+	workspace      Workspace
+}
+
+func NewService(defaultStoreID string, layout MediaLayout, stores map[string]Store) (*Service, error) {
+	workspace, err := NewLocalWorkspace("")
+	if err != nil {
+		return nil, err
+	}
+	return NewServiceWithWorkspace(defaultStoreID, layout, workspace, stores)
+}
+
+func NewServiceWithWorkspace(defaultStoreID string, layout MediaLayout, workspace Workspace, stores map[string]Store) (*Service, error) {
+	if defaultStoreID == "" || layout == nil || workspace == nil {
+		return nil, ErrStoreNotConfigured
+	}
+	defaultStore, ok := stores[defaultStoreID]
+	if !ok || defaultStore == nil {
+		return nil, fmt.Errorf("%w: %s", ErrStoreNotConfigured, defaultStoreID)
+	}
+	owned := make(map[string]Store, len(stores))
+	for id, store := range stores {
+		if id == "" || store == nil {
+			return nil, ErrStoreNotConfigured
+		}
+		owned[id] = store
+	}
+	return &Service{
+		defaultStoreID: defaultStoreID,
+		stores:         owned,
+		layout:         layout,
+		workspace:      workspace,
+	}, nil
+}
+
+func (s *Service) DefaultStoreID() string {
+	if s == nil {
+		return ""
+	}
+	return s.defaultStoreID
+}
+
+func (s *Service) Default() (Store, error) {
+	if s == nil {
+		return nil, ErrStoreNotConfigured
+	}
+	return s.Store(s.defaultStoreID)
+}
+
+func (s *Service) Store(id string) (Store, error) {
+	if s == nil {
+		return nil, ErrStoreNotConfigured
+	}
+	store, ok := s.stores[id]
+	if !ok || store == nil {
+		return nil, fmt.Errorf("%w: %s", ErrStoreNotConfigured, id)
+	}
+	return store, nil
+}
+
+func (s *Service) Layout() MediaLayout {
+	if s == nil {
+		return nil
+	}
+	return s.layout
+}
+
+func (s *Service) Workspace() Workspace {
+	if s == nil {
+		return nil
+	}
+	return s.workspace
+}
+
+func (s *Service) Close() error {
+	if s == nil {
+		return nil
+	}
+	ids := make([]string, 0, len(s.stores))
+	for id := range s.stores {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	var closeErr error
+	for _, id := range ids {
+		closeErr = errors.Join(closeErr, s.stores[id].Close())
+	}
+	return closeErr
+}

--- a/storage/service.go
+++ b/storage/service.go
@@ -74,6 +74,16 @@ func (s *Service) Store(id string) (Store, error) {
 	return store, nil
 }
 
+// StoreOrDefault resolves a persisted store ID. Empty IDs are treated as the
+// active default for compatibility with records created before store IDs were
+// persisted.
+func (s *Service) StoreOrDefault(id string) (Store, error) {
+	if id == "" {
+		return s.Default()
+	}
+	return s.Store(id)
+}
+
 func (s *Service) Layout() MediaLayout {
 	if s == nil {
 		return nil

--- a/storage/store.go
+++ b/storage/store.go
@@ -37,7 +37,10 @@ type PutOptions struct {
 
 // Store exposes only operations that have equivalent semantics on local disk
 // and object storage. Directory creation and renames intentionally do not form
-// part of this contract.
+// part of this contract. Open must support repeated seeks efficiently; remote
+// adapters should translate seeks into provider range requests rather than
+// downloading the entire object. Delete is idempotent. Walk visits only the
+// object at prefix or descendants below the prefix segment boundary.
 type Store interface {
 	Open(ctx context.Context, key Key) (*Object, error)
 	Put(ctx context.Context, key Key, src io.Reader, opts PutOptions) (ObjectInfo, error)

--- a/storage/store.go
+++ b/storage/store.go
@@ -1,0 +1,48 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"io"
+	"time"
+)
+
+var ErrNotFound = errors.New("storage object not found")
+
+type ReadSeekCloser interface {
+	io.Reader
+	io.Seeker
+	io.Closer
+}
+
+type Object struct {
+	Body ReadSeekCloser
+	Info ObjectInfo
+}
+
+type ObjectInfo struct {
+	Key          Key
+	Size         int64
+	ModTime      time.Time
+	ContentType  string
+	CacheControl string
+	ETag         string
+}
+
+type PutOptions struct {
+	ContentType  string
+	CacheControl string
+	ExpectedSize *int64
+}
+
+// Store exposes only operations that have equivalent semantics on local disk
+// and object storage. Directory creation and renames intentionally do not form
+// part of this contract.
+type Store interface {
+	Open(ctx context.Context, key Key) (*Object, error)
+	Put(ctx context.Context, key Key, src io.Reader, opts PutOptions) (ObjectInfo, error)
+	Stat(ctx context.Context, key Key) (ObjectInfo, error)
+	Delete(ctx context.Context, key Key) error
+	Walk(ctx context.Context, prefix Key, fn func(ObjectInfo) error) error
+	Close() error
+}

--- a/storage/transfer.go
+++ b/storage/transfer.go
@@ -1,0 +1,275 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"mime"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type localPathStore interface {
+	LocalPath(context.Context, Key) (string, error)
+}
+
+// Materialize copies an object into local scratch storage when the selected
+// adapter cannot expose a local path. The returned cleanup must be called.
+func (s *Service) Materialize(ctx context.Context, storeID string, key Key, purpose, suffix string) (string, func() error, error) {
+	store, err := s.StoreOrDefault(storeID)
+	if err != nil {
+		return "", nil, err
+	}
+	if local, ok := store.(localPathStore); ok {
+		path, err := local.LocalPath(ctx, key)
+		if err != nil {
+			return "", nil, err
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			return "", nil, err
+		}
+		if !info.Mode().IsRegular() {
+			return "", nil, fmt.Errorf("%w: %s", ErrNotFound, key.String())
+		}
+		return path, noCleanup, nil
+	}
+
+	object, err := store.Open(ctx, key)
+	if err != nil {
+		return "", nil, err
+	}
+	defer object.Body.Close()
+
+	temporary, cleanup, err := s.workspace.TempFile(ctx, purpose, suffix)
+	if err != nil {
+		return "", nil, err
+	}
+	path := temporary.Name()
+	written, copyErr := copyWithContext(ctx, temporary, object.Body)
+	closeErr := temporary.Close()
+	if copyErr != nil || closeErr != nil || written != object.Info.Size {
+		_ = cleanup()
+		if copyErr != nil {
+			return "", nil, copyErr
+		}
+		if closeErr != nil {
+			return "", nil, closeErr
+		}
+		return "", nil, fmt.Errorf("materialized object %s size mismatch: wrote %d, expected %d", key.String(), written, object.Info.Size)
+	}
+	return path, cleanup, nil
+}
+
+// MaterializePrefix makes a complete object prefix available as a local
+// directory. Relative object names are preserved for manifests such as HLS.
+func (s *Service) MaterializePrefix(ctx context.Context, storeID string, prefix Key, purpose string) (string, func() error, error) {
+	store, err := s.StoreOrDefault(storeID)
+	if err != nil {
+		return "", nil, err
+	}
+	if local, ok := store.(localPathStore); ok {
+		path, err := local.LocalPath(ctx, prefix)
+		if err != nil {
+			return "", nil, err
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			return "", nil, err
+		}
+		if !info.IsDir() {
+			return "", nil, fmt.Errorf("%w: %s", ErrNotFound, prefix.String())
+		}
+		return path, noCleanup, nil
+	}
+
+	directory, cleanup, err := s.workspace.TempDir(ctx, purpose)
+	if err != nil {
+		return "", nil, err
+	}
+	found := false
+	err = store.Walk(ctx, prefix, func(info ObjectInfo) error {
+		relative, err := relativeObjectKey(prefix, info.Key)
+		if err != nil {
+			return err
+		}
+		destination := filepath.Join(directory, filepath.FromSlash(relative))
+		if err := os.MkdirAll(filepath.Dir(destination), 0o700); err != nil {
+			return err
+		}
+		object, err := store.Open(ctx, info.Key)
+		if err != nil {
+			return err
+		}
+		file, err := os.OpenFile(destination, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+		if err != nil {
+			object.Body.Close()
+			return err
+		}
+		written, copyErr := copyWithContext(ctx, file, object.Body)
+		closeErr := errors.Join(file.Close(), object.Body.Close())
+		if copyErr != nil {
+			return copyErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+		if written != object.Info.Size {
+			return fmt.Errorf("materialized object %s size mismatch: wrote %d, expected %d", info.Key.String(), written, object.Info.Size)
+		}
+		found = true
+		return nil
+	})
+	if err != nil || !found {
+		_ = cleanup()
+		if err != nil {
+			return "", nil, err
+		}
+		return "", nil, fmt.Errorf("%w: %s", ErrNotFound, prefix.String())
+	}
+	return directory, cleanup, nil
+}
+
+func (s *Service) PublishFile(ctx context.Context, storeID string, key Key, localPath string, opts PutOptions) (ObjectInfo, error) {
+	store, err := s.StoreOrDefault(storeID)
+	if err != nil {
+		return ObjectInfo{}, err
+	}
+	file, err := os.Open(localPath)
+	if err != nil {
+		return ObjectInfo{}, err
+	}
+	defer file.Close()
+	info, err := file.Stat()
+	if err != nil {
+		return ObjectInfo{}, err
+	}
+	if !info.Mode().IsRegular() {
+		return ObjectInfo{}, fmt.Errorf("publish source is not a regular file: %s", localPath)
+	}
+	expectedSize := info.Size()
+	opts.ExpectedSize = &expectedSize
+	if opts.ContentType == "" {
+		opts.ContentType = mime.TypeByExtension(filepath.Ext(localPath))
+	}
+	return store.Put(ctx, key, file, opts)
+}
+
+// PublishPrefix publishes regular files under localRoot while preserving their
+// relative names. Manifest files are written last, then stale remote objects
+// are removed only after the replacement tree is complete.
+func (s *Service) PublishPrefix(ctx context.Context, storeID string, prefix Key, localRoot string, opts PutOptions) ([]ObjectInfo, error) {
+	store, err := s.StoreOrDefault(storeID)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := publishEntries(localRoot)
+	if err != nil {
+		return nil, err
+	}
+	published := make([]ObjectInfo, 0, len(entries))
+	publishedKeys := make(map[string]bool, len(entries))
+	for _, entry := range entries {
+		key, err := ParseKey(prefix.String() + "/" + entry.relative)
+		if err != nil {
+			return nil, err
+		}
+		info, err := s.PublishFile(ctx, storeID, key, entry.path, opts)
+		if err != nil {
+			return nil, err
+		}
+		published = append(published, info)
+		publishedKeys[key.String()] = true
+	}
+	var stale []Key
+	if err := store.Walk(ctx, prefix, func(info ObjectInfo) error {
+		if publishedKeys[info.Key.String()] {
+			return nil
+		}
+		stale = append(stale, info.Key)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	for _, key := range stale {
+		if err := store.Delete(ctx, key); err != nil {
+			return nil, err
+		}
+	}
+	return published, nil
+}
+
+type publishEntry struct {
+	path     string
+	relative string
+	manifest bool
+}
+
+func publishEntries(root string) ([]publishEntry, error) {
+	root, err := filepath.Abs(root)
+	if err != nil {
+		return nil, err
+	}
+	var entries []publishEntry
+	err = filepath.WalkDir(root, func(current string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return fmt.Errorf("publish tree contains symlink: %s", current)
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("publish tree contains non-regular file: %s", current)
+		}
+		relative, err := filepath.Rel(root, current)
+		if err != nil {
+			return err
+		}
+		relative = filepath.ToSlash(relative)
+		if _, err := ParseKey(relative); err != nil {
+			return err
+		}
+		entries = append(entries, publishEntry{
+			path:     current,
+			relative: relative,
+			manifest: strings.EqualFold(filepath.Ext(relative), ".m3u8"),
+		})
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(entries) == 0 {
+		return nil, errors.New("publish tree is empty")
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].manifest != entries[j].manifest {
+			return !entries[i].manifest
+		}
+		return entries[i].relative < entries[j].relative
+	})
+	return entries, nil
+}
+
+func relativeObjectKey(prefix, key Key) (string, error) {
+	base := prefix.String() + "/"
+	if !strings.HasPrefix(key.String(), base) {
+		return "", fmt.Errorf("object %s is outside prefix %s", key.String(), prefix.String())
+	}
+	relative := strings.TrimPrefix(key.String(), base)
+	if _, err := ParseKey(relative); err != nil {
+		return "", err
+	}
+	return relative, nil
+}
+
+func noCleanup() error { return nil }

--- a/storage/transfer_test.go
+++ b/storage/transfer_test.go
@@ -1,0 +1,111 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type opaqueStore struct{ Store }
+
+func TestPublishAndMaterializePrefix(t *testing.T) {
+	ctx := context.Background()
+	storeRoot := t.TempDir()
+	workspaceRoot := t.TempDir()
+	sourceRoot := t.TempDir()
+	local, err := NewLocalStore(storeRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace, err := NewLocalWorkspace(workspaceRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service, err := NewServiceWithWorkspace("remote", LegacyMediaLayout{}, workspace, map[string]Store{
+		"remote": opaqueStore{Store: local},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mustWriteStorageTestFile(t, filepath.Join(sourceRoot, "out0.ts"), "segment")
+	mustWriteStorageTestFile(t, filepath.Join(sourceRoot, "stream.m3u8"), "manifest")
+	prefix, err := JoinKey("file", "720p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale, err := JoinKey("file", "720p", "stale.ts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := local.Put(ctx, stale, strings.NewReader("stale"), PutOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	published, err := service.PublishPrefix(ctx, "remote", prefix, sourceRoot, PutOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(published) != 2 {
+		t.Fatalf("published %d objects, want 2", len(published))
+	}
+	if _, err := local.Stat(ctx, stale); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("stale object was not removed: %v", err)
+	}
+
+	materialized, cleanup, err := service.MaterializePrefix(ctx, "remote", prefix, "download-input")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cleanup()
+	data, err := os.ReadFile(filepath.Join(materialized, "out0.ts"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "segment" {
+		t.Fatalf("materialized segment = %q", data)
+	}
+}
+
+func TestMaterializeUsesLocalPathWithoutRemovingIt(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	local, err := NewLocalStore(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service, err := NewService("local", LegacyMediaLayout{}, map[string]Store{"local": local})
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := JoinKey("file", "source", "original.mp4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := local.Put(ctx, key, strings.NewReader("source"), PutOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	path, cleanup, err := service.Materialize(ctx, "local", key, "encoder-input", ".mp4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cleanup(); err != nil {
+		t.Fatal(err)
+	}
+	if data, err := os.ReadFile(path); err != nil || string(data) != "source" {
+		t.Fatalf("local materialization was removed or changed: %q, %v", data, err)
+	}
+}
+
+func mustWriteStorageTestFile(t *testing.T, path, data string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/storage/transfer_test.go
+++ b/storage/transfer_test.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,6 +11,25 @@ import (
 )
 
 type opaqueStore struct{ Store }
+
+type wrongSizeStore struct{ Store }
+
+func (s wrongSizeStore) Open(ctx context.Context, key Key) (*Object, error) {
+	object, err := s.Store.Open(ctx, key)
+	if err == nil {
+		object.Info.Size++
+	}
+	return object, err
+}
+
+type failManifestStore struct{ Store }
+
+func (s failManifestStore) Put(ctx context.Context, key Key, src io.Reader, opts PutOptions) (ObjectInfo, error) {
+	if strings.HasSuffix(key.String(), ".m3u8") {
+		return ObjectInfo{}, errors.New("injected manifest failure")
+	}
+	return s.Store.Put(ctx, key, src, opts)
+}
 
 func TestPublishAndMaterializePrefix(t *testing.T) {
 	ctx := context.Background()
@@ -100,6 +120,88 @@ func TestMaterializeUsesLocalPathWithoutRemovingIt(t *testing.T) {
 	}
 }
 
+func TestMaterializeRemovesScratchFileAfterSizeMismatch(t *testing.T) {
+	ctx := context.Background()
+	backing, err := NewLocalStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaceRoot := t.TempDir()
+	workspace, err := NewLocalWorkspace(workspaceRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	service, err := NewServiceWithWorkspace("remote", LegacyMediaLayout{}, workspace, map[string]Store{
+		"remote": wrongSizeStore{Store: backing},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := JoinKey("file", "source", "original.mp4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := backing.Put(ctx, key, strings.NewReader("source"), PutOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := service.Materialize(ctx, "remote", key, "encoder-source", ".mp4"); err == nil {
+		t.Fatal("Materialize() error = nil, want size mismatch")
+	}
+	entries, err := os.ReadDir(workspaceRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("workspace retained %d entries after failure", len(entries))
+	}
+}
+
+func TestPublishPrefixWritesManifestLastAndKeepsStaleObjectsOnFailure(t *testing.T) {
+	ctx := context.Background()
+	backing, err := NewLocalStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	service, err := NewService("remote", LegacyMediaLayout{}, map[string]Store{
+		"remote": failManifestStore{Store: backing},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prefix, err := JoinKey("file", "720p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := mustParseKey(t, "file/720p/stream.m3u8")
+	segment := mustParseKey(t, "file/720p/out0.ts")
+	stale := mustParseKey(t, "file/720p/stale.ts")
+	for key, value := range map[Key]string{
+		manifest: "old manifest",
+		segment:  "old segment",
+		stale:    "stale segment",
+	} {
+		if _, err := backing.Put(ctx, key, strings.NewReader(value), PutOptions{}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sourceRoot := t.TempDir()
+	mustWriteStorageTestFile(t, filepath.Join(sourceRoot, "out0.ts"), "new segment")
+	mustWriteStorageTestFile(t, filepath.Join(sourceRoot, "stream.m3u8"), "new manifest")
+
+	if _, err := service.PublishPrefix(ctx, "remote", prefix, sourceRoot, PutOptions{}); err == nil {
+		t.Fatal("PublishPrefix() error = nil, want injected failure")
+	}
+	if got := readStorageTestObject(t, backing, manifest); got != "old manifest" {
+		t.Fatalf("manifest = %q, want old manifest", got)
+	}
+	if got := readStorageTestObject(t, backing, segment); got != "new segment" {
+		t.Fatalf("segment = %q, want new segment", got)
+	}
+	if _, err := backing.Stat(ctx, stale); err != nil {
+		t.Fatalf("stale object was removed before successful publish: %v", err)
+	}
+}
+
 func mustWriteStorageTestFile(t *testing.T, path, data string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
@@ -108,4 +210,18 @@ func mustWriteStorageTestFile(t *testing.T, path, data string) {
 	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func readStorageTestObject(t *testing.T, store Store, key Key) string {
+	t.Helper()
+	object, err := store.Open(context.Background(), key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer object.Body.Close()
+	data, err := io.ReadAll(object.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
 }

--- a/storage/tree.go
+++ b/storage/tree.go
@@ -1,0 +1,29 @@
+package storage
+
+import (
+	"context"
+	"errors"
+)
+
+// DeletePrefix removes every object below prefix. It is intentionally built
+// from Walk and Delete so adapters do not have to emulate filesystem
+// RemoveAll semantics.
+func DeletePrefix(ctx context.Context, store Store, prefix Key) error {
+	if store == nil {
+		return ErrStoreNotConfigured
+	}
+	keys := make([]Key, 0)
+	if err := store.Walk(ctx, prefix, func(info ObjectInfo) error {
+		keys = append(keys, info.Key)
+		return nil
+	}); err != nil {
+		return err
+	}
+	var deleteErr error
+	for _, key := range keys {
+		if err := store.Delete(ctx, key); err != nil {
+			deleteErr = errors.Join(deleteErr, err)
+		}
+	}
+	return deleteErr
+}

--- a/storage/workspace.go
+++ b/storage/workspace.go
@@ -1,0 +1,83 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+var safePurpose = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,62}$`)
+var safeSuffix = regexp.MustCompile(`^(\.[a-z0-9]{1,16})?$`)
+
+// Workspace represents explicitly local, non-authoritative scratch space for
+// path-oriented tools such as FFmpeg and ffprobe.
+type Workspace interface {
+	TempFile(ctx context.Context, purpose string, suffix string) (*os.File, func() error, error)
+	TempDir(ctx context.Context, purpose string) (string, func() error, error)
+}
+
+type LocalWorkspace struct {
+	root string
+}
+
+func NewLocalWorkspace(root string) (*LocalWorkspace, error) {
+	if root == "" {
+		root = os.TempDir()
+	}
+	absRoot, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("resolve workspace root: %w", err)
+	}
+	if err := os.MkdirAll(absRoot, 0o700); err != nil {
+		return nil, fmt.Errorf("create workspace root: %w", err)
+	}
+	return &LocalWorkspace{root: absRoot}, nil
+}
+
+func (w *LocalWorkspace) TempFile(ctx context.Context, purpose string, suffix string) (*os.File, func() error, error) {
+	if err := validateWorkspaceRequest(ctx, w, purpose); err != nil {
+		return nil, nil, err
+	}
+	if !safeSuffix.MatchString(suffix) {
+		return nil, nil, fmt.Errorf("invalid workspace suffix %q", suffix)
+	}
+	file, err := os.CreateTemp(w.root, "videocms-"+purpose+"-*"+suffix)
+	if err != nil {
+		return nil, nil, err
+	}
+	cleanup := func() error {
+		err := os.Remove(file.Name())
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	return file, cleanup, nil
+}
+
+func (w *LocalWorkspace) TempDir(ctx context.Context, purpose string) (string, func() error, error) {
+	if err := validateWorkspaceRequest(ctx, w, purpose); err != nil {
+		return "", nil, err
+	}
+	directory, err := os.MkdirTemp(w.root, "videocms-"+purpose+"-*")
+	if err != nil {
+		return "", nil, err
+	}
+	return directory, func() error { return os.RemoveAll(directory) }, nil
+}
+
+func validateWorkspaceRequest(ctx context.Context, workspace *LocalWorkspace, purpose string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if workspace == nil || workspace.root == "" {
+		return ErrStoreNotConfigured
+	}
+	if !safePurpose.MatchString(purpose) {
+		return fmt.Errorf("invalid workspace purpose %q", purpose)
+	}
+	return nil
+}

--- a/storage/workspace_test.go
+++ b/storage/workspace_test.go
@@ -1,0 +1,50 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+)
+
+func TestLocalWorkspaceCreatesAndCleansScratchResources(t *testing.T) {
+	workspace, err := NewLocalWorkspace(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewLocalWorkspace() error = %v", err)
+	}
+	file, cleanupFile, err := workspace.TempFile(context.Background(), "thumbnail-input", ".png")
+	if err != nil {
+		t.Fatalf("TempFile() error = %v", err)
+	}
+	filePath := file.Name()
+	if err := file.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if err := cleanupFile(); err != nil {
+		t.Fatalf("cleanup file error = %v", err)
+	}
+	if _, err := os.Stat(filePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("temporary file still exists or stat failed unexpectedly: %v", err)
+	}
+
+	directory, cleanupDir, err := workspace.TempDir(context.Background(), "generated-thumbnail")
+	if err != nil {
+		t.Fatalf("TempDir() error = %v", err)
+	}
+	if err := cleanupDir(); err != nil {
+		t.Fatalf("cleanup directory error = %v", err)
+	}
+	if _, err := os.Stat(directory); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("temporary directory still exists or stat failed unexpectedly: %v", err)
+	}
+}
+
+func TestLocalWorkspaceRejectsUnsafePurpose(t *testing.T) {
+	workspace, err := NewLocalWorkspace(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewLocalWorkspace() error = %v", err)
+	}
+	if _, _, err := workspace.TempFile(context.Background(), "../escape", ""); err == nil {
+		t.Fatal("TempFile() error = nil, want unsafe purpose rejection")
+	}
+}


### PR DESCRIPTION
## What this is for

VideoCMS currently couples media upload, processing, serving, thumbnails, downloads, and deletion to local filesystem paths. This PR creates a provider-neutral storage boundary while keeping the existing local-storage behavior and on-disk layout compatible.

## Goal

The goal is to let each media file retain a named storage backend and use validated object keys instead of filesystem paths for durable data. Path-only tools such as FFmpeg still get local files, but only through an explicit scratch materialization boundary. This lets us add S3-compatible, GCS, Azure Blob, or other adapters without assuming those systems support directory or rename semantics.

## What changes

- Adds a small storage contract for opening, writing, inspecting, deleting, and walking objects.
- Adds validated object keys and a media layout abstraction matching the current tree.
- Implements the local adapter with atomic writes, range-capable reads, normalized errors, and a zero-copy local-path optimization.
- Separates durable media storage from non-authoritative local scratch workspace.
- Persists a store ID and source object key per file, with existing rows backfilled to the local store.
- Publishes imported source files into the selected store and removes the upload-stage copy.
- Materializes source objects for FFmpeg and publishes completed video, audio, and subtitle trees back to storage.
- Materializes selected rendition trees for progressive and prepared download assembly.
- Routes media, embedded subtitles, thumbnails, cleanup, and deletion through the file-specific named store.
- Includes migration, named-store routing, transfer failure, materialization cleanup, lifecycle, range, and deletion tests.

## Upgrading an existing installation

The application migration is automatic on startup:

- GORM adds the new file storage columns.
- Existing file rows, including soft-deleted records, are assigned to the local store.
- Existing source paths remain valid through the legacy fallback.
- Existing encoded media stays in the current FolderVideoQualitysPriv tree.
- No media objects are moved, renamed, or copied during upgrade.
- Existing public media URLs remain unchanged.

No manual database command or media migration is required. As with any upgrade, backing up the database and videos directory first is recommended.

StorageScratchDir defaults to ./videos/scratch and is created automatically. Operators only need to ensure that this location is writable and has enough temporary capacity for FFmpeg output. Docker installations keep the default under the existing /app/videos volume and may override StorageScratchDir if desired.

## Deliberately not included yet

This PR still configures only the local adapter. The next driver phase will add S3-compatible configuration and implementation, including endpoint/region credentials, metadata mapping, paginated prefix walking, efficient range-backed seeking, and multipart-aware uploads. Prepared download artifacts and tus upload staging remain explicitly local lifecycle data; finalized media is published through the storage boundary.

## Compatibility

- The current local media directory and public URLs remain unchanged.
- Existing file rows are assigned to the local store during migration.
- Empty store IDs in older tokens and test fixtures resolve to the current default.
- No existing media files are moved by this PR.

## Validation

- go test ./...
- go test -race ./...
- go vet ./...
- docker build --target binary .
- git diff --check