### PR TITLE
Fix mounted store retirement lifecycle

### DIFF
--- a/cmd/storage.go
+++ b/cmd/storage.go
@@ -72,7 +72,7 @@ func newStorageService(ctx context.Context, cfg config.Config, db *gorm.DB) (*st
 			markStorageMountLoadFailure(db, mount, err)
 			continue
 		}
-		if _, err := storageService.RegisterStore(mount.UUID, store); err != nil {
+		if err := storageService.RegisterStore(mount.UUID, store); err != nil {
 			_ = store.Close()
 			markStorageMountLoadFailure(db, mount, err)
 			continue

--- a/logic/StorageAdmin.go
+++ b/logic/StorageAdmin.go
@@ -214,7 +214,7 @@ func (s *Service) CreateS3StorageMount(ctx context.Context, input S3StorageMount
 		_ = store.Close()
 		return models.StorageMount{}, StorageReconnectResult{}, err
 	}
-	if _, err := s.Deps.Storage.RegisterStore(mount.UUID, store); err != nil {
+	if err := s.Deps.Storage.RegisterStore(mount.UUID, store); err != nil {
 		_ = store.Close()
 		_ = s.Deps.DB.Unscoped().Delete(&mount).Error
 		return models.StorageMount{}, StorageReconnectResult{}, err
@@ -299,7 +299,7 @@ func (s *Service) UpdateS3StorageMount(ctx context.Context, mountID uint, input 
 	mount.LastCheckedAt = &now
 	mount.LastError = ""
 	if mount.Mounted {
-		if _, err := s.Deps.Storage.RegisterStore(mount.UUID, store); err != nil {
+		if err := s.Deps.Storage.RegisterStore(mount.UUID, store); err != nil {
 			_ = store.Close()
 			return models.StorageMount{}, err
 		}
@@ -350,7 +350,7 @@ func (s *Service) UnmountStorageMount(mountID uint) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	if _, err := s.Deps.Storage.UnregisterStore(mount.UUID); err != nil && !errors.Is(err, storage.ErrStoreNotConfigured) {
+	if err := s.Deps.Storage.UnregisterStore(mount.UUID); err != nil && !errors.Is(err, storage.ErrStoreNotConfigured) {
 		return unavailable, err
 	}
 	return unavailable, nil
@@ -428,7 +428,7 @@ func (s *Service) RemountStorageMount(ctx context.Context, mountID uint) (Storag
 		releaseMount()
 		return StorageReconnectResult{}, err
 	}
-	if _, err := s.Deps.Storage.RegisterStore(mount.UUID, store); err != nil {
+	if err := s.Deps.Storage.RegisterStore(mount.UUID, store); err != nil {
 		_ = store.Close()
 		releaseMount()
 		return StorageReconnectResult{}, err
@@ -440,7 +440,7 @@ func (s *Service) RemountStorageMount(ctx context.Context, mountID uint) (Storag
 		"last_error":      "",
 		"last_checked_at": &now,
 	}).Error; err != nil {
-		_, _ = s.Deps.Storage.UnregisterStore(mount.UUID)
+		_ = s.Deps.Storage.UnregisterStore(mount.UUID)
 		releaseMount()
 		return StorageReconnectResult{}, err
 	}

--- a/logic/StorageAdmin_test.go
+++ b/logic/StorageAdmin_test.go
@@ -26,10 +26,11 @@ func TestStorageMountReconnectAndUnmountLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	remoteStore, err := storage.NewLocalStore(t.TempDir())
+	remoteLocal, err := storage.NewLocalStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
+	remoteStore := &adminCloseTrackingStore{Store: remoteLocal}
 	storageService, err := storage.NewService("local", storage.LegacyMediaLayout{}, map[string]storage.Store{
 		"local":  localStore,
 		"remote": remoteStore,
@@ -110,6 +111,9 @@ func TestStorageMountReconnectAndUnmountLifecycle(t *testing.T) {
 	}
 	if _, err := storageService.Store(mount.UUID); !errors.Is(err, storage.ErrStoreNotConfigured) {
 		t.Fatalf("unmounted store error = %v", err)
+	}
+	if got := remoteStore.CloseCount(); got != 1 {
+		t.Fatalf("unmounted store close count = %d, want 1", got)
 	}
 	var membershipCount int64
 	if err := db.Model(&models.StoragePoolMount{}).Where("storage_mount_id = ?", mount.ID).Count(&membershipCount).Error; err != nil {
@@ -597,6 +601,25 @@ type delayedStatStore struct {
 	mu        sync.Mutex
 	active    int
 	maxActive int
+}
+
+type adminCloseTrackingStore struct {
+	storage.Store
+	mu         sync.Mutex
+	closeCount int
+}
+
+func (s *adminCloseTrackingStore) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closeCount++
+	return nil
+}
+
+func (s *adminCloseTrackingStore) CloseCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closeCount
 }
 
 func (s *delayedStatStore) Stat(ctx context.Context, key storage.Key) (storage.ObjectInfo, error) {

--- a/storage/managed_store.go
+++ b/storage/managed_store.go
@@ -1,0 +1,216 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// managedStore keeps the underlying provider alive while an operation is in
+// flight. Registry replacement and unmount retire the handle immediately, so
+// new operations fail while existing operations are allowed to drain before
+// the provider is closed.
+type managedStore struct {
+	id      string
+	store   Store
+	exposed Store
+
+	mu       sync.Mutex
+	active   int
+	retired  bool
+	closing  bool
+	closeErr error
+	done     chan struct{}
+	onClosed func(*managedStore, error)
+}
+
+func newManagedStore(id string, store Store, onClosed func(*managedStore, error)) *managedStore {
+	managed := &managedStore{
+		id:       id,
+		store:    store,
+		done:     make(chan struct{}),
+		onClosed: onClosed,
+	}
+	managed.exposed = managed
+	if local, ok := store.(localPathStore); ok {
+		managed.exposed = &managedLocalPathStore{managedStore: managed, local: local}
+	}
+	return managed
+}
+
+func (s *managedStore) resolved() Store {
+	return s.exposed
+}
+
+func (s *managedStore) acquire() (Store, func(), error) {
+	s.mu.Lock()
+	if s.retired {
+		s.mu.Unlock()
+		return nil, nil, fmt.Errorf("%w: %s is retired", ErrStoreNotConfigured, s.id)
+	}
+	s.active++
+	store := s.store
+	s.mu.Unlock()
+
+	var once sync.Once
+	release := func() {
+		once.Do(s.release)
+	}
+	return store, release, nil
+}
+
+func (s *managedStore) release() {
+	s.mu.Lock()
+	s.active--
+	shouldClose := s.retired && s.active == 0 && !s.closing
+	if shouldClose {
+		s.closing = true
+	}
+	s.mu.Unlock()
+	if shouldClose {
+		s.finishClose()
+	}
+}
+
+func (s *managedStore) retire() {
+	s.mu.Lock()
+	if s.retired {
+		s.mu.Unlock()
+		return
+	}
+	s.retired = true
+	shouldClose := s.active == 0 && !s.closing
+	if shouldClose {
+		s.closing = true
+	}
+	s.mu.Unlock()
+	if shouldClose {
+		s.finishClose()
+	}
+}
+
+func (s *managedStore) finishClose() {
+	err := s.store.Close()
+	s.mu.Lock()
+	s.closeErr = err
+	onClosed := s.onClosed
+	s.mu.Unlock()
+	if onClosed != nil {
+		onClosed(s, err)
+	}
+	close(s.done)
+}
+
+func (s *managedStore) waitClosed() error {
+	<-s.done
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closeErr
+}
+
+func (s *managedStore) Open(ctx context.Context, key Key) (*Object, error) {
+	store, release, err := s.acquire()
+	if err != nil {
+		return nil, err
+	}
+	object, err := store.Open(ctx, key)
+	if err != nil {
+		release()
+		return nil, err
+	}
+	if object == nil || object.Body == nil {
+		release()
+		return nil, errors.New("storage store returned an object without a body")
+	}
+	object.Body = &managedReadSeekCloser{ReadSeekCloser: object.Body, release: release}
+	return object, nil
+}
+
+func (s *managedStore) Put(ctx context.Context, key Key, src io.Reader, opts PutOptions) (ObjectInfo, error) {
+	store, release, err := s.acquire()
+	if err != nil {
+		return ObjectInfo{}, err
+	}
+	defer release()
+	return store.Put(ctx, key, src, opts)
+}
+
+func (s *managedStore) Stat(ctx context.Context, key Key) (ObjectInfo, error) {
+	store, release, err := s.acquire()
+	if err != nil {
+		return ObjectInfo{}, err
+	}
+	defer release()
+	return store.Stat(ctx, key)
+}
+
+func (s *managedStore) Delete(ctx context.Context, key Key) error {
+	store, release, err := s.acquire()
+	if err != nil {
+		return err
+	}
+	defer release()
+	return store.Delete(ctx, key)
+}
+
+func (s *managedStore) Walk(ctx context.Context, prefix Key, fn func(ObjectInfo) error) error {
+	store, release, err := s.acquire()
+	if err != nil {
+		return err
+	}
+	defer release()
+	return store.Walk(ctx, prefix, fn)
+}
+
+func (s *managedStore) Check(ctx context.Context) error {
+	store, release, err := s.acquire()
+	if err != nil {
+		return err
+	}
+	defer release()
+	checker, ok := store.(HealthChecker)
+	if !ok {
+		return nil
+	}
+	return checker.Check(ctx)
+}
+
+func (s *managedStore) Close() error {
+	s.retire()
+	return s.waitClosed()
+}
+
+type managedLocalPathStore struct {
+	*managedStore
+	local localPathStore
+}
+
+func (s *managedLocalPathStore) LocalPath(ctx context.Context, key Key) (string, error) {
+	_, release, err := s.acquire()
+	if err != nil {
+		return "", err
+	}
+	defer release()
+	return s.local.LocalPath(ctx, key)
+}
+
+type managedReadSeekCloser struct {
+	ReadSeekCloser
+	release  func()
+	once     sync.Once
+	closeErr error
+}
+
+func (r *managedReadSeekCloser) Close() error {
+	r.once.Do(func() {
+		r.closeErr = r.ReadSeekCloser.Close()
+		r.release()
+	})
+	return r.closeErr
+}
+
+var _ Store = (*managedStore)(nil)
+var _ Store = (*managedLocalPathStore)(nil)
+var _ HealthChecker = (*managedStore)(nil)

--- a/storage/service.go
+++ b/storage/service.go
@@ -8,6 +8,7 @@ import (
 )
 
 var ErrStoreNotConfigured = errors.New("storage store not configured")
+var ErrStorageServiceClosed = errors.New("storage service is closed")
 
 // Service is the runtime registry for named stores and the active media key
 // layout. Named stores allow records to retain their original location during
@@ -15,7 +16,10 @@ var ErrStoreNotConfigured = errors.New("storage store not configured")
 type Service struct {
 	mu             sync.RWMutex
 	defaultStoreID string
-	stores         map[string]Store
+	stores         map[string]*managedStore
+	retired        map[*managedStore]struct{}
+	closeErr       error
+	closed         bool
 	layout         MediaLayout
 	workspace      Workspace
 }
@@ -36,19 +40,20 @@ func NewServiceWithWorkspace(defaultStoreID string, layout MediaLayout, workspac
 	if !ok || defaultStore == nil {
 		return nil, fmt.Errorf("%w: %s", ErrStoreNotConfigured, defaultStoreID)
 	}
-	owned := make(map[string]Store, len(stores))
+	service := &Service{
+		defaultStoreID: defaultStoreID,
+		stores:         make(map[string]*managedStore, len(stores)),
+		retired:        make(map[*managedStore]struct{}),
+		layout:         layout,
+		workspace:      workspace,
+	}
 	for id, store := range stores {
 		if id == "" || store == nil {
 			return nil, ErrStoreNotConfigured
 		}
-		owned[id] = store
+		service.stores[id] = newManagedStore(id, store, service.storeClosed)
 	}
-	return &Service{
-		defaultStoreID: defaultStoreID,
-		stores:         owned,
-		layout:         layout,
-		workspace:      workspace,
-	}, nil
+	return service, nil
 }
 
 func (s *Service) DefaultStoreID() string {
@@ -71,45 +76,67 @@ func (s *Service) Store(id string) (Store, error) {
 	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
+	if s.closed {
+		return nil, ErrStorageServiceClosed
+	}
 	store, ok := s.stores[id]
 	if !ok || store == nil {
 		return nil, fmt.Errorf("%w: %s", ErrStoreNotConfigured, id)
 	}
-	return store, nil
+	return store.resolved(), nil
 }
 
-// RegisterStore atomically mounts or replaces a named store. The returned
-// previous store is no longer discoverable but may still be in use by a
-// request that resolved it before the replacement, so callers must not close
-// it until those operations have drained.
-func (s *Service) RegisterStore(id string, store Store) (Store, error) {
+// RegisterStore atomically mounts or replaces a named store. A replaced store
+// is retired automatically: new operations resolve the replacement while
+// active operations drain before the old provider is closed.
+func (s *Service) RegisterStore(id string, store Store) error {
 	if s == nil || id == "" || store == nil {
-		return nil, ErrStoreNotConfigured
+		return ErrStoreNotConfigured
 	}
+	managed := newManagedStore(id, store, s.storeClosed)
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	if s.closed {
+		s.mu.Unlock()
+		return ErrStorageServiceClosed
+	}
 	previous := s.stores[id]
-	s.stores[id] = store
-	return previous, nil
+	s.stores[id] = managed
+	if previous != nil {
+		s.retired[previous] = struct{}{}
+	}
+	s.mu.Unlock()
+	if previous != nil {
+		previous.retire()
+	}
+	return nil
 }
 
 // UnregisterStore removes an additional mount from future resolution. The
-// built-in default store cannot be unregistered.
-func (s *Service) UnregisterStore(id string) (Store, error) {
+// built-in default store cannot be unregistered. The removed store is closed
+// automatically after its active operations finish.
+func (s *Service) UnregisterStore(id string) error {
 	if s == nil || id == "" {
-		return nil, ErrStoreNotConfigured
+		return ErrStoreNotConfigured
 	}
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	if s.closed {
+		s.mu.Unlock()
+		return ErrStorageServiceClosed
+	}
 	if id == s.defaultStoreID {
-		return nil, fmt.Errorf("cannot unmount built-in store %q", id)
+		s.mu.Unlock()
+		return fmt.Errorf("cannot unmount built-in store %q", id)
 	}
 	store, ok := s.stores[id]
 	if !ok {
-		return nil, fmt.Errorf("%w: %s", ErrStoreNotConfigured, id)
+		s.mu.Unlock()
+		return fmt.Errorf("%w: %s", ErrStoreNotConfigured, id)
 	}
 	delete(s.stores, id)
-	return store, nil
+	s.retired[store] = struct{}{}
+	s.mu.Unlock()
+	store.retire()
+	return nil
 }
 
 func (s *Service) StoreIDs() []string {
@@ -154,20 +181,33 @@ func (s *Service) Close() error {
 	if s == nil {
 		return nil
 	}
-	s.mu.RLock()
-	stores := make(map[string]Store, len(s.stores))
+	s.mu.Lock()
+	s.closed = true
 	for id, store := range s.stores {
-		stores[id] = store
+		s.retired[store] = struct{}{}
+		delete(s.stores, id)
 	}
-	s.mu.RUnlock()
-	ids := make([]string, 0, len(stores))
-	for id := range stores {
-		ids = append(ids, id)
+	stores := make([]*managedStore, 0, len(s.retired))
+	for store := range s.retired {
+		stores = append(stores, store)
 	}
-	sort.Strings(ids)
-	var closeErr error
-	for _, id := range ids {
-		closeErr = errors.Join(closeErr, stores[id].Close())
+	s.mu.Unlock()
+
+	for _, store := range stores {
+		store.retire()
 	}
-	return closeErr
+	for _, store := range stores {
+		_ = store.waitClosed()
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closeErr
+}
+
+func (s *Service) storeClosed(store *managedStore, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.retired, store)
+	s.closeErr = errors.Join(s.closeErr, err)
 }

--- a/storage/service_test.go
+++ b/storage/service_test.go
@@ -1,8 +1,12 @@
 package storage
 
 import (
+	"context"
 	"errors"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestServiceMountRegistry(t *testing.T) {
@@ -15,24 +19,219 @@ func TestServiceMountRegistry(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = service.Close() })
-	remote, err := NewLocalStore(t.TempDir())
+	remoteLocal, err := NewLocalStore(t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
-	if previous, err := service.RegisterStore("remote", remote); err != nil || previous != nil {
-		t.Fatalf("RegisterStore() = %T, %v", previous, err)
+	remote := &closeTrackingStore{Store: remoteLocal}
+	if err := service.RegisterStore("remote", remote); err != nil {
+		t.Fatalf("RegisterStore() error = %v", err)
 	}
 	if got := service.StoreIDs(); len(got) != 2 || got[0] != "local" || got[1] != "remote" {
 		t.Fatalf("StoreIDs() = %v", got)
 	}
-	removed, err := service.UnregisterStore("remote")
-	if err != nil || removed != remote {
-		t.Fatalf("UnregisterStore() = %T, %v", removed, err)
+	if err := service.UnregisterStore("remote"); err != nil {
+		t.Fatalf("UnregisterStore() error = %v", err)
 	}
 	if _, err := service.Store("remote"); !errors.Is(err, ErrStoreNotConfigured) {
 		t.Fatalf("removed store error = %v", err)
 	}
-	if _, err := service.UnregisterStore("local"); err == nil {
+	if got := remote.CloseCount(); got != 1 {
+		t.Fatalf("removed store close count = %d, want 1", got)
+	}
+	if err := service.UnregisterStore("local"); err == nil {
 		t.Fatal("UnregisterStore(local) error = nil")
 	}
+}
+
+func TestServiceReplacementDrainsOpenObjectsBeforeClosingStore(t *testing.T) {
+	local, err := NewLocalStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldLocal, err := NewLocalStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := ParseKey("video/segment.ts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := oldLocal.Put(context.Background(), key, strings.NewReader("segment"), PutOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	oldStore := &closeTrackingStore{Store: oldLocal}
+	service, err := NewService("local", LegacyMediaLayout{}, map[string]Store{
+		"local":  local,
+		"remote": oldStore,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = service.Close() })
+
+	resolvedOld, err := service.Store("remote")
+	if err != nil {
+		t.Fatal(err)
+	}
+	object, err := resolvedOld.Open(context.Background(), key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	replacementLocal, err := NewLocalStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement := &closeTrackingStore{Store: replacementLocal}
+	if err := service.RegisterStore("remote", replacement); err != nil {
+		t.Fatal(err)
+	}
+	if got := oldStore.CloseCount(); got != 0 {
+		t.Fatalf("old store closed with an open object: close count = %d", got)
+	}
+	if _, err := resolvedOld.Stat(context.Background(), key); !errors.Is(err, ErrStoreNotConfigured) {
+		t.Fatalf("retired store accepted a new operation: %v", err)
+	}
+	if resolvedNew, err := service.Store("remote"); err != nil {
+		t.Fatal(err)
+	} else if resolvedNew == resolvedOld {
+		t.Fatal("replacement resolved to the retired store")
+	}
+
+	if err := object.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := object.Body.Close(); err != nil {
+		t.Fatalf("second object close returned an error: %v", err)
+	}
+	if got := oldStore.CloseCount(); got != 1 {
+		t.Fatalf("drained store close count = %d, want 1", got)
+	}
+
+	if err := service.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := oldStore.CloseCount(); got != 1 {
+		t.Fatalf("old store close count after service close = %d, want 1", got)
+	}
+	if got := replacement.CloseCount(); got != 1 {
+		t.Fatalf("replacement close count = %d, want 1", got)
+	}
+}
+
+func TestServiceCloseWaitsForOpenObjects(t *testing.T) {
+	local, err := NewLocalStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := ParseKey("video/source.mp4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := local.Put(context.Background(), key, strings.NewReader("source"), PutOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	tracked := &closeTrackingStore{Store: local}
+	service, err := NewService("local", LegacyMediaLayout{}, map[string]Store{"local": tracked})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resolved, err := service.Default()
+	if err != nil {
+		t.Fatal(err)
+	}
+	object, err := resolved.Open(context.Background(), key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	closed := make(chan error, 1)
+	go func() {
+		closed <- service.Close()
+	}()
+	deadline := time.After(time.Second)
+	for {
+		_, storeErr := service.Default()
+		if errors.Is(storeErr, ErrStorageServiceClosed) {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("storage service did not begin closing")
+		default:
+		}
+	}
+	select {
+	case err := <-closed:
+		t.Fatalf("Close returned before the open object drained: %v", err)
+	default:
+	}
+	if got := tracked.CloseCount(); got != 0 {
+		t.Fatalf("store close count with open object = %d, want 0", got)
+	}
+
+	if err := object.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Close did not finish after the object drained")
+	}
+	if got := tracked.CloseCount(); got != 1 {
+		t.Fatalf("store close count = %d, want 1", got)
+	}
+}
+
+func TestServiceCloseReportsErrorsFromPreviouslyRetiredStores(t *testing.T) {
+	local, err := NewLocalStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	remoteLocal, err := NewLocalStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantErr := errors.New("close remote connection")
+	remote := &closeTrackingStore{Store: remoteLocal, closeErr: wantErr}
+	service, err := NewService("local", LegacyMediaLayout{}, map[string]Store{
+		"local":  local,
+		"remote": remote,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := service.UnregisterStore("remote"); err != nil {
+		t.Fatal(err)
+	}
+	if err := service.Close(); !errors.Is(err, wantErr) {
+		t.Fatalf("Close() error = %v, want %v", err, wantErr)
+	}
+	if got := remote.CloseCount(); got != 1 {
+		t.Fatalf("retired store close count = %d, want 1", got)
+	}
+}
+
+type closeTrackingStore struct {
+	Store
+	mu         sync.Mutex
+	closeCount int
+	closeErr   error
+}
+
+func (s *closeTrackingStore) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closeCount++
+	return s.closeErr
+}
+
+func (s *closeTrackingStore) CloseCount() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.closeCount
 }


### PR DESCRIPTION
## Summary
- make the storage registry own replacement and unmount cleanup
- drain active operations and open media bodies before closing retired providers
- close providers exactly once and preserve close errors during shutdown
- cover replacement, unmount, active streaming, and shutdown behavior

## Verification
- go test ./...
- go vet ./...
- go test -race ./storage ./logic ./cmd
- git diff --check