### PR TITLE
Promote encoder reliability fixes to staging

### DIFF
--- a/controllers/UpdateSettingsController.go
+++ b/controllers/UpdateSettingsController.go
@@ -27,6 +27,8 @@ func (h *Handlers) UpdateSettings(c echo.Context) error {
 	remoteDownloadsNowDisabled := !settingFlagEnabled(validation.RemoteDownloadEnabled, true)
 	downloadsWereEnabled := settingFlagEnabled(previousSetting.DownloadEnabled, true)
 	downloadsNowDisabled := !settingFlagEnabled(validation.DownloadEnabled, true)
+	encoderConfigChanged := settingFlagEnabled(previousSetting.EncodingEnabled, true) != settingFlagEnabled(validation.EncodingEnabled, true) ||
+		strings.TrimSpace(previousSetting.MaxRunningEncodes) != strings.TrimSpace(validation.MaxRunningEncodes)
 
 	var setting models.Setting
 	setting.ID = validation.ID
@@ -118,6 +120,9 @@ func (h *Handlers) UpdateSettings(c echo.Context) error {
 		return c.NoContent(http.StatusInternalServerError)
 	}
 	h.Deps.Snapshots.Replace(snapshot)
+	if h.Workers != nil && encoderConfigChanged {
+		h.Workers.NotifyEncoderConfigChanged()
+	}
 	if h.Workers != nil && remoteDownloadsWereEnabled && remoteDownloadsNowDisabled {
 		h.Workers.CancelAllRemoteDownloads("Remote downloads disabled by administrator")
 	}

--- a/services/Deleter.go
+++ b/services/Deleter.go
@@ -91,12 +91,8 @@ func (w *WorkerGroup) runDeleter() {
 		}
 
 		if encoding {
-			// kill ffmpeg process if active
-			for _, v := range w.activeEncodingsForFile(todo.ID) {
-				if v.FileID == todo.ID && v.Channel != nil {
-					*v.Channel <- true
-				}
-			}
+			// Cancel any active source transfer, encode, or output publication.
+			w.cancelActiveEncodingsForFile(todo.ID, "file queued for deletion")
 
 			// we will try again in the next loop (the encoding process may be finished until then)
 			skippingDeletion++

--- a/services/Encoder.go
+++ b/services/Encoder.go
@@ -5,8 +5,9 @@ import (
 	"ch/kirari04/videocms/models"
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
-	"log"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -30,9 +31,12 @@ type ActiveEncoding struct {
 }
 
 type EncodingTask struct {
-	Type   string
-	FileID uint
-	ID     uint // qualityID | audioID | subID
+	Type      string
+	FileID    uint
+	FileUUID  string
+	StorageID string
+	ID        uint // qualityID | audioID | subID
+	Name      string
 }
 
 type IwithProcess interface {
@@ -47,8 +51,9 @@ func (w *WorkerGroup) Encoder(ctx context.Context) {
 	}
 
 	cfg := w.Config()
-	log.Printf(
-		"Encoder scheduler started (enabled=%t, max concurrent encodes=%d)",
+	w.encoderLogf(
+		"scheduler_started",
+		"enabled=%t max_concurrent=%d",
 		encodingEnabled(cfg),
 		maxRunningEncodes(cfg),
 	)
@@ -79,8 +84,9 @@ func (w *WorkerGroup) Encoder(ctx context.Context) {
 // encoder only prevents new work from being claimed.
 func (w *WorkerGroup) NotifyEncoderConfigChanged() {
 	cfg := w.Config()
-	log.Printf(
-		"Encoder configuration updated (enabled=%t, max concurrent encodes=%d)",
+	w.encoderLogf(
+		"configuration_updated",
+		"enabled=%t max_concurrent=%d",
 		encodingEnabled(cfg),
 		maxRunningEncodes(cfg),
 	)
@@ -152,7 +158,7 @@ func (w *WorkerGroup) ResetEncodingState() {
 		}, "Encoding").
 		Or("progress > ?", 0).
 		Updates(map[string]interface{}{"encoding": false, "progress": 0}); res.Error != nil {
-		log.Println("Failed to reset encoding status on Quality", res.Error)
+		w.encoderLogf("state_reset_failed", "task_type=quality error=%q", res.Error)
 	}
 
 	if res := w.deps.DB.
@@ -162,7 +168,7 @@ func (w *WorkerGroup) ResetEncodingState() {
 		}, "Encoding").
 		Or("progress > ?", 0).
 		Updates(map[string]interface{}{"encoding": false, "progress": 0}); res.Error != nil {
-		log.Println("Failed to reset encoding status on Audio", res.Error)
+		w.encoderLogf("state_reset_failed", "task_type=audio error=%q", res.Error)
 	}
 
 	if res := w.deps.DB.
@@ -172,7 +178,7 @@ func (w *WorkerGroup) ResetEncodingState() {
 		}, "Encoding").
 		Or("progress > ?", 0).
 		Updates(map[string]interface{}{"encoding": false, "progress": 0}); res.Error != nil {
-		log.Println("Failed to reset encoding status on Subtitle", res.Error)
+		w.encoderLogf("state_reset_failed", "task_type=subtitle error=%q", res.Error)
 	}
 }
 
@@ -202,12 +208,12 @@ func (w *WorkerGroup) loadEncodingTasks(ctx context.Context) {
 		Limit(available).
 		Find(&encodingSubs)
 	if result.Error != nil {
-		log.Printf("Failed to load subtitles to encode: %v", result.Error)
+		w.encoderLogf("queue_load_failed", "task_type=subtitle error=%q", result.Error)
 		return
 	}
 
 	if len(encodingSubs) > 0 {
-		log.Printf("Loaded %v subs to encode", len(encodingSubs))
+		w.encoderLogf("queue_loaded", "task_type=subtitle count=%d", len(encodingSubs))
 	}
 
 	for i := range encodingSubs {
@@ -215,17 +221,21 @@ func (w *WorkerGroup) loadEncodingTasks(ctx context.Context) {
 		if !w.tryReserveEncodingSlot() {
 			return
 		}
+		task := EncodingTask{
+			Type:      "subtitle",
+			FileID:    v.FileID,
+			FileUUID:  v.File.UUID,
+			StorageID: v.File.StorageID,
+			ID:        v.ID,
+			Name:      v.Name,
+		}
 		v.Encoding = true
 		if result := v.Save(w.deps.DB); result.Error != nil {
 			w.releaseEncodingSlot()
-			log.Printf("Failed to claim subtitle %d for encoding: %v", v.ID, result.Error)
+			w.encodingTaskLog("task_claim_failed", task, time.Time{}, result.Error)
 			continue
 		}
-		w.startEncodingTask(ctx, EncodingTask{
-			Type:   "sub",
-			FileID: v.FileID,
-			ID:     v.ID,
-		})
+		w.startEncodingTask(ctx, task)
 		available--
 	}
 
@@ -246,13 +256,13 @@ func (w *WorkerGroup) loadEncodingTasks(ctx context.Context) {
 			Limit(available).
 			Find(&encodingAudios)
 		if result.Error != nil {
-			log.Printf("Failed to load audios to encode: %v", result.Error)
+			w.encoderLogf("queue_load_failed", "task_type=audio error=%q", result.Error)
 			return
 		}
 	}
 
 	if len(encodingAudios) > 0 {
-		log.Printf("Loaded %v audios to encode", len(encodingAudios))
+		w.encoderLogf("queue_loaded", "task_type=audio count=%d", len(encodingAudios))
 	}
 
 	for i := range encodingAudios {
@@ -260,17 +270,21 @@ func (w *WorkerGroup) loadEncodingTasks(ctx context.Context) {
 		if !w.tryReserveEncodingSlot() {
 			return
 		}
+		task := EncodingTask{
+			Type:      "audio",
+			FileID:    v.FileID,
+			FileUUID:  v.File.UUID,
+			StorageID: v.File.StorageID,
+			ID:        v.ID,
+			Name:      v.Name,
+		}
 		v.Encoding = true
 		if result := v.Save(w.deps.DB); result.Error != nil {
 			w.releaseEncodingSlot()
-			log.Printf("Failed to claim audio %d for encoding: %v", v.ID, result.Error)
+			w.encodingTaskLog("task_claim_failed", task, time.Time{}, result.Error)
 			continue
 		}
-		w.startEncodingTask(ctx, EncodingTask{
-			Type:   "audio",
-			FileID: v.FileID,
-			ID:     v.ID,
-		})
+		w.startEncodingTask(ctx, task)
 		available--
 	}
 
@@ -291,13 +305,13 @@ func (w *WorkerGroup) loadEncodingTasks(ctx context.Context) {
 			Limit(available).
 			Find(&encodingQualitys)
 		if result.Error != nil {
-			log.Printf("Failed to load qualities to encode: %v", result.Error)
+			w.encoderLogf("queue_load_failed", "task_type=quality error=%q", result.Error)
 			return
 		}
 	}
 
 	if len(encodingQualitys) > 0 {
-		log.Printf("Loaded %v qualitys to encode", len(encodingQualitys))
+		w.encoderLogf("queue_loaded", "task_type=quality count=%d", len(encodingQualitys))
 	}
 
 	for i := range encodingQualitys {
@@ -305,17 +319,21 @@ func (w *WorkerGroup) loadEncodingTasks(ctx context.Context) {
 		if !w.tryReserveEncodingSlot() {
 			return
 		}
+		task := EncodingTask{
+			Type:      "quality",
+			FileID:    v.FileID,
+			FileUUID:  v.File.UUID,
+			StorageID: v.File.StorageID,
+			ID:        v.ID,
+			Name:      v.Name,
+		}
 		v.Encoding = true
 		if result := v.Save(w.deps.DB); result.Error != nil {
 			w.releaseEncodingSlot()
-			log.Printf("Failed to claim quality %d for encoding: %v", v.ID, result.Error)
+			w.encodingTaskLog("task_claim_failed", task, time.Time{}, result.Error)
 			continue
 		}
-		w.startEncodingTask(ctx, EncodingTask{
-			Type:   "quality",
-			FileID: v.FileID,
-			ID:     v.ID,
-		})
+		w.startEncodingTask(ctx, task)
 		available--
 	}
 }
@@ -323,65 +341,69 @@ func (w *WorkerGroup) loadEncodingTasks(ctx context.Context) {
 func (w *WorkerGroup) startEncodingTask(ctx context.Context, task EncodingTask) {
 	go func() {
 		defer w.releaseEncodingSlot()
+		started := time.Now()
+		w.encodingTaskLog("task_started", task, time.Time{}, nil)
+
+		var err error
 		if w.encodingTaskRunner != nil {
-			w.encodingTaskRunner(ctx, task)
+			err = w.encodingTaskRunner(ctx, task)
+		} else {
+			err = w.runEncode(ctx, task)
+		}
+		if err != nil {
+			w.encodingTaskLog("task_failed", task, started, err)
 			return
 		}
-		w.runEncode(ctx, task)
+		w.encodingTaskLog("task_completed", task, started, nil)
 	}()
 }
 
-func (w *WorkerGroup) runEncode(ctx context.Context, encodingTaskInformation EncodingTask) {
+func (w *WorkerGroup) runEncode(ctx context.Context, encodingTaskInformation EncodingTask) error {
 	switch encodingTaskInformation.Type {
 	case "quality":
 		var encodingTask models.Quality
-		w.deps.DB.Preload("File").Find(&encodingTask, encodingTaskInformation.ID)
-		w.runEncodeQuality(ctx, encodingTask)
+		if result := w.deps.DB.Preload("File").First(&encodingTask, encodingTaskInformation.ID); result.Error != nil {
+			return fmt.Errorf("load quality task: %w", result.Error)
+		}
+		return w.runEncodeQuality(ctx, encodingTask, encodingTaskInformation)
 	case "audio":
 		var encodingTask models.Audio
-		w.deps.DB.Preload("File").Find(&encodingTask, encodingTaskInformation.ID)
-		w.runEncodeAudio(ctx, encodingTask)
-	case "sub":
+		if result := w.deps.DB.Preload("File").First(&encodingTask, encodingTaskInformation.ID); result.Error != nil {
+			return fmt.Errorf("load audio task: %w", result.Error)
+		}
+		return w.runEncodeAudio(ctx, encodingTask, encodingTaskInformation)
+	case "subtitle":
 		var encodingTask models.Subtitle
-		w.deps.DB.Preload("File").Find(&encodingTask, encodingTaskInformation.ID)
-		w.runEncodeSub(ctx, encodingTask)
+		if result := w.deps.DB.Preload("File").First(&encodingTask, encodingTaskInformation.ID); result.Error != nil {
+			return fmt.Errorf("load subtitle task: %w", result.Error)
+		}
+		return w.runEncodeSub(ctx, encodingTask, encodingTaskInformation)
+	default:
+		return fmt.Errorf("unsupported encoding task type %q", encodingTaskInformation.Type)
 	}
 }
 
-func (w *WorkerGroup) runEncodeQuality(ctx context.Context, encodingTask models.Quality) {
+func (w *WorkerGroup) runEncodeQuality(ctx context.Context, encodingTask models.Quality, task EncodingTask) error {
 	// we check if the original file has been deleted during the waittime
-	if !w.originalFileExists(encodingTask.FileID) {
-		encodingTask.Ready = false
-		encodingTask.Encoding = false
-		encodingTask.Failed = true
-		encodingTask.Error = "Skipped because waiting for deletion"
-		w.deps.DB.Save(&encodingTask)
-		return
+	exists, err := w.originalFileExists(encodingTask.FileID)
+	if err != nil {
+		return w.failEncodingTask(&encodingTask, fmt.Errorf("check source file: %w", err))
 	}
-
-	// log.Printf("Start encoding %s %s\n", encodingTask.File.UUID, encodingTask.Name)
+	if !exists {
+		return w.failEncodingTask(&encodingTask, fmt.Errorf("source file was deleted before encoding started"))
+	}
 
 	totalDuration := encodingTask.File.Duration
 	absFileInput, cleanupInput, err := w.materializeEncodingSource(ctx, encodingTask.File)
 	if err != nil {
-		encodingTask.Ready = false
-		encodingTask.Encoding = false
-		encodingTask.Failed = true
-		encodingTask.Error = fmt.Sprintf("Failed to prepare source: %v", err)
-		w.deps.DB.Save(&encodingTask)
-		return
+		return w.failEncodingTask(&encodingTask, fmt.Errorf("prepare source: %w", err))
 	}
-	defer cleanupInput()
+	defer w.cleanupEncodingResource(task, "source", cleanupInput)
 	absFolderOutput, cleanupOutput, err := w.encodingOutputDirectory(ctx, "encode-quality", encodingTask.Path)
 	if err != nil {
-		encodingTask.Ready = false
-		encodingTask.Encoding = false
-		encodingTask.Failed = true
-		encodingTask.Error = fmt.Sprintf("Failed to prepare output: %v", err)
-		w.deps.DB.Save(&encodingTask)
-		return
+		return w.failEncodingTask(&encodingTask, fmt.Errorf("prepare output workspace: %w", err))
 	}
-	defer cleanupOutput()
+	defer w.cleanupEncodingResource(task, "output workspace", cleanupOutput)
 
 	var frameRateString string
 	var segmenDuration int = 4
@@ -391,7 +413,7 @@ func (w *WorkerGroup) runEncodeQuality(ctx context.Context, encodingTask models.
 
 	encFilePath := fmt.Sprintf("%s/%s", absFolderOutput, encodingTask.OutputFile)
 
-	var ffmpegCommand string = "echo Encoding type didnt match && exit 1"
+	var ffmpegCommand string
 	switch encodingTask.Type {
 	case "hls":
 
@@ -423,13 +445,22 @@ func (w *WorkerGroup) runEncodeQuality(ctx context.Context, encodingTask models.
 				totalDuration,
 				fmt.Sprintf("%x", sha256.Sum256([]byte(uuid.NewString()))),
 				&encodingTask,
+				task,
 			)) // progress tracking
+	default:
+		return w.failEncodingTask(
+			&encodingTask,
+			fmt.Errorf("unsupported quality encoding type %q", encodingTask.Type),
+		)
 	}
 
 	cmd := exec.CommandContext(ctx,
 		"bash",
 		"-c",
 		ffmpegCommand)
+	diagnostics := newEncodingDiagnosticTail(8192)
+	cmd.Stdout = diagnostics
+	cmd.Stderr = diagnostics
 
 	activeEncodingChannel := make(chan bool)
 	defer w.deleteActiveEncoding(encodingTask.FileID, encodingTask.ID, "quality")
@@ -449,19 +480,13 @@ func (w *WorkerGroup) runEncodeQuality(ctx context.Context, encodingTask models.
 			if cmd.Process != nil {
 				_ = cmd.Process.Kill()
 			}
-			log.Printf("killed encode (quality) of FileID %d QualityID %d\n", encodingTask.FileID, encodingTask.ID)
+			w.encodingTaskLog("task_kill_requested", task, time.Time{}, nil)
 		}
 	}()
 
 	start := time.Now()
 	if err := cmd.Run(); err != nil {
-		encodingTask.Ready = false
-		encodingTask.Encoding = false
-		encodingTask.Failed = true
-		w.deps.DB.Save(&encodingTask)
-		log.Printf("Error happend while encoding quality: %v", err.Error())
-		log.Println(ffmpegCommand)
-		return
+		return w.failEncodingTask(&encodingTask, ffmpegEncodingError(ctx, err, diagnostics))
 	}
 	if w.deps.Storage != nil && w.deps.Storage.Layout() != nil {
 		prefix, err := w.deps.Storage.Layout().VideoPrefix(encodingTask.File.UUID, encodingTask.Name)
@@ -469,12 +494,7 @@ func (w *WorkerGroup) runEncodeQuality(ctx context.Context, encodingTask models.
 			err = w.publishEncodingOutput(ctx, encodingTask.File, prefix, absFolderOutput)
 		}
 		if err != nil {
-			encodingTask.Ready = false
-			encodingTask.Encoding = false
-			encodingTask.Failed = true
-			encodingTask.Error = fmt.Sprintf("Failed to publish output: %v", err)
-			w.deps.DB.Save(&encodingTask)
-			return
+			return w.failEncodingTask(&encodingTask, fmt.Errorf("publish output: %w", err))
 		}
 	}
 	duration := time.Since(start).Seconds()
@@ -482,52 +502,36 @@ func (w *WorkerGroup) runEncodeQuality(ctx context.Context, encodingTask models.
 
 	qualitySize, err := dirSize(absFolderOutput)
 	if err != nil {
-		log.Printf("Failed to calc folder size after quality encode: %v", err)
+		w.encodingTaskLog("output_size_failed", task, time.Time{}, err)
 	}
 
 	encodingTask.Size = qualitySize
-	encodingTask.Encoding = false
-	encodingTask.Ready = true
-	encodingTask.Error = ""
-	w.deps.DB.Save(&encodingTask)
+	return w.completeEncodingTask(&encodingTask)
 }
 
-func (w *WorkerGroup) runEncodeAudio(ctx context.Context, encodingTask models.Audio) {
+func (w *WorkerGroup) runEncodeAudio(ctx context.Context, encodingTask models.Audio, task EncodingTask) error {
 	// we check if the original file has been deleted during the waittime
-	if !w.originalFileExists(encodingTask.FileID) {
-		encodingTask.Ready = false
-		encodingTask.Encoding = false
-		encodingTask.Failed = true
-		encodingTask.Error = "Skipped because waiting for deletion"
-		w.deps.DB.Save(&encodingTask)
-		return
+	exists, err := w.originalFileExists(encodingTask.FileID)
+	if err != nil {
+		return w.failEncodingTask(&encodingTask, fmt.Errorf("check source file: %w", err))
 	}
-
-	// log.Printf("Start encoding %s %s\n", encodingTask.File.UUID, encodingTask.Name)
+	if !exists {
+		return w.failEncodingTask(&encodingTask, fmt.Errorf("source file was deleted before encoding started"))
+	}
 
 	totalDuration := encodingTask.File.Duration
 	absFileInput, cleanupInput, err := w.materializeEncodingSource(ctx, encodingTask.File)
 	if err != nil {
-		encodingTask.Ready = false
-		encodingTask.Encoding = false
-		encodingTask.Failed = true
-		encodingTask.Error = fmt.Sprintf("Failed to prepare source: %v", err)
-		w.deps.DB.Save(&encodingTask)
-		return
+		return w.failEncodingTask(&encodingTask, fmt.Errorf("prepare source: %w", err))
 	}
-	defer cleanupInput()
+	defer w.cleanupEncodingResource(task, "source", cleanupInput)
 	absFolderOutput, cleanupOutput, err := w.encodingOutputDirectory(ctx, "encode-audio", encodingTask.Path)
 	if err != nil {
-		encodingTask.Ready = false
-		encodingTask.Encoding = false
-		encodingTask.Failed = true
-		encodingTask.Error = fmt.Sprintf("Failed to prepare output: %v", err)
-		w.deps.DB.Save(&encodingTask)
-		return
+		return w.failEncodingTask(&encodingTask, fmt.Errorf("prepare output workspace: %w", err))
 	}
-	defer cleanupOutput()
+	defer w.cleanupEncodingResource(task, "output workspace", cleanupOutput)
 
-	var ffmpegCommand string = "echo Audioencoding type didnt match && exit 1"
+	var ffmpegCommand string
 	switch encodingTask.Type {
 	case "hls":
 
@@ -551,13 +555,22 @@ func (w *WorkerGroup) runEncodeAudio(ctx context.Context, encodingTask models.Au
 				totalDuration,
 				fmt.Sprintf("%x", sha256.Sum256([]byte(uuid.NewString()))),
 				&encodingTask,
+				task,
 			)) // progress tracking
+	default:
+		return w.failEncodingTask(
+			&encodingTask,
+			fmt.Errorf("unsupported audio encoding type %q", encodingTask.Type),
+		)
 	}
 
 	cmd := exec.CommandContext(ctx,
 		"bash",
 		"-c",
 		ffmpegCommand)
+	diagnostics := newEncodingDiagnosticTail(8192)
+	cmd.Stdout = diagnostics
+	cmd.Stderr = diagnostics
 
 	activeEncodingChannel := make(chan bool)
 	defer w.deleteActiveEncoding(encodingTask.FileID, encodingTask.ID, "audio")
@@ -577,19 +590,13 @@ func (w *WorkerGroup) runEncodeAudio(ctx context.Context, encodingTask models.Au
 			if cmd.Process != nil {
 				_ = cmd.Process.Kill()
 			}
-			log.Printf("killed encode (quality) of FileID %d AudioID %d\n", encodingTask.FileID, encodingTask.ID)
+			w.encodingTaskLog("task_kill_requested", task, time.Time{}, nil)
 		}
 	}()
 
 	start := time.Now()
 	if err := cmd.Run(); err != nil {
-		encodingTask.Ready = false
-		encodingTask.Encoding = false
-		encodingTask.Failed = true
-		w.deps.DB.Save(&encodingTask)
-		log.Printf("Error happend while encoding audio: %v", err.Error())
-		log.Println(ffmpegCommand)
-		return
+		return w.failEncodingTask(&encodingTask, ffmpegEncodingError(ctx, err, diagnostics))
 	}
 	if w.deps.Storage != nil && w.deps.Storage.Layout() != nil {
 		prefix, err := w.deps.Storage.Layout().AudioPrefix(encodingTask.File.UUID, encodingTask.UUID)
@@ -597,81 +604,56 @@ func (w *WorkerGroup) runEncodeAudio(ctx context.Context, encodingTask models.Au
 			err = w.publishEncodingOutput(ctx, encodingTask.File, prefix, absFolderOutput)
 		}
 		if err != nil {
-			encodingTask.Ready = false
-			encodingTask.Encoding = false
-			encodingTask.Failed = true
-			encodingTask.Error = fmt.Sprintf("Failed to publish output: %v", err)
-			w.deps.DB.Save(&encodingTask)
-			return
+			return w.failEncodingTask(&encodingTask, fmt.Errorf("publish output: %w", err))
 		}
 	}
 	duration := time.Since(start).Seconds()
 	w.logic.TrackEncoding(encodingTask.File.UserID, encodingTask.FileID, "audio", duration)
 
-	encodingTask.Encoding = false
-	encodingTask.Ready = true
-	encodingTask.Error = ""
-	w.deps.DB.Save(&encodingTask)
+	return w.completeEncodingTask(&encodingTask)
 }
 
-func (w *WorkerGroup) runEncodeSub(ctx context.Context, encodingTask models.Subtitle) {
+func (w *WorkerGroup) runEncodeSub(ctx context.Context, encodingTask models.Subtitle, task EncodingTask) error {
 	// we check if the original file has been deleted during the waittime
-	if !w.originalFileExists(encodingTask.FileID) {
-		encodingTask.Ready = false
-		encodingTask.Encoding = false
-		encodingTask.Failed = true
-		encodingTask.Error = "Skipped because waiting for deletion"
-		w.deps.DB.Save(&encodingTask)
-		return
+	exists, err := w.originalFileExists(encodingTask.FileID)
+	if err != nil {
+		return w.failEncodingTask(&encodingTask, fmt.Errorf("check source file: %w", err))
 	}
-
-	// log.Printf("Start encoding %s %s\n", encodingTask.File.UUID, encodingTask.Name)
+	if !exists {
+		return w.failEncodingTask(&encodingTask, fmt.Errorf("source file was deleted before encoding started"))
+	}
 
 	totalDuration := encodingTask.File.Duration
 	absFileInput, cleanupInput, err := w.materializeEncodingSource(ctx, encodingTask.File)
 	if err != nil {
-		encodingTask.Ready = false
-		encodingTask.Encoding = false
-		encodingTask.Failed = true
-		encodingTask.Error = fmt.Sprintf("Failed to prepare source: %v", err)
-		w.deps.DB.Save(&encodingTask)
-		return
+		return w.failEncodingTask(&encodingTask, fmt.Errorf("prepare source: %w", err))
 	}
-	defer cleanupInput()
+	defer w.cleanupEncodingResource(task, "source", cleanupInput)
 	absFolderOutput, cleanupOutput, err := w.encodingOutputDirectory(ctx, "encode-subtitle", encodingTask.Path)
 	if err != nil {
-		encodingTask.Ready = false
-		encodingTask.Encoding = false
-		encodingTask.Failed = true
-		encodingTask.Error = fmt.Sprintf("Failed to prepare output: %v", err)
-		w.deps.DB.Save(&encodingTask)
-		return
+		return w.failEncodingTask(&encodingTask, fmt.Errorf("prepare output workspace: %w", err))
 	}
-	defer cleanupOutput()
+	defer w.cleanupEncodingResource(task, "output workspace", cleanupOutput)
 
-	var ffmpegCommand string = "echo Subencoding type didnt match && exit 1"
+	var ffmpegCommand string
 
 	if encodingTask.OriginalCodec == "hdmv_pgs_subtitle" {
 		cfg := w.Config()
 		if cfg.EnablePluginPgsServer == nil || *cfg.EnablePluginPgsServer == false {
-			log.Printf("PluginPgsServer disabled")
-			encodingTask.Ready = false
-			encodingTask.Encoding = false
-			encodingTask.Failed = true
-			w.deps.DB.Save(&encodingTask)
-			return
+			return w.failEncodingTask(
+				&encodingTask,
+				fmt.Errorf("PGS subtitle preprocessing is disabled"),
+			)
 		}
 
 		// prepocess pgs
 		if err := w.prepocessPgs(ctx, encodingTask, absFolderOutput, &absFileInput); err != nil {
-			log.Printf("[Preprocess Error] %v", err)
-			encodingTask.Ready = false
-			encodingTask.Encoding = false
-			encodingTask.Failed = true
-			w.deps.DB.Save(&encodingTask)
-			return
+			return w.failEncodingTask(&encodingTask, fmt.Errorf("preprocess PGS subtitle: %w", err))
 		}
-		defer os.Remove(absFileInput) // delete srt file after encode
+		preprocessedInput := absFileInput
+		defer w.cleanupEncodingResource(task, "preprocessed subtitle", func() error {
+			return os.Remove(preprocessedInput)
+		})
 
 		switch encodingTask.Type {
 		case "ass":
@@ -683,6 +665,7 @@ func (w *WorkerGroup) runEncodeSub(ctx context.Context, encodingTask models.Subt
 					totalDuration,
 					fmt.Sprintf("%x", sha256.Sum256([]byte(uuid.NewString()))),
 					&encodingTask,
+					task,
 				)) // progress tracking
 		case "vtt":
 			ffmpegCommand = "ffmpeg " +
@@ -693,7 +676,13 @@ func (w *WorkerGroup) runEncodeSub(ctx context.Context, encodingTask models.Subt
 					totalDuration,
 					fmt.Sprintf("%x", sha256.Sum256([]byte(uuid.NewString()))),
 					&encodingTask,
+					task,
 				)) // progress tracking
+		default:
+			return w.failEncodingTask(
+				&encodingTask,
+				fmt.Errorf("unsupported subtitle encoding type %q", encodingTask.Type),
+			)
 		}
 	} else {
 		// normal subtitles
@@ -710,6 +699,7 @@ func (w *WorkerGroup) runEncodeSub(ctx context.Context, encodingTask models.Subt
 					totalDuration,
 					fmt.Sprintf("%x", sha256.Sum256([]byte(uuid.NewString()))),
 					&encodingTask,
+					task,
 				)) // progress tracking
 		case "vtt":
 			ffmpegCommand = "ffmpeg " +
@@ -723,7 +713,13 @@ func (w *WorkerGroup) runEncodeSub(ctx context.Context, encodingTask models.Subt
 					totalDuration,
 					fmt.Sprintf("%x", sha256.Sum256([]byte(uuid.NewString()))),
 					&encodingTask,
+					task,
 				)) // progress tracking
+		default:
+			return w.failEncodingTask(
+				&encodingTask,
+				fmt.Errorf("unsupported subtitle encoding type %q", encodingTask.Type),
+			)
 		}
 	}
 
@@ -731,6 +727,9 @@ func (w *WorkerGroup) runEncodeSub(ctx context.Context, encodingTask models.Subt
 		"bash",
 		"-c",
 		ffmpegCommand)
+	diagnostics := newEncodingDiagnosticTail(8192)
+	cmd.Stdout = diagnostics
+	cmd.Stderr = diagnostics
 	activeEncodingChannel := make(chan bool)
 	defer w.deleteActiveEncoding(encodingTask.FileID, encodingTask.ID, "sub")
 
@@ -749,19 +748,13 @@ func (w *WorkerGroup) runEncodeSub(ctx context.Context, encodingTask models.Subt
 			if cmd.Process != nil {
 				_ = cmd.Process.Kill()
 			}
-			log.Printf("killed encode (quality) of FileID %d SubID %d\n", encodingTask.FileID, encodingTask.ID)
+			w.encodingTaskLog("task_kill_requested", task, time.Time{}, nil)
 		}
 	}()
 
 	start := time.Now()
 	if err := cmd.Run(); err != nil {
-		encodingTask.Ready = false
-		encodingTask.Encoding = false
-		encodingTask.Failed = true
-		w.deps.DB.Save(&encodingTask)
-		log.Printf("Error happend while encoding subtitle: %v", err.Error())
-		log.Println(ffmpegCommand)
-		return
+		return w.failEncodingTask(&encodingTask, ffmpegEncodingError(ctx, err, diagnostics))
 	}
 	if w.deps.Storage != nil && w.deps.Storage.Layout() != nil {
 		prefix, err := w.deps.Storage.Layout().SubtitlePrefix(encodingTask.File.UUID, encodingTask.UUID)
@@ -769,29 +762,23 @@ func (w *WorkerGroup) runEncodeSub(ctx context.Context, encodingTask models.Subt
 			err = w.publishEncodingOutput(ctx, encodingTask.File, prefix, absFolderOutput)
 		}
 		if err != nil {
-			encodingTask.Ready = false
-			encodingTask.Encoding = false
-			encodingTask.Failed = true
-			encodingTask.Error = fmt.Sprintf("Failed to publish output: %v", err)
-			w.deps.DB.Save(&encodingTask)
-			return
+			return w.failEncodingTask(&encodingTask, fmt.Errorf("publish output: %w", err))
 		}
 	}
 	duration := time.Since(start).Seconds()
 	w.logic.TrackEncoding(encodingTask.File.UserID, encodingTask.FileID, "sub", duration)
 
-	encodingTask.Encoding = false
-	encodingTask.Ready = true
-	encodingTask.Error = ""
-	w.deps.DB.Save(&encodingTask)
+	return w.completeEncodingTask(&encodingTask)
 }
 
-func (w *WorkerGroup) tempSock(totalDuration float64, sockFileName string, encodingTask IwithProcess) string {
+func (w *WorkerGroup) tempSock(totalDuration float64, sockFileName string, encodingTask IwithProcess, task EncodingTask) string {
 	sockFilePath := path.Join(os.TempDir(), sockFileName)
-	_ = os.Remove(sockFilePath)
+	if err := os.Remove(sockFilePath); err != nil && !errors.Is(err, os.ErrNotExist) {
+		w.encodingTaskLog("progress_socket_cleanup_failed", task, time.Time{}, err)
+	}
 	l, err := net.Listen("unix", sockFilePath)
 	if err != nil {
-		log.Printf("failed to create encoder progress socket %s: %v", sockFilePath, err)
+		w.encodingTaskLog("progress_socket_listen_failed", task, time.Time{}, err)
 		return sockFilePath
 	}
 
@@ -800,7 +787,7 @@ func (w *WorkerGroup) tempSock(totalDuration float64, sockFileName string, encod
 		re := regexp.MustCompile(`out_time_ms=(\d+)`)
 		fd, err := l.Accept()
 		if err != nil {
-			log.Printf("encoder progress socket accept error: %v", err)
+			w.encodingTaskLog("progress_socket_accept_failed", task, time.Time{}, err)
 			return
 		}
 		defer fd.Close()
@@ -808,11 +795,17 @@ func (w *WorkerGroup) tempSock(totalDuration float64, sockFileName string, encod
 		data := ""
 		progress := ""
 		for {
-			_, err := fd.Read(buf)
+			n, err := fd.Read(buf)
 			if err != nil {
+				if !errors.Is(err, io.EOF) {
+					w.encodingTaskLog("progress_socket_read_failed", task, time.Time{}, err)
+				}
 				return
 			}
-			data += string(buf)
+			data += string(buf[:n])
+			if len(data) > 4096 {
+				data = data[len(data)-4096:]
+			}
 			a := re.FindAllStringSubmatch(data, -1)
 			cp := ""
 			if len(a) > 0 && len(a[len(a)-1]) > 0 {
@@ -830,12 +823,15 @@ func (w *WorkerGroup) tempSock(totalDuration float64, sockFileName string, encod
 				// fmt.Println("progress: ", progress)
 				floatProg, err := strconv.ParseFloat(progress, 64)
 				if err != nil {
-					fmt.Println("could not save progress in database")
+					w.encodingTaskLog("progress_parse_failed", task, time.Time{}, err)
+					continue
 				}
 				if floatProg != 0 {
 					encodingTask.SetProcess(floatProg)
 				}
-				encodingTask.Save(w.deps.DB)
+				if result := encodingTask.Save(w.deps.DB); result.Error != nil {
+					w.encodingTaskLog("progress_persist_failed", task, time.Time{}, result.Error)
+				}
 			}
 		}
 	}()
@@ -843,11 +839,14 @@ func (w *WorkerGroup) tempSock(totalDuration float64, sockFileName string, encod
 	return sockFilePath
 }
 
-func (w *WorkerGroup) originalFileExists(fileId uint) bool {
-	if res := w.deps.DB.First(&models.File{}, fileId); res.Error != nil {
-		return false
+func (w *WorkerGroup) originalFileExists(fileID uint) (bool, error) {
+	if res := w.deps.DB.First(&models.File{}, fileID); res.Error != nil {
+		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+			return false, nil
+		}
+		return false, res.Error
 	}
-	return true
+	return true, nil
 }
 
 func (w *WorkerGroup) addActiveEncoding(encoding ActiveEncoding) {
@@ -880,7 +879,13 @@ func (w *WorkerGroup) deleteActiveEncoding(fileID uint, ID uint, Type string) {
 		}
 	}
 	if foundIndex < 0 {
-		log.Printf("Failed to delete an deleteActiveEncoding with the fileID %v and ID %v", fileID, ID)
+		w.encoderLogf(
+			"active_task_unregister_failed",
+			"task_type=%s file_id=%d task_id=%d",
+			Type,
+			fileID,
+			ID,
+		)
 		return
 	}
 
@@ -907,15 +912,18 @@ func (w *WorkerGroup) prepocessPgs(ctx context.Context, encodingTask models.Subt
 		"bash",
 		"-c",
 		ffmpegCommand)
+	diagnostics := newEncodingDiagnosticTail(8192)
+	cmd.Stdout = diagnostics
+	cmd.Stderr = diagnostics
 	if err := cmd.Run(); err != nil {
-		log.Println(ffmpegCommand)
-		return fmt.Errorf("Error happend while encoding subtitle: %v", err.Error())
+		return ffmpegEncodingError(ctx, err, diagnostics)
 	}
 
 	pgsFile, err := os.Open(ffmpegOutputFilePath)
 	if err != nil {
-		return fmt.Errorf("Error happend while opening pgs subtitle: %v", err.Error())
+		return fmt.Errorf("open extracted PGS subtitle: %w", err)
 	}
+	defer pgsFile.Close()
 
 	requestCtx, cancel := context.WithTimeout(ctx, time.Minute*5)
 	defer cancel()
@@ -926,14 +934,13 @@ func (w *WorkerGroup) prepocessPgs(ctx context.Context, encodingTask models.Subt
 		SetFileReader("file", "subtitle.sup", pgsFile).
 		Post(w.Config().PluginPgsServer)
 	if err != nil {
-		return fmt.Errorf("Error happend while scanning pgs subtitle: %v", err.Error())
+		return fmt.Errorf("send PGS subtitle to preprocessing service: %w", err)
 	}
 	if !res.IsSuccessState() {
-		return fmt.Errorf("Error happend waiting for srt from pgs plugin: %v", err)
-
+		return fmt.Errorf("PGS preprocessing service returned HTTP %d", res.StatusCode)
 	}
 	if err := os.WriteFile(pgsOutputFilePath, res.Bytes(), 0644); err != nil {
-		return fmt.Errorf("Error happend while saving srt from pgs: %v", err.Error())
+		return fmt.Errorf("save preprocessed PGS subtitle: %w", err)
 	}
 	*absFileInput = pgsOutputFilePath
 	return nil

--- a/services/Encoder.go
+++ b/services/Encoder.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"ch/kirari04/videocms/config"
 	"ch/kirari04/videocms/models"
 	"context"
 	"crypto/sha256"
@@ -44,13 +45,103 @@ func (w *WorkerGroup) Encoder(ctx context.Context) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	w.limitChan = make(chan bool, w.Config().MaxRunningEncodes)
+
+	cfg := w.Config()
+	log.Printf(
+		"Encoder scheduler started (enabled=%t, max concurrent encodes=%d)",
+		encodingEnabled(cfg),
+		maxRunningEncodes(cfg),
+	)
+
 	for {
-		go w.loadEncodingTasks(ctx)
-		if !sleepContext(ctx, time.Second*10) {
+		if encodingEnabled(w.Config()) {
+			w.loadEncodingTasks(ctx)
+		}
+
+		interval := w.encoderPollInterval
+		if interval <= 0 {
+			interval = time.Second * 10
+		}
+		timer := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
 			return
+		case <-w.encoderConfigChanged:
+			timer.Stop()
+		case <-timer.C:
 		}
 	}
+}
+
+// NotifyEncoderConfigChanged applies EncodingEnabled and MaxRunningEncodes
+// changes immediately. In-flight encodes are allowed to finish; disabling the
+// encoder only prevents new work from being claimed.
+func (w *WorkerGroup) NotifyEncoderConfigChanged() {
+	cfg := w.Config()
+	log.Printf(
+		"Encoder configuration updated (enabled=%t, max concurrent encodes=%d)",
+		encodingEnabled(cfg),
+		maxRunningEncodes(cfg),
+	)
+	w.wakeEncoder()
+}
+
+func encodingEnabled(cfg config.Config) bool {
+	return cfg.EncodingEnabled != nil && *cfg.EncodingEnabled
+}
+
+func maxRunningEncodes(cfg config.Config) int {
+	if cfg.MaxRunningEncodes < 1 {
+		return 1
+	}
+	return int(cfg.MaxRunningEncodes)
+}
+
+func (w *WorkerGroup) wakeEncoder() {
+	if w.encoderConfigChanged == nil {
+		return
+	}
+	select {
+	case w.encoderConfigChanged <- struct{}{}:
+	default:
+	}
+}
+
+func (w *WorkerGroup) availableEncodingSlots() int {
+	w.encoderMu.Lock()
+	defer w.encoderMu.Unlock()
+
+	cfg := w.Config()
+	if !encodingEnabled(cfg) {
+		return 0
+	}
+	available := maxRunningEncodes(cfg) - w.activeEncodingJobs
+	if available < 0 {
+		return 0
+	}
+	return available
+}
+
+func (w *WorkerGroup) tryReserveEncodingSlot() bool {
+	w.encoderMu.Lock()
+	defer w.encoderMu.Unlock()
+
+	cfg := w.Config()
+	if !encodingEnabled(cfg) || w.activeEncodingJobs >= maxRunningEncodes(cfg) {
+		return false
+	}
+	w.activeEncodingJobs++
+	return true
+}
+
+func (w *WorkerGroup) releaseEncodingSlot() {
+	w.encoderMu.Lock()
+	if w.activeEncodingJobs > 0 {
+		w.activeEncodingJobs--
+	}
+	w.encoderMu.Unlock()
+	w.wakeEncoder()
 }
 
 func (w *WorkerGroup) ResetEncodingState() {
@@ -86,12 +177,18 @@ func (w *WorkerGroup) ResetEncodingState() {
 }
 
 func (w *WorkerGroup) loadEncodingTasks(ctx context.Context) {
-	var encodingTasks []EncodingTask
+	available := w.availableEncodingSlots()
+	if available == 0 {
+		return
+	}
+	if available > 10 {
+		available = 10
+	}
 
 	// we want to encode the subtitles first, then audio and in the end the qualities
 	// SUBTITLES
 	var encodingSubs []models.Subtitle
-	w.deps.DB.
+	result := w.deps.DB.
 		Model(&models.Subtitle{}).
 		Joins("JOIN files ON files.id = subtitles.file_id").
 		Preload("File").
@@ -101,28 +198,41 @@ func (w *WorkerGroup) loadEncodingTasks(ctx context.Context) {
 			Ready:    false,
 			Failed:   false,
 		}, "Encoding", "Ready", "Failed").
-		Order("id ASC").
-		Limit(10).
+		Order("subtitles.id ASC").
+		Limit(available).
 		Find(&encodingSubs)
+	if result.Error != nil {
+		log.Printf("Failed to load subtitles to encode: %v", result.Error)
+		return
+	}
 
 	if len(encodingSubs) > 0 {
 		log.Printf("Loaded %v subs to encode", len(encodingSubs))
 	}
 
-	for _, v := range encodingSubs {
+	for i := range encodingSubs {
+		v := &encodingSubs[i]
+		if !w.tryReserveEncodingSlot() {
+			return
+		}
 		v.Encoding = true
-		v.Save(w.deps.DB)
-		encodingTasks = append(encodingTasks, EncodingTask{
+		if result := v.Save(w.deps.DB); result.Error != nil {
+			w.releaseEncodingSlot()
+			log.Printf("Failed to claim subtitle %d for encoding: %v", v.ID, result.Error)
+			continue
+		}
+		w.startEncodingTask(ctx, EncodingTask{
 			Type:   "sub",
 			FileID: v.FileID,
 			ID:     v.ID,
 		})
+		available--
 	}
 
 	// AUDIOS
 	var encodingAudios []models.Audio
-	if len(encodingSubs) < 10 {
-		w.deps.DB.
+	if available > 0 {
+		result = w.deps.DB.
 			Model(&models.Audio{}).
 			Joins("JOIN files ON files.id = audios.file_id").
 			Preload("File").
@@ -132,29 +242,42 @@ func (w *WorkerGroup) loadEncodingTasks(ctx context.Context) {
 				Ready:    false,
 				Failed:   false,
 			}, "Encoding", "Ready", "Failed").
-			Order("id ASC").
-			Limit(10).
+			Order("audios.id ASC").
+			Limit(available).
 			Find(&encodingAudios)
+		if result.Error != nil {
+			log.Printf("Failed to load audios to encode: %v", result.Error)
+			return
+		}
 	}
 
 	if len(encodingAudios) > 0 {
 		log.Printf("Loaded %v audios to encode", len(encodingAudios))
 	}
 
-	for _, v := range encodingAudios {
+	for i := range encodingAudios {
+		v := &encodingAudios[i]
+		if !w.tryReserveEncodingSlot() {
+			return
+		}
 		v.Encoding = true
-		v.Save(w.deps.DB)
-		encodingTasks = append(encodingTasks, EncodingTask{
+		if result := v.Save(w.deps.DB); result.Error != nil {
+			w.releaseEncodingSlot()
+			log.Printf("Failed to claim audio %d for encoding: %v", v.ID, result.Error)
+			continue
+		}
+		w.startEncodingTask(ctx, EncodingTask{
 			Type:   "audio",
 			FileID: v.FileID,
 			ID:     v.ID,
 		})
+		available--
 	}
 
 	// QUALITYS
 	var encodingQualitys []models.Quality
-	if len(encodingSubs) < 10 && len(encodingAudios) < 10 {
-		w.deps.DB.
+	if available > 0 {
+		result = w.deps.DB.
 			Model(&models.Quality{}).
 			Joins("JOIN files ON files.id = qualities.file_id").
 			Preload("File").
@@ -164,39 +287,48 @@ func (w *WorkerGroup) loadEncodingTasks(ctx context.Context) {
 				Ready:    false,
 				Failed:   false,
 			}, "Encoding", "Ready", "Failed").
-			Order("id ASC").
-			Limit(10).
+			Order("qualities.id ASC").
+			Limit(available).
 			Find(&encodingQualitys)
+		if result.Error != nil {
+			log.Printf("Failed to load qualities to encode: %v", result.Error)
+			return
+		}
 	}
 
 	if len(encodingQualitys) > 0 {
 		log.Printf("Loaded %v qualitys to encode", len(encodingQualitys))
 	}
 
-	for _, v := range encodingQualitys {
+	for i := range encodingQualitys {
+		v := &encodingQualitys[i]
+		if !w.tryReserveEncodingSlot() {
+			return
+		}
 		v.Encoding = true
-		v.Save(w.deps.DB)
-		encodingTasks = append(encodingTasks, EncodingTask{
+		if result := v.Save(w.deps.DB); result.Error != nil {
+			w.releaseEncodingSlot()
+			log.Printf("Failed to claim quality %d for encoding: %v", v.ID, result.Error)
+			continue
+		}
+		w.startEncodingTask(ctx, EncodingTask{
 			Type:   "quality",
 			FileID: v.FileID,
 			ID:     v.ID,
 		})
+		available--
 	}
+}
 
-	// RUNNING ENCODING TASKS
-	for _, v := range encodingTasks {
-		select {
-		case <-ctx.Done():
+func (w *WorkerGroup) startEncodingTask(ctx context.Context, task EncodingTask) {
+	go func() {
+		defer w.releaseEncodingSlot()
+		if w.encodingTaskRunner != nil {
+			w.encodingTaskRunner(ctx, task)
 			return
-		case w.limitChan <- true:
 		}
-		go func(encodingTask EncodingTask) {
-			defer func() {
-				<-w.limitChan
-			}()
-			w.runEncode(ctx, encodingTask)
-		}(v)
-	}
+		w.runEncode(ctx, task)
+	}()
 }
 
 func (w *WorkerGroup) runEncode(ctx context.Context, encodingTaskInformation EncodingTask) {

--- a/services/Encoder.go
+++ b/services/Encoder.go
@@ -24,10 +24,8 @@ import (
 )
 
 type ActiveEncoding struct {
-	Type    string
-	FileID  uint
-	ID      uint       // qualityID | audioID | subID
-	Channel *chan bool // sending true will kill the encoding process
+	Task   EncodingTask
+	Cancel context.CancelFunc
 }
 
 type EncodingTask struct {
@@ -341,14 +339,19 @@ func (w *WorkerGroup) loadEncodingTasks(ctx context.Context) {
 func (w *WorkerGroup) startEncodingTask(ctx context.Context, task EncodingTask) {
 	go func() {
 		defer w.releaseEncodingSlot()
+		taskCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+		w.addActiveEncoding(ActiveEncoding{Task: task, Cancel: cancel})
+		defer w.deleteActiveEncoding(task)
+
 		started := time.Now()
 		w.encodingTaskLog("task_started", task, time.Time{}, nil)
 
 		var err error
 		if w.encodingTaskRunner != nil {
-			err = w.encodingTaskRunner(ctx, task)
+			err = w.encodingTaskRunner(taskCtx, task)
 		} else {
-			err = w.runEncode(ctx, task)
+			err = w.runEncode(taskCtx, task)
 		}
 		if err != nil {
 			w.encodingTaskLog("task_failed", task, started, err)
@@ -462,28 +465,6 @@ func (w *WorkerGroup) runEncodeQuality(ctx context.Context, encodingTask models.
 	cmd.Stdout = diagnostics
 	cmd.Stderr = diagnostics
 
-	activeEncodingChannel := make(chan bool)
-	defer w.deleteActiveEncoding(encodingTask.FileID, encodingTask.ID, "quality")
-
-	w.addActiveEncoding(ActiveEncoding{
-		Type:    "quality",
-		FileID:  encodingTask.FileID,
-		ID:      encodingTask.ID,
-		Channel: &activeEncodingChannel,
-	})
-	go func() {
-		for {
-			_, ok := <-activeEncodingChannel
-			if !ok {
-				break
-			}
-			if cmd.Process != nil {
-				_ = cmd.Process.Kill()
-			}
-			w.encodingTaskLog("task_kill_requested", task, time.Time{}, nil)
-		}
-	}()
-
 	start := time.Now()
 	if err := cmd.Run(); err != nil {
 		return w.failEncodingTask(&encodingTask, ffmpegEncodingError(ctx, err, diagnostics))
@@ -571,28 +552,6 @@ func (w *WorkerGroup) runEncodeAudio(ctx context.Context, encodingTask models.Au
 	diagnostics := newEncodingDiagnosticTail(8192)
 	cmd.Stdout = diagnostics
 	cmd.Stderr = diagnostics
-
-	activeEncodingChannel := make(chan bool)
-	defer w.deleteActiveEncoding(encodingTask.FileID, encodingTask.ID, "audio")
-
-	w.addActiveEncoding(ActiveEncoding{
-		Type:    "audio",
-		FileID:  encodingTask.FileID,
-		ID:      encodingTask.ID,
-		Channel: &activeEncodingChannel,
-	})
-	go func() {
-		for {
-			_, ok := <-activeEncodingChannel
-			if !ok {
-				break
-			}
-			if cmd.Process != nil {
-				_ = cmd.Process.Kill()
-			}
-			w.encodingTaskLog("task_kill_requested", task, time.Time{}, nil)
-		}
-	}()
 
 	start := time.Now()
 	if err := cmd.Run(); err != nil {
@@ -730,27 +689,6 @@ func (w *WorkerGroup) runEncodeSub(ctx context.Context, encodingTask models.Subt
 	diagnostics := newEncodingDiagnosticTail(8192)
 	cmd.Stdout = diagnostics
 	cmd.Stderr = diagnostics
-	activeEncodingChannel := make(chan bool)
-	defer w.deleteActiveEncoding(encodingTask.FileID, encodingTask.ID, "sub")
-
-	w.addActiveEncoding(ActiveEncoding{
-		Type:    "sub",
-		FileID:  encodingTask.FileID,
-		ID:      encodingTask.ID,
-		Channel: &activeEncodingChannel,
-	})
-	go func() {
-		for {
-			_, ok := <-activeEncodingChannel
-			if !ok {
-				break
-			}
-			if cmd.Process != nil {
-				_ = cmd.Process.Kill()
-			}
-			w.encodingTaskLog("task_kill_requested", task, time.Time{}, nil)
-		}
-	}()
 
 	start := time.Now()
 	if err := cmd.Run(); err != nil {
@@ -855,26 +793,42 @@ func (w *WorkerGroup) addActiveEncoding(encoding ActiveEncoding) {
 	w.activeEncodingsMu.Unlock()
 }
 
-func (w *WorkerGroup) activeEncodingsForFile(fileID uint) []ActiveEncoding {
+func (w *WorkerGroup) cancelActiveEncodingsForFile(fileID uint, reason string) int {
 	w.activeEncodingsMu.Lock()
-	defer w.activeEncodingsMu.Unlock()
-
 	encodings := make([]ActiveEncoding, 0)
 	for _, encoding := range w.activeEncodings {
-		if encoding.FileID == fileID {
+		if encoding.Task.FileID == fileID {
 			encodings = append(encodings, encoding)
 		}
 	}
-	return encodings
+	w.activeEncodingsMu.Unlock()
+
+	for _, encoding := range encodings {
+		w.encoderLogf(
+			"task_cancel_requested",
+			"task_type=%s file_id=%d file_uuid=%q task_id=%d task_name=%q storage_id=%q reason=%q",
+			encoding.Task.Type,
+			encoding.Task.FileID,
+			encoding.Task.FileUUID,
+			encoding.Task.ID,
+			encoding.Task.Name,
+			encoding.Task.StorageID,
+			reason,
+		)
+		if encoding.Cancel != nil {
+			encoding.Cancel()
+		}
+	}
+	return len(encodings)
 }
 
-func (w *WorkerGroup) deleteActiveEncoding(fileID uint, ID uint, Type string) {
+func (w *WorkerGroup) deleteActiveEncoding(task EncodingTask) {
 	w.activeEncodingsMu.Lock()
 	defer w.activeEncodingsMu.Unlock()
 
 	foundIndex := -1
 	for i, v := range w.activeEncodings {
-		if v.FileID == fileID && v.ID == ID && v.Type == Type {
+		if v.Task.FileID == task.FileID && v.Task.ID == task.ID && v.Task.Type == task.Type {
 			foundIndex = i
 		}
 	}
@@ -882,9 +836,9 @@ func (w *WorkerGroup) deleteActiveEncoding(fileID uint, ID uint, Type string) {
 		w.encoderLogf(
 			"active_task_unregister_failed",
 			"task_type=%s file_id=%d task_id=%d",
-			Type,
-			fileID,
-			ID,
+			task.Type,
+			task.FileID,
+			task.ID,
 		)
 		return
 	}

--- a/services/EncoderLogging.go
+++ b/services/EncoderLogging.go
@@ -1,0 +1,166 @@
+package services
+
+import (
+	"ch/kirari04/videocms/models"
+	"context"
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+)
+
+func (w *WorkerGroup) encoderLogf(event, format string, args ...interface{}) {
+	logger := w.encoderLogger
+	if logger == nil {
+		logger = log.Default()
+	}
+	message := fmt.Sprintf("component=encoder event=%s", event)
+	if format != "" {
+		message += " " + fmt.Sprintf(format, args...)
+	}
+	logger.Print(message)
+}
+
+func (w *WorkerGroup) encodingTaskLog(event string, task EncodingTask, started time.Time, taskErr error) {
+	details := fmt.Sprintf(
+		"task_type=%s file_id=%d file_uuid=%q task_id=%d task_name=%q storage_id=%q",
+		task.Type,
+		task.FileID,
+		task.FileUUID,
+		task.ID,
+		task.Name,
+		task.StorageID,
+	)
+	if !started.IsZero() {
+		details += fmt.Sprintf(" duration_ms=%d", time.Since(started).Milliseconds())
+	}
+	if taskErr != nil {
+		details += fmt.Sprintf(" error=%q", taskErr.Error())
+	}
+	w.encoderLogf(event, "%s", details)
+}
+
+func (w *WorkerGroup) failEncodingTask(task IwithProcess, cause error) error {
+	if cause == nil {
+		cause = fmt.Errorf("encoding failed without an error")
+	}
+	message := cause.Error()
+	const maxStoredEncodingError = 8192
+	if len(message) > maxStoredEncodingError {
+		message = message[len(message)-maxStoredEncodingError:]
+	}
+
+	switch value := task.(type) {
+	case *models.Quality:
+		value.Ready = false
+		value.Encoding = false
+		value.Failed = true
+		value.Error = message
+	case *models.Audio:
+		value.Ready = false
+		value.Encoding = false
+		value.Failed = true
+		value.Error = message
+	case *models.Subtitle:
+		value.Ready = false
+		value.Encoding = false
+		value.Failed = true
+		value.Error = message
+	default:
+		return fmt.Errorf("%w; unsupported task model %T", cause, task)
+	}
+
+	if result := task.Save(w.deps.DB); result.Error != nil {
+		return fmt.Errorf("%w; persist failed state: %v", cause, result.Error)
+	}
+	return cause
+}
+
+func (w *WorkerGroup) completeEncodingTask(task IwithProcess) error {
+	switch value := task.(type) {
+	case *models.Quality:
+		value.Encoding = false
+		value.Failed = false
+		value.Ready = true
+		value.Error = ""
+	case *models.Audio:
+		value.Encoding = false
+		value.Failed = false
+		value.Ready = true
+		value.Error = ""
+	case *models.Subtitle:
+		value.Encoding = false
+		value.Failed = false
+		value.Ready = true
+		value.Error = ""
+	default:
+		return fmt.Errorf("unsupported task model %T", task)
+	}
+
+	if result := task.Save(w.deps.DB); result.Error != nil {
+		return fmt.Errorf("persist completed state: %w", result.Error)
+	}
+	return nil
+}
+
+func (w *WorkerGroup) cleanupEncodingResource(task EncodingTask, resource string, cleanup func() error) {
+	if cleanup == nil {
+		return
+	}
+	if err := cleanup(); err != nil {
+		w.encodingTaskLog(
+			"cleanup_failed",
+			task,
+			time.Time{},
+			fmt.Errorf("cleanup %s: %w", resource, err),
+		)
+	}
+}
+
+type encodingDiagnosticTail struct {
+	mu    sync.Mutex
+	limit int
+	data  []byte
+}
+
+func newEncodingDiagnosticTail(limit int) *encodingDiagnosticTail {
+	return &encodingDiagnosticTail{limit: limit}
+}
+
+func (b *encodingDiagnosticTail) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	written := len(p)
+	if b.limit <= 0 {
+		return written, nil
+	}
+	if len(p) >= b.limit {
+		b.data = append(b.data[:0], p[len(p)-b.limit:]...)
+		return written, nil
+	}
+	if overflow := len(b.data) + len(p) - b.limit; overflow > 0 {
+		copy(b.data, b.data[overflow:])
+		b.data = b.data[:len(b.data)-overflow]
+	}
+	b.data = append(b.data, p...)
+	return written, nil
+}
+
+func (b *encodingDiagnosticTail) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return strings.TrimSpace(string(b.data))
+}
+
+func ffmpegEncodingError(ctx context.Context, runErr error, diagnostics *encodingDiagnosticTail) error {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		return fmt.Errorf("ffmpeg canceled: %w", ctxErr)
+	}
+	message := diagnostics.String()
+	if message == "" {
+		return fmt.Errorf("ffmpeg failed: %w", runErr)
+	}
+	return fmt.Errorf("ffmpeg failed: %w; diagnostic tail: %s", runErr, message)
+}

--- a/services/Encoder_test.go
+++ b/services/Encoder_test.go
@@ -98,6 +98,46 @@ func TestEncodingDiagnosticTailIsBounded(t *testing.T) {
 	}
 }
 
+func TestCancelActiveEncodingsForFileUsesTaskContext(t *testing.T) {
+	worker := encoderTestWorker(t, true, 1, 1)
+	var logs bytes.Buffer
+	worker.encoderLogger = log.New(&logs, "", 0)
+	started := make(chan EncodingTask, 1)
+	canceled := make(chan struct{}, 1)
+	worker.encodingTaskRunner = func(ctx context.Context, task EncodingTask) error {
+		started <- task
+		<-ctx.Done()
+		canceled <- struct{}{}
+		return ctx.Err()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go worker.Encoder(ctx)
+	task := waitForEncodingStart(t, started)
+
+	if count := worker.cancelActiveEncodingsForFile(task.FileID, "test cancellation"); count != 1 {
+		t.Fatalf("canceled task count = %d, want 1", count)
+	}
+	waitForSignal(t, canceled, "encoding context cancellation")
+	waitForEncoderIdle(t, worker)
+	if count := worker.cancelActiveEncodingsForFile(task.FileID, "repeat cancellation"); count != 0 {
+		t.Fatalf("active task count after completion = %d, want 0", count)
+	}
+
+	output := logs.String()
+	for _, expected := range []string{
+		"component=encoder event=task_cancel_requested",
+		`reason="test cancellation"`,
+		"component=encoder event=task_failed",
+		`error="context canceled"`,
+	} {
+		if !strings.Contains(output, expected) {
+			t.Errorf("encoder cancellation log does not contain %q:\n%s", expected, output)
+		}
+	}
+}
+
 func TestEncoderStartsQueuedWorkWhenEnabledAtRuntime(t *testing.T) {
 	worker := encoderTestWorker(t, false, 1, 1)
 	started := make(chan EncodingTask, 1)

--- a/services/Encoder_test.go
+++ b/services/Encoder_test.go
@@ -1,11 +1,14 @@
 package services
 
 import (
+	"bytes"
 	"ch/kirari04/videocms/app"
 	"ch/kirari04/videocms/config"
 	"ch/kirari04/videocms/models"
 	"context"
 	"fmt"
+	"log"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -14,11 +17,93 @@ import (
 	"gorm.io/gorm"
 )
 
+func TestEncoderLogsConsistentTaskLifecycle(t *testing.T) {
+	worker := encoderTestWorker(t, true, 1, 1)
+	var logs bytes.Buffer
+	worker.encoderLogger = log.New(&logs, "", 0)
+	started := make(chan EncodingTask, 1)
+	worker.encodingTaskRunner = func(_ context.Context, task EncodingTask) error {
+		started <- task
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go worker.Encoder(ctx)
+
+	task := waitForEncodingStart(t, started)
+	waitForEncoderIdle(t, worker)
+	output := logs.String()
+	for _, expected := range []string{
+		"component=encoder event=task_started",
+		"component=encoder event=task_completed",
+		"task_type=quality",
+		fmt.Sprintf("file_id=%d", task.FileID),
+		`file_uuid="550e8400-e29b-41d4-a716-446655440100"`,
+		fmt.Sprintf("task_id=%d", task.ID),
+		`task_name="test-0"`,
+		"duration_ms=",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Errorf("encoder log does not contain %q:\n%s", expected, output)
+		}
+	}
+}
+
+func TestEncoderPersistsAndLogsTaskFailure(t *testing.T) {
+	worker := encoderTestWorker(t, true, 1, 1)
+	var logs bytes.Buffer
+	worker.encoderLogger = log.New(&logs, "", 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go worker.Encoder(ctx)
+
+	deadline := time.Now().Add(time.Second)
+	var quality models.Quality
+	for {
+		if err := worker.deps.DB.First(&quality).Error; err != nil {
+			t.Fatalf("load quality: %v", err)
+		}
+		if quality.Failed {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for encoding failure")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	waitForEncoderIdle(t, worker)
+
+	if !strings.Contains(quality.Error, "prepare source") {
+		t.Fatalf("persisted encoding error = %q, want source preparation error", quality.Error)
+	}
+	output := logs.String()
+	if !strings.Contains(output, "component=encoder event=task_failed") ||
+		!strings.Contains(output, `error="prepare source:`) {
+		t.Fatalf("missing consistent failure log:\n%s", output)
+	}
+}
+
+func TestEncodingDiagnosticTailIsBounded(t *testing.T) {
+	tail := newEncodingDiagnosticTail(5)
+	if _, err := tail.Write([]byte("1234")); err != nil {
+		t.Fatalf("write diagnostic: %v", err)
+	}
+	if _, err := tail.Write([]byte("5678")); err != nil {
+		t.Fatalf("write diagnostic: %v", err)
+	}
+	if got := tail.String(); got != "45678" {
+		t.Fatalf("diagnostic tail = %q, want %q", got, "45678")
+	}
+}
+
 func TestEncoderStartsQueuedWorkWhenEnabledAtRuntime(t *testing.T) {
 	worker := encoderTestWorker(t, false, 1, 1)
 	started := make(chan EncodingTask, 1)
-	worker.encodingTaskRunner = func(_ context.Context, task EncodingTask) {
+	worker.encodingTaskRunner = func(_ context.Context, task EncodingTask) error {
 		started <- task
+		return nil
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -40,10 +125,11 @@ func TestEncoderStopsClaimingWorkWhenDisabledAtRuntime(t *testing.T) {
 	started := make(chan EncodingTask, 2)
 	release := make(chan struct{})
 	finished := make(chan struct{}, 2)
-	worker.encodingTaskRunner = func(_ context.Context, task EncodingTask) {
+	worker.encodingTaskRunner = func(_ context.Context, task EncodingTask) error {
 		started <- task
 		<-release
 		finished <- struct{}{}
+		return nil
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -67,9 +153,10 @@ func TestEncoderAppliesRuntimeConcurrencyChanges(t *testing.T) {
 	worker := encoderTestWorker(t, true, 1, 3)
 	started := make(chan EncodingTask, 3)
 	release := make(chan struct{})
-	worker.encodingTaskRunner = func(_ context.Context, task EncodingTask) {
+	worker.encodingTaskRunner = func(_ context.Context, task EncodingTask) error {
 		started <- task
 		<-release
+		return nil
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -96,8 +183,7 @@ func TestEncoderAppliesRuntimeConcurrencyChanges(t *testing.T) {
 
 func encoderTestWorker(t *testing.T, enabled bool, maxRunning, qualityCount int) *WorkerGroup {
 	t.Helper()
-	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", strings.ReplaceAll(t.Name(), "/", "_"))
-	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "encoder.db")), &gorm.Config{})
 	if err != nil {
 		t.Fatalf("open database: %v", err)
 	}
@@ -162,6 +248,23 @@ func waitForSignal(t *testing.T, signal <-chan struct{}, description string) {
 	case <-signal:
 	case <-time.After(time.Second):
 		t.Fatalf("timed out waiting for %s", description)
+	}
+}
+
+func waitForEncoderIdle(t *testing.T, worker *WorkerGroup) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for {
+		worker.encoderMu.Lock()
+		active := worker.activeEncodingJobs
+		worker.encoderMu.Unlock()
+		if active == 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for encoder to become idle")
+		}
+		time.Sleep(5 * time.Millisecond)
 	}
 }
 

--- a/services/Encoder_test.go
+++ b/services/Encoder_test.go
@@ -1,0 +1,175 @@
+package services
+
+import (
+	"ch/kirari04/videocms/app"
+	"ch/kirari04/videocms/config"
+	"ch/kirari04/videocms/models"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestEncoderStartsQueuedWorkWhenEnabledAtRuntime(t *testing.T) {
+	worker := encoderTestWorker(t, false, 1, 1)
+	started := make(chan EncodingTask, 1)
+	worker.encodingTaskRunner = func(_ context.Context, task EncodingTask) {
+		started <- task
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go worker.Encoder(ctx)
+
+	assertNoEncodingStarted(t, started)
+	setEncoderTestConfig(worker, true, 1)
+	worker.NotifyEncoderConfigChanged()
+
+	task := waitForEncodingStart(t, started)
+	if task.Type != "quality" {
+		t.Fatalf("started task type = %q, want quality", task.Type)
+	}
+}
+
+func TestEncoderStopsClaimingWorkWhenDisabledAtRuntime(t *testing.T) {
+	worker := encoderTestWorker(t, true, 1, 2)
+	started := make(chan EncodingTask, 2)
+	release := make(chan struct{})
+	finished := make(chan struct{}, 2)
+	worker.encodingTaskRunner = func(_ context.Context, task EncodingTask) {
+		started <- task
+		<-release
+		finished <- struct{}{}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go worker.Encoder(ctx)
+
+	waitForEncodingStart(t, started)
+	setEncoderTestConfig(worker, false, 1)
+	worker.NotifyEncoderConfigChanged()
+	release <- struct{}{}
+	waitForSignal(t, finished, "first encoding to finish")
+	assertNoEncodingStarted(t, started)
+
+	setEncoderTestConfig(worker, true, 1)
+	worker.NotifyEncoderConfigChanged()
+	waitForEncodingStart(t, started)
+	release <- struct{}{}
+}
+
+func TestEncoderAppliesRuntimeConcurrencyChanges(t *testing.T) {
+	worker := encoderTestWorker(t, true, 1, 3)
+	started := make(chan EncodingTask, 3)
+	release := make(chan struct{})
+	worker.encodingTaskRunner = func(_ context.Context, task EncodingTask) {
+		started <- task
+		<-release
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go worker.Encoder(ctx)
+
+	waitForEncodingStart(t, started)
+	assertNoEncodingStarted(t, started)
+
+	setEncoderTestConfig(worker, true, 2)
+	worker.NotifyEncoderConfigChanged()
+	waitForEncodingStart(t, started)
+	assertNoEncodingStarted(t, started)
+
+	setEncoderTestConfig(worker, true, 1)
+	worker.NotifyEncoderConfigChanged()
+	release <- struct{}{}
+	assertNoEncodingStarted(t, started)
+
+	release <- struct{}{}
+	waitForEncodingStart(t, started)
+	release <- struct{}{}
+}
+
+func encoderTestWorker(t *testing.T, enabled bool, maxRunning, qualityCount int) *WorkerGroup {
+	t.Helper()
+	dsn := fmt.Sprintf("file:%s?mode=memory&cache=shared", strings.ReplaceAll(t.Name(), "/", "_"))
+	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open database: %v", err)
+	}
+	if err := db.AutoMigrate(&models.File{}, &models.Quality{}, &models.Audio{}, &models.Subtitle{}); err != nil {
+		t.Fatalf("migrate database: %v", err)
+	}
+	file := models.File{
+		UUID:         "550e8400-e29b-41d4-a716-446655440100",
+		StorageState: models.FileStorageAvailable,
+	}
+	if err := db.Create(&file).Error; err != nil {
+		t.Fatalf("create file: %v", err)
+	}
+	for i := 0; i < qualityCount; i++ {
+		quality := models.Quality{
+			FileID: file.ID,
+			Name:   fmt.Sprintf("test-%d", i),
+			Type:   "hls",
+		}
+		if err := db.Create(&quality).Error; err != nil {
+			t.Fatalf("create quality: %v", err)
+		}
+	}
+
+	deps := &app.Deps{
+		DB: db,
+		Snapshots: app.NewSnapshotStore(app.Snapshot{Config: config.Config{
+			EncodingEnabled:   boolPointer(enabled),
+			MaxRunningEncodes: int64(maxRunning),
+		}}),
+	}
+	worker := NewWorkerGroup(deps, nil)
+	worker.encoderPollInterval = time.Hour
+	return worker
+}
+
+func setEncoderTestConfig(worker *WorkerGroup, enabled bool, maxRunning int) {
+	worker.deps.Snapshots.Replace(app.Snapshot{Config: config.Config{
+		EncodingEnabled:   boolPointer(enabled),
+		MaxRunningEncodes: int64(maxRunning),
+	}})
+}
+
+func boolPointer(value bool) *bool {
+	return &value
+}
+
+func waitForEncodingStart(t *testing.T, started <-chan EncodingTask) EncodingTask {
+	t.Helper()
+	select {
+	case task := <-started:
+		return task
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for encoding to start")
+		return EncodingTask{}
+	}
+}
+
+func waitForSignal(t *testing.T, signal <-chan struct{}, description string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for %s", description)
+	}
+}
+
+func assertNoEncodingStarted(t *testing.T, started <-chan EncodingTask) {
+	t.Helper()
+	select {
+	case task := <-started:
+		t.Fatalf("encoding task started unexpectedly: %#v", task)
+	case <-time.After(75 * time.Millisecond):
+	}
+}

--- a/services/WorkerGroup.go
+++ b/services/WorkerGroup.go
@@ -16,7 +16,12 @@ type WorkerGroup struct {
 
 	activeEncodingsMu sync.Mutex
 	activeEncodings   []ActiveEncoding
-	limitChan         chan bool
+
+	encoderMu            sync.Mutex
+	activeEncodingJobs   int
+	encoderConfigChanged chan struct{}
+	encoderPollInterval  time.Duration
+	encodingTaskRunner   func(context.Context, EncodingTask)
 
 	activeDownloadsMu     sync.Mutex
 	activeDownloadCancels map[uint]context.CancelFunc
@@ -44,6 +49,8 @@ func NewWorkerGroup(deps *app.Deps, logicSvc *logic.Service) *WorkerGroup {
 		activePreparations:    map[uint]activeDownloadPreparation{},
 		downloadAssembler:     downloadsvc.FFmpegAssembler{},
 		preparationTimeout:    downloadPreparationTimeout,
+		encoderConfigChanged:  make(chan struct{}, 1),
+		encoderPollInterval:   time.Second * 10,
 		resourcesInterval:     time.Second * 10,
 	}
 }
@@ -57,11 +64,11 @@ func (w *WorkerGroup) Start(ctx context.Context) {
 		ctx = context.Background()
 	}
 
-	cfg := w.Config()
-	if cfg.EncodingEnabled != nil && *cfg.EncodingEnabled {
-		w.ResetEncodingState()
-		go w.Encoder(ctx)
-	}
+	// Reset jobs left in progress by a previous process before starting the
+	// scheduler. The scheduler stays alive while encoding is disabled so an
+	// administrator can enable it without restarting the application.
+	w.ResetEncodingState()
+	go w.Encoder(ctx)
 
 	go w.Downloader(ctx)
 	go w.DownloadPreparer(ctx)

--- a/services/WorkerGroup.go
+++ b/services/WorkerGroup.go
@@ -6,6 +6,7 @@ import (
 	downloadsvc "ch/kirari04/videocms/download"
 	"ch/kirari04/videocms/logic"
 	"context"
+	"log"
 	"sync"
 	"time"
 )
@@ -21,7 +22,8 @@ type WorkerGroup struct {
 	activeEncodingJobs   int
 	encoderConfigChanged chan struct{}
 	encoderPollInterval  time.Duration
-	encodingTaskRunner   func(context.Context, EncodingTask)
+	encoderLogger        *log.Logger
+	encodingTaskRunner   func(context.Context, EncodingTask) error
 
 	activeDownloadsMu     sync.Mutex
 	activeDownloadCancels map[uint]context.CancelFunc
@@ -51,6 +53,7 @@ func NewWorkerGroup(deps *app.Deps, logicSvc *logic.Service) *WorkerGroup {
 		preparationTimeout:    downloadPreparationTimeout,
 		encoderConfigChanged:  make(chan struct{}, 1),
 		encoderPollInterval:   time.Second * 10,
+		encoderLogger:         log.Default(),
 		resourcesInterval:     time.Second * 10,
 	}
 }


### PR DESCRIPTION
## Purpose

Promote the encoder reliability and observability fixes currently verified on `dev` to `staging`.

## Included changes

- Restore encoding queue processing after storage-aware joins made SQLite ordering ambiguous.
- Apply encoder enable/disable and concurrency changes from the admin UI without requiring a restart.
- Add consistent, correlated lifecycle logging for queue activity, task execution, FFmpeg failures, storage operations, progress, and cleanup.
- Persist useful encoding failure diagnostics with a bounded FFmpeg output tail.
- Replace per-job cancellation watcher goroutines with task-scoped context cancellation covering source retrieval, FFmpeg, and output publication.
- Add regression and race-detector coverage for scheduling, runtime configuration, logging, failure persistence, concurrency, and cancellation cleanup.

## Upgrade behavior

No database or file migration is required. Pending, non-failed encoding jobs are discovered automatically after deployment. Jobs already marked as failed remain failed and are not retried automatically.

## Source

This promotion contains the merged work from #133 and no unrelated changes.
