### PR TITLE
feat(storage): add resumable pool migrations

### DIFF
--- a/app/storage_lifecycle.go
+++ b/app/storage_lifecycle.go
@@ -1,37 +1,125 @@
 package app
 
-import "sync"
+import (
+	"fmt"
+	"sort"
+	"sync"
+)
 
-// StorageLifecycle serializes operations that must not overlap a mount
-// transition. The zero value is ready to use. Locks are scoped by durable
-// mount ID so detaching one backend does not stall uploads to another.
+// StorageLifecycle serializes storage, pool, and per-file transitions that
+// must not overlap. The zero value is ready to use. Independent resources use
+// separate keyed locks, and unused entries are released from the lock map.
 type StorageLifecycle struct {
 	mu    sync.Mutex
-	locks map[string]*sync.RWMutex
+	locks map[string]*storageLifecycleLock
+}
+
+type storageLifecycleLock struct {
+	lock sync.RWMutex
+	refs int
 }
 
 func (l *StorageLifecycle) ReadLock(mountID string) func() {
-	lock := l.mountLock(mountID)
-	lock.RLock()
-	return lock.RUnlock
+	entry := l.retainLock(mountID)
+	entry.lock.RLock()
+	return func() {
+		entry.lock.RUnlock()
+		l.releaseLock(mountID, entry)
+	}
 }
 
 func (l *StorageLifecycle) WriteLock(mountID string) func() {
-	lock := l.mountLock(mountID)
-	lock.Lock()
-	return lock.Unlock
+	entry := l.retainLock(mountID)
+	entry.lock.Lock()
+	return func() {
+		entry.lock.Unlock()
+		l.releaseLock(mountID, entry)
+	}
 }
 
-func (l *StorageLifecycle) mountLock(mountID string) *sync.RWMutex {
+func (l *StorageLifecycle) ReadLocks(mountIDs ...string) func() {
+	ids := uniqueLifecycleIDs(mountIDs)
+	releases := make([]func(), 0, len(ids))
+	for _, id := range ids {
+		releases = append(releases, l.ReadLock(id))
+	}
+	return func() {
+		for index := len(releases) - 1; index >= 0; index-- {
+			releases[index]()
+		}
+	}
+}
+
+func (l *StorageLifecycle) FileReadLock(fileID uint) func() {
+	return l.ReadLock(fmt.Sprintf("file:%d", fileID))
+}
+
+func (l *StorageLifecycle) FileReadLocks(fileIDs ...uint) func() {
+	keys := make([]string, 0, len(fileIDs))
+	for _, fileID := range fileIDs {
+		if fileID > 0 {
+			keys = append(keys, fmt.Sprintf("file:%d", fileID))
+		}
+	}
+	return l.ReadLocks(keys...)
+}
+
+func (l *StorageLifecycle) FileWriteLock(fileID uint) func() {
+	return l.WriteLock(fmt.Sprintf("file:%d", fileID))
+}
+
+func (l *StorageLifecycle) PoolReadLock(poolID uint) func() {
+	return l.ReadLock(fmt.Sprintf("pool:%d", poolID))
+}
+
+func (l *StorageLifecycle) PoolWriteLock(poolID uint) func() {
+	return l.WriteLock(fmt.Sprintf("pool:%d", poolID))
+}
+
+func (l *StorageLifecycle) PoolReadLocks(poolIDs ...uint) func() {
+	keys := make([]string, 0, len(poolIDs))
+	for _, poolID := range poolIDs {
+		if poolID > 0 {
+			keys = append(keys, fmt.Sprintf("pool:%d", poolID))
+		}
+	}
+	return l.ReadLocks(keys...)
+}
+
+func uniqueLifecycleIDs(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	result := make([]string, 0, len(values))
+	for _, value := range values {
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func (l *StorageLifecycle) retainLock(mountID string) *storageLifecycleLock {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	if l.locks == nil {
-		l.locks = make(map[string]*sync.RWMutex)
+		l.locks = make(map[string]*storageLifecycleLock)
 	}
-	lock := l.locks[mountID]
-	if lock == nil {
-		lock = &sync.RWMutex{}
-		l.locks[mountID] = lock
+	entry := l.locks[mountID]
+	if entry == nil {
+		entry = &storageLifecycleLock{}
+		l.locks[mountID] = entry
 	}
-	return lock
+	entry.refs++
+	return entry
+}
+
+func (l *StorageLifecycle) releaseLock(mountID string, entry *storageLifecycleLock) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	entry.refs--
+	if entry.refs == 0 && l.locks[mountID] == entry {
+		delete(l.locks, mountID)
+	}
 }

--- a/app/storage_lifecycle_test.go
+++ b/app/storage_lifecycle_test.go
@@ -1,0 +1,20 @@
+package app
+
+import "testing"
+
+func TestStorageLifecycleReleasesUnusedKeyedLocks(t *testing.T) {
+	var lifecycle StorageLifecycle
+	first := lifecycle.ReadLock("mount-a")
+	second := lifecycle.ReadLock("mount-a")
+	if len(lifecycle.locks) != 1 || lifecycle.locks["mount-a"].refs != 2 {
+		t.Fatalf("unexpected retained lock state: %#v", lifecycle.locks)
+	}
+	first()
+	if len(lifecycle.locks) != 1 || lifecycle.locks["mount-a"].refs != 1 {
+		t.Fatalf("lock was released while still referenced: %#v", lifecycle.locks)
+	}
+	second()
+	if len(lifecycle.locks) != 0 {
+		t.Fatalf("unused lifecycle lock was retained: %#v", lifecycle.locks)
+	}
+}

--- a/background/errors.go
+++ b/background/errors.go
@@ -18,6 +18,7 @@ const (
 	ErrorPermanent   ErrorClass = "permanent"
 	ErrorCanceled    ErrorClass = "canceled"
 	ErrorInterrupted ErrorClass = "interrupted"
+	ErrorPaused      ErrorClass = "paused"
 )
 
 type TaskError struct {
@@ -57,6 +58,14 @@ func Interrupted(cause error) error {
 	return &TaskError{Code: "interrupted", Public: "Interrupted by application shutdown", Diagnostic: diagnostic(cause), Class: ErrorInterrupted, Cause: cause}
 }
 
+func Paused(cause error) error {
+	return &TaskError{Code: "paused", Public: "Paused", Diagnostic: diagnostic(cause), Class: ErrorPaused, Cause: cause}
+}
+
+func PauseRequested(ctx context.Context) bool {
+	return ctx != nil && errors.Is(context.Cause(ctx), errUserPaused)
+}
+
 func classifyError(ctx context.Context, err error) *TaskError {
 	if err == nil {
 		return nil
@@ -68,6 +77,9 @@ func classifyError(ctx context.Context, err error) *TaskError {
 	if errors.Is(err, context.Canceled) {
 		if ctx != nil && errors.Is(context.Cause(ctx), errRuntimeStopping) {
 			return &TaskError{Code: "interrupted", Public: "Interrupted by application shutdown", Diagnostic: diagnostic(err), Class: ErrorInterrupted, Cause: err}
+		}
+		if ctx != nil && errors.Is(context.Cause(ctx), errUserPaused) {
+			return &TaskError{Code: "paused", Public: "Paused", Diagnostic: diagnostic(err), Class: ErrorPaused, Cause: err}
 		}
 		return &TaskError{Code: "canceled", Public: "Canceled", Diagnostic: diagnostic(err), Class: ErrorCanceled, Cause: err}
 	}

--- a/background/runtime.go
+++ b/background/runtime.go
@@ -20,6 +20,7 @@ import (
 var (
 	errRuntimeStopping     = errors.New("background runtime stopping")
 	errUserCanceled        = errors.New("background job canceled")
+	errUserPaused          = errors.New("background job paused")
 	ErrIdempotencyConflict = errors.New("idempotency key was already used for a different request")
 	ErrConflict            = errors.New("background operation conflicts with its current state")
 	ErrCommitStarted       = fmt.Errorf("%w: irreversible task commit has started", ErrConflict)
@@ -51,6 +52,7 @@ type Runtime struct {
 
 type activeTask struct {
 	queue  string
+	jobID  string
 	cancel context.CancelCauseFunc
 }
 
@@ -450,6 +452,7 @@ func (r *Runtime) Recover(ctx context.Context) error {
 			Where("status = ? AND commit_started_at IS NULL", TaskRunning).
 			Updates(map[string]any{
 				"status":              TaskQueued,
+				"max_attempts":        gorm.Expr("max_attempts + 1"),
 				"run_after":           nil,
 				"heartbeat_at":        nil,
 				"error_code":          "worker_interrupted",
@@ -459,7 +462,7 @@ func (r *Runtime) Recover(ctx context.Context) error {
 			return err
 		}
 		var jobs []Job
-		if err := tx.Where("status IN ?", []string{JobRunning, JobRetryWait, JobCancelRequested}).Find(&jobs).Error; err != nil {
+		if err := tx.Where("status IN ?", []string{JobRunning, JobRetryWait, JobPauseRequested, JobPaused, JobCancelRequested}).Find(&jobs).Error; err != nil {
 			return err
 		}
 		for index := range jobs {
@@ -514,12 +517,16 @@ func (r *Runtime) recoverStaleTasks(ctx context.Context, before time.Time) error
 				message = "Cancellation completed after the worker heartbeat expired"
 				finishedAt = &now
 			}
+			taskUpdates := map[string]any{
+				"status": taskStatus, "run_after": nil, "heartbeat_at": nil, "finished_at": finishedAt,
+				"cancel_requested_at": nil, "error_code": code, "error_message": message,
+			}
+			if taskStatus == TaskQueued {
+				taskUpdates["max_attempts"] = gorm.Expr("max_attempts + 1")
+			}
 			updated := tx.Model(&Task{}).
 				Where("id = ? AND status = ? AND (heartbeat_at IS NULL OR heartbeat_at < ?)", task.ID, task.Status, before).
-				Updates(map[string]any{
-					"status": taskStatus, "run_after": nil, "heartbeat_at": nil, "finished_at": finishedAt,
-					"cancel_requested_at": nil, "error_code": code, "error_message": message,
-				})
+				Updates(taskUpdates)
 			if updated.Error != nil {
 				return updated.Error
 			}
@@ -595,7 +602,7 @@ func (r *Runtime) claim(queue string) (*Task, *Attempt, error) {
 	now := time.Now()
 	err := r.db.WithContext(r.rootCtx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.
-			Where("queue = ? AND status IN ? AND (run_after IS NULL OR run_after <= ?)", queue, []string{TaskQueued, TaskRetryWait}, now).
+			Where("queue = ? AND status IN ? AND (run_after IS NULL OR run_after <= ?) AND job_id IN (SELECT id FROM background_jobs WHERE pause_requested_at IS NULL AND cancel_requested_at IS NULL)", queue, []string{TaskQueued, TaskRetryWait}, now).
 			Order("priority + CAST((julianday(CURRENT_TIMESTAMP) - julianday(created_at)) * 1440 AS INTEGER) DESC").
 			Order("created_at ASC, id ASC").
 			First(&task).Error; err != nil {
@@ -603,7 +610,7 @@ func (r *Runtime) claim(queue string) (*Task, *Attempt, error) {
 		}
 		startedAt := now
 		updated := tx.Model(&Task{}).
-			Where("id = ? AND status IN ?", task.ID, []string{TaskQueued, TaskRetryWait}).
+			Where("id = ? AND status IN ? AND job_id IN (SELECT id FROM background_jobs WHERE pause_requested_at IS NULL AND cancel_requested_at IS NULL)", task.ID, []string{TaskQueued, TaskRetryWait}).
 			Updates(map[string]any{
 				"status":            TaskRunning,
 				"attempt_count":     gorm.Expr("attempt_count + 1"),
@@ -658,7 +665,7 @@ func (r *Runtime) launch(task Task, attempt Attempt) {
 	reporter := &executionReporter{runtime: r, taskID: task.ID, last: task.Progress}
 	ctx = context.WithValue(ctx, executionReporterKey{}, reporter)
 	r.mu.Lock()
-	r.active[task.ID] = activeTask{queue: task.Queue, cancel: cancel}
+	r.active[task.ID] = activeTask{queue: task.Queue, jobID: task.JobID, cancel: cancel}
 	handler := r.handlers[task.Kind]
 	r.mu.Unlock()
 
@@ -721,7 +728,7 @@ func (r *Runtime) finish(task Task, attempt Attempt, result Result, taskErr *Tas
 		if current.Status != TaskRunning && current.Status != TaskCancelRequested {
 			return nil
 		}
-		if taskErr == nil && current.Status == TaskCancelRequested && current.CommitStartedAt == nil {
+		if (taskErr == nil || taskErr.Class == ErrorPaused) && current.Status == TaskCancelRequested && current.CommitStartedAt == nil {
 			taskErr = &TaskError{Code: "canceled", Public: "Canceled", Class: ErrorCanceled, Cause: errUserCanceled}
 		}
 
@@ -751,6 +758,16 @@ func (r *Runtime) finish(task Task, attempt Attempt, result Result, taskErr *Tas
 			updates["error_message"] = public
 			updates["progress"] = current.Progress
 			switch taskErr.Class {
+			case ErrorPaused:
+				attemptStatus = AttemptInterrupted
+				taskStatus = TaskQueued
+				updates["status"] = taskStatus
+				updates["run_after"] = nil
+				updates["finished_at"] = nil
+				updates["cancel_requested_at"] = nil
+				updates["max_attempts"] = gorm.Expr("max_attempts + 1")
+				eventType = "task_paused"
+				eventMessage = "Task paused at a safe checkpoint"
 			case ErrorInterrupted:
 				attemptStatus = AttemptInterrupted
 				taskStatus = TaskQueued
@@ -758,6 +775,7 @@ func (r *Runtime) finish(task Task, attempt Attempt, result Result, taskErr *Tas
 				updates["run_after"] = nil
 				updates["finished_at"] = nil
 				updates["cancel_requested_at"] = nil
+				updates["max_attempts"] = gorm.Expr("max_attempts + 1")
 				eventType = "task_interrupted"
 				eventMessage = "Task interrupted and queued again"
 			case ErrorCanceled:
@@ -911,6 +929,9 @@ func equalFoldASCII(a, b string) bool {
 }
 
 func recomputeJob(tx *gorm.DB, job *Job, now time.Time) error {
+	if err := tx.First(job, "id = ?", job.ID).Error; err != nil {
+		return err
+	}
 	var tasks []Task
 	if err := tx.Where("job_id = ?", job.ID).Order("created_at ASC").Find(&tasks).Error; err != nil {
 		return err
@@ -992,6 +1013,10 @@ func recomputeJob(tx *gorm.DB, job *Job, now time.Time) error {
 		switch {
 		case job.CancelRequestedAt != nil:
 			status = JobCancelRequested
+		case job.PauseRequestedAt != nil && running > 0:
+			status = JobPauseRequested
+		case job.PauseRequestedAt != nil:
+			status = JobPaused
 		case running > 0:
 			status = JobRunning
 		case waiting > 0:
@@ -1019,6 +1044,15 @@ func recomputeJob(tx *gorm.DB, job *Job, now time.Time) error {
 		"progress":      progress,
 		"error_code":    boundedMessage(errorCode, 80),
 		"error_message": boundedMessage(errorMessage, 512),
+	}
+	if status == JobPaused {
+		updates["paused_at"] = gorm.Expr("COALESCE(paused_at, ?)", now)
+	} else if status != JobPauseRequested {
+		updates["paused_at"] = nil
+	}
+	if terminalJobStatus(status) {
+		updates["pause_requested_at"] = nil
+		updates["paused_at"] = nil
 	}
 	if (status == JobRunning || status == JobRetryWait) && job.StartedAt == nil {
 		updates["started_at"] = &now
@@ -1109,7 +1143,7 @@ func BeginCommit(ctx context.Context, phase string) bool {
 		if err := tx.First(&job, "id = ?", task.JobID).Error; err != nil {
 			return err
 		}
-		if job.CancelRequestedAt != nil {
+		if job.CancelRequestedAt != nil || job.PauseRequestedAt != nil {
 			return ErrConflict
 		}
 		updated := tx.Model(&Task{}).Where("id = ? AND status = ? AND cancel_requested_at IS NULL", reporter.taskID, TaskRunning).Updates(map[string]any{"phase": boundedMessage(phase, 120), "commit_started_at": &now})
@@ -1122,6 +1156,75 @@ func BeginCommit(ctx context.Context, phase string) bool {
 		return recomputeJob(tx, &job, now)
 	})
 	return err == nil
+}
+
+func (r *Runtime) PauseJob(ctx context.Context, jobID string, actorID uint, actorName string) error {
+	now := time.Now()
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var job Job
+		if err := tx.First(&job, "id = ?", jobID).Error; err != nil {
+			return err
+		}
+		if !pausableJobStatus(job.Status) || job.PauseRequestedAt != nil || job.CancelRequestedAt != nil {
+			return ErrConflict
+		}
+		var committing int64
+		if err := tx.Model(&Task{}).Where("job_id = ? AND commit_started_at IS NOT NULL AND status IN ?", jobID, []string{TaskRunning, TaskCancelRequested}).Count(&committing).Error; err != nil {
+			return err
+		}
+		if committing > 0 {
+			return ErrCommitStarted
+		}
+		if err := tx.Model(&job).Updates(map[string]any{"pause_requested_at": &now, "paused_at": nil}).Error; err != nil {
+			return err
+		}
+		job.PauseRequestedAt = &now
+		if err := addEvent(tx, Event{JobID: jobID, Type: "job_pause_requested", ActorID: optionalActor(actorID), ActorName: actorName, Message: "Pause requested"}); err != nil {
+			return err
+		}
+		return recomputeJob(tx, &job, now)
+	})
+	if err != nil {
+		return err
+	}
+	r.mu.Lock()
+	var cancels []context.CancelCauseFunc
+	for _, active := range r.active {
+		if active.jobID == jobID {
+			cancels = append(cancels, active.cancel)
+		}
+	}
+	r.mu.Unlock()
+	for _, cancel := range cancels {
+		cancel(errUserPaused)
+	}
+	return nil
+}
+
+func (r *Runtime) ResumeJob(ctx context.Context, jobID string, actorID uint, actorName string) error {
+	now := time.Now()
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var job Job
+		if err := tx.First(&job, "id = ?", jobID).Error; err != nil {
+			return err
+		}
+		if job.Status != JobPauseRequested && job.Status != JobPaused {
+			return ErrConflict
+		}
+		if err := tx.Model(&job).Updates(map[string]any{"pause_requested_at": nil, "paused_at": nil}).Error; err != nil {
+			return err
+		}
+		job.PauseRequestedAt = nil
+		job.PausedAt = nil
+		if err := addEvent(tx, Event{JobID: jobID, Type: "job_resumed", ActorID: optionalActor(actorID), ActorName: actorName, Message: "Job resumed"}); err != nil {
+			return err
+		}
+		return recomputeJob(tx, &job, now)
+	})
+	if err == nil {
+		r.Wake()
+	}
+	return err
 }
 
 func (r *Runtime) heartbeatLoop() {
@@ -1214,11 +1317,12 @@ func (r *Runtime) QueueSummaries(ctx context.Context) ([]QueueSummary, error) {
 	result := make([]QueueSummary, 0, len(states))
 	for _, state := range states {
 		summary := QueueSummary{QueueState: state, Capacity: r.capacity(state.Name), Active: r.activeCount(state.Name)}
-		if err := r.db.WithContext(ctx).Model(&Task{}).Where("queue = ? AND status IN ?", state.Name, []string{TaskQueued, TaskRetryWait}).Count(&summary.Waiting).Error; err != nil {
+		dispatchable := "queue = ? AND status IN ? AND job_id IN (SELECT id FROM background_jobs WHERE pause_requested_at IS NULL AND cancel_requested_at IS NULL)"
+		if err := r.db.WithContext(ctx).Model(&Task{}).Where(dispatchable, state.Name, []string{TaskQueued, TaskRetryWait}).Count(&summary.Waiting).Error; err != nil {
 			return nil, err
 		}
 		var oldest Task
-		if err := r.db.WithContext(ctx).Where("queue = ? AND status IN ?", state.Name, []string{TaskQueued, TaskRetryWait}).Order("created_at ASC").First(&oldest).Error; err == nil {
+		if err := r.db.WithContext(ctx).Where(dispatchable, state.Name, []string{TaskQueued, TaskRetryWait}).Order("created_at ASC").First(&oldest).Error; err == nil {
 			summary.OldestAt = &oldest.CreatedAt
 		}
 		result = append(result, summary)
@@ -1266,7 +1370,7 @@ func (r *Runtime) CancelJob(ctx context.Context, jobID string, actorID uint, act
 		if committing > 0 {
 			return ErrCommitStarted
 		}
-		if err := tx.Model(&job).Updates(map[string]any{"status": JobCancelRequested, "cancel_requested_at": &now}).Error; err != nil {
+		if err := tx.Model(&job).Updates(map[string]any{"status": JobCancelRequested, "cancel_requested_at": &now, "pause_requested_at": nil, "paused_at": nil}).Error; err != nil {
 			return err
 		}
 		if err := tx.Model(&Task{}).Where("job_id = ? AND status IN ?", jobID, []string{TaskQueued, TaskRetryWait}).Updates(map[string]any{
@@ -1326,7 +1430,7 @@ func (r *Runtime) RetryJob(ctx context.Context, jobID string, actorID uint, acto
 		if result.RowsAffected == 0 {
 			return ErrConflict
 		}
-		if err := tx.Model(&job).Updates(map[string]any{"status": JobQueued, "finished_at": nil, "cancel_requested_at": nil, "error_code": "", "error_message": ""}).Error; err != nil {
+		if err := tx.Model(&job).Updates(map[string]any{"status": JobQueued, "finished_at": nil, "cancel_requested_at": nil, "pause_requested_at": nil, "paused_at": nil, "error_code": "", "error_message": ""}).Error; err != nil {
 			return err
 		}
 		if err := addEvent(tx, Event{JobID: jobID, Type: "job_retried", ActorID: optionalActor(actorID), ActorName: actorName, Message: "Job queued for manual retry"}); err != nil {

--- a/background/runtime.go
+++ b/background/runtime.go
@@ -1165,7 +1165,7 @@ func (r *Runtime) PauseJob(ctx context.Context, jobID string, actorID uint, acto
 		if err := tx.First(&job, "id = ?", jobID).Error; err != nil {
 			return err
 		}
-		if !pausableJobStatus(job.Status) || job.PauseRequestedAt != nil || job.CancelRequestedAt != nil {
+		if !job.Pausable || !pausableJobStatus(job.Status) || job.PauseRequestedAt != nil || job.CancelRequestedAt != nil {
 			return ErrConflict
 		}
 		var committing int64

--- a/background/runtime_test.go
+++ b/background/runtime_test.go
@@ -324,6 +324,115 @@ func TestCancelRunningJobPropagatesToHandler(t *testing.T) {
 	}
 }
 
+func TestPauseRunningJobCheckpointsAndResumes(t *testing.T) {
+	runtime, _ := testRuntime(t)
+	started := make(chan struct{})
+	var calls atomic.Int32
+	if err := runtime.Register("test.pause", func(ctx context.Context, _ Task) (Result, error) {
+		if calls.Add(1) == 1 {
+			ReportProgress(ctx, 0.42, "Checkpointed")
+			close(started)
+			<-ctx.Done()
+			return Result{}, ctx.Err()
+		}
+		return Result{}, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	startTestRuntime(t, runtime)
+	job := enqueueTestJob(t, runtime, "pause-running", "test.pause", QueueStorage, 2)
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not start")
+	}
+	if err := runtime.PauseJob(context.Background(), job.ID, 1, "admin"); err != nil {
+		t.Fatalf("pause job: %v", err)
+	}
+	detail := waitForJob(t, runtime, job.ID, JobPaused)
+	if detail.Tasks[0].Status != TaskQueued || detail.Tasks[0].Progress < 4000 || detail.Tasks[0].MaxAttempts != 3 || len(detail.Tasks[0].Attempts) != 1 || detail.Tasks[0].Attempts[0].Status != AttemptInterrupted {
+		t.Fatalf("unexpected paused state: %#v", detail.Tasks[0])
+	}
+	if detail.CanPause || !detail.CanResume || !detail.CanCancel || detail.PausedAt == nil {
+		t.Fatalf("unexpected paused capabilities: %#v", detail.Job)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if calls.Load() != 1 {
+		t.Fatalf("paused task was reclaimed; calls=%d", calls.Load())
+	}
+	if err := runtime.ResumeJob(context.Background(), job.ID, 1, "admin"); err != nil {
+		t.Fatalf("resume job: %v", err)
+	}
+	detail = waitForJob(t, runtime, job.ID, JobSucceeded)
+	if calls.Load() != 2 || len(detail.Tasks[0].Attempts) != 2 || detail.Tasks[0].Attempts[1].Status != AttemptSucceeded {
+		t.Fatalf("unexpected resumed state: calls=%d task=%#v", calls.Load(), detail.Tasks[0])
+	}
+}
+
+func TestQueuedJobCanBePausedAndCanceledWithoutExecution(t *testing.T) {
+	runtime, _ := testRuntime(t)
+	job := enqueueTestJob(t, runtime, "pause-queued", "test.pause.queued", QueueStorage, 1)
+	if err := runtime.PauseJob(context.Background(), job.ID, 1, "admin"); err != nil {
+		t.Fatalf("pause queued job: %v", err)
+	}
+	detail := waitForJob(t, runtime, job.ID, JobPaused)
+	if detail.Tasks[0].Status != TaskQueued || detail.PausedAt == nil {
+		t.Fatalf("unexpected queued pause state: %#v", detail)
+	}
+	if err := runtime.CancelJob(context.Background(), job.ID, 1, "admin"); err != nil {
+		t.Fatalf("cancel paused job: %v", err)
+	}
+	detail = waitForJob(t, runtime, job.ID, JobCanceled)
+	if detail.Tasks[0].Status != TaskCanceled || detail.PauseRequestedAt != nil || detail.PausedAt != nil {
+		t.Fatalf("unexpected canceled pause state: %#v", detail)
+	}
+}
+
+func TestPausedJobIsNotCountedAsDispatchableQueueWork(t *testing.T) {
+	runtime, _ := testRuntime(t)
+	job := enqueueTestJob(t, runtime, "pause-queue-summary", "test.pause.summary", QueueStorage, 1)
+	if err := runtime.PauseJob(context.Background(), job.ID, 1, "admin"); err != nil {
+		t.Fatalf("pause queued job: %v", err)
+	}
+	queues, err := runtime.QueueSummaries(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, queue := range queues {
+		if queue.Name == QueueStorage && queue.Waiting != 0 {
+			t.Fatalf("paused task counted as waiting work: %#v", queue)
+		}
+	}
+}
+
+func TestPauseIsRejectedAfterIrreversibleCommit(t *testing.T) {
+	runtime, _ := testRuntime(t)
+	committed := make(chan struct{})
+	release := make(chan struct{})
+	if err := runtime.Register("test.pause.commit", func(ctx context.Context, _ Task) (Result, error) {
+		if !BeginCommit(ctx, "Committing") {
+			return Result{}, ctx.Err()
+		}
+		close(committed)
+		<-release
+		return Result{}, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	startTestRuntime(t, runtime)
+	job := enqueueTestJob(t, runtime, "pause-commit", "test.pause.commit", QueueStorage, 1)
+	select {
+	case <-committed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not enter commit")
+	}
+	if err := runtime.PauseJob(context.Background(), job.ID, 1, "admin"); !errors.Is(err, ErrCommitStarted) {
+		t.Fatalf("expected commit conflict, got %v", err)
+	}
+	close(release)
+	waitForJob(t, runtime, job.ID, JobSucceeded)
+}
+
 func TestDeletionCancellationStopsAtIrreversiblePhase(t *testing.T) {
 	runtime, _ := testRuntime(t)
 	phaseStarted := make(chan struct{})

--- a/background/runtime_test.go
+++ b/background/runtime_test.go
@@ -46,10 +46,18 @@ func startTestRuntime(t *testing.T, runtime *Runtime) {
 }
 
 func enqueueTestJob(t *testing.T, runtime *Runtime, key, kind, queue string, maxAttempts int) *Job {
+	return enqueueTestJobWithPause(t, runtime, key, kind, queue, maxAttempts, false)
+}
+
+func enqueuePausableTestJob(t *testing.T, runtime *Runtime, key, kind, queue string, maxAttempts int) *Job {
+	return enqueueTestJobWithPause(t, runtime, key, kind, queue, maxAttempts, true)
+}
+
+func enqueueTestJobWithPause(t *testing.T, runtime *Runtime, key, kind, queue string, maxAttempts int, pausable bool) *Job {
 	t.Helper()
 	ownerID := uint(7)
 	job, _, err := runtime.Enqueue(context.Background(), JobSpec{
-		Kind: kind, Visibility: VisibilityUser, OwnerID: &ownerID, IdempotencyKey: key, Label: key,
+		Kind: kind, Visibility: VisibilityUser, OwnerID: &ownerID, IdempotencyKey: key, Label: key, Pausable: pausable,
 		Tasks: []TaskSpec{{Kind: kind, Queue: queue, Phase: "Working", DedupeKey: kind, Required: true, Weight: 1, MaxAttempts: maxAttempts}},
 	})
 	if err != nil {
@@ -340,7 +348,7 @@ func TestPauseRunningJobCheckpointsAndResumes(t *testing.T) {
 		t.Fatal(err)
 	}
 	startTestRuntime(t, runtime)
-	job := enqueueTestJob(t, runtime, "pause-running", "test.pause", QueueStorage, 2)
+	job := enqueuePausableTestJob(t, runtime, "pause-running", "test.pause", QueueStorage, 2)
 	select {
 	case <-started:
 	case <-time.After(2 * time.Second):
@@ -371,7 +379,7 @@ func TestPauseRunningJobCheckpointsAndResumes(t *testing.T) {
 
 func TestQueuedJobCanBePausedAndCanceledWithoutExecution(t *testing.T) {
 	runtime, _ := testRuntime(t)
-	job := enqueueTestJob(t, runtime, "pause-queued", "test.pause.queued", QueueStorage, 1)
+	job := enqueuePausableTestJob(t, runtime, "pause-queued", "test.pause.queued", QueueStorage, 1)
 	if err := runtime.PauseJob(context.Background(), job.ID, 1, "admin"); err != nil {
 		t.Fatalf("pause queued job: %v", err)
 	}
@@ -388,9 +396,84 @@ func TestQueuedJobCanBePausedAndCanceledWithoutExecution(t *testing.T) {
 	}
 }
 
+func TestPauseIsRejectedForJobsWithoutDurablePauseSupport(t *testing.T) {
+	runtime, _ := testRuntime(t)
+	job := enqueueTestJob(t, runtime, "pause-unsupported", "test.pause.unsupported", QueueStorage, 1)
+	if job.Pausable || job.CanPause || job.CanResume {
+		t.Fatalf("non-pausable job advertised pause support: %#v", job)
+	}
+	if err := runtime.PauseJob(context.Background(), job.ID, 1, "admin"); !errors.Is(err, ErrConflict) {
+		t.Fatalf("expected unsupported pause to conflict, got %v", err)
+	}
+}
+
+func TestLegacyPausedJobCanResumeWithoutAdvertisingNewPauses(t *testing.T) {
+	runtime, db := testRuntime(t)
+	job := enqueueTestJob(t, runtime, "legacy-paused", "test.legacy.pause", QueueStorage, 1)
+	now := time.Now()
+	if err := db.Model(&Job{}).Where("id = ?", job.ID).Updates(map[string]any{
+		"status": JobPaused, "pause_requested_at": &now, "paused_at": &now,
+	}).Error; err != nil {
+		t.Fatal(err)
+	}
+	detail, err := runtime.Job(context.Background(), job.ID, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detail.Pausable || detail.CanPause || !detail.CanResume {
+		t.Fatalf("legacy paused job capabilities are unsafe: %#v", detail.Job)
+	}
+	if err := runtime.ResumeJob(context.Background(), job.ID, 1, "admin"); err != nil {
+		t.Fatal(err)
+	}
+	detail, err = runtime.Job(context.Background(), job.ID, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detail.Status != JobQueued || detail.CanPause || detail.CanResume {
+		t.Fatalf("legacy job did not resume without gaining pause support: %#v", detail.Job)
+	}
+}
+
+func TestMigrateBackfillsStorageMigrationPauseCapability(t *testing.T) {
+	runtime, db := testRuntime(t)
+	job := enqueueTestJob(t, runtime, "legacy-storage-migration", "storage.migration", QueueStorage, 1)
+	if job.Pausable {
+		t.Fatal("test precondition expected a legacy non-pausable job")
+	}
+	if err := Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	detail, err := runtime.Job(context.Background(), job.ID, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !detail.Pausable || !detail.CanPause {
+		t.Fatalf("storage migration pause capability was not backfilled: %#v", detail.Job)
+	}
+}
+
+func TestPausedJobRemainsPausedAcrossRecovery(t *testing.T) {
+	runtime, _ := testRuntime(t)
+	job := enqueuePausableTestJob(t, runtime, "pause-restart", "test.pause.restart", QueueStorage, 1)
+	if err := runtime.PauseJob(context.Background(), job.ID, 1, "admin"); err != nil {
+		t.Fatal(err)
+	}
+	if err := runtime.Recover(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	detail, err := runtime.Job(context.Background(), job.ID, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detail.Status != JobPaused || !detail.Pausable || detail.CanPause || !detail.CanResume {
+		t.Fatalf("paused job changed during recovery: %#v", detail.Job)
+	}
+}
+
 func TestPausedJobIsNotCountedAsDispatchableQueueWork(t *testing.T) {
 	runtime, _ := testRuntime(t)
-	job := enqueueTestJob(t, runtime, "pause-queue-summary", "test.pause.summary", QueueStorage, 1)
+	job := enqueuePausableTestJob(t, runtime, "pause-queue-summary", "test.pause.summary", QueueStorage, 1)
 	if err := runtime.PauseJob(context.Background(), job.ID, 1, "admin"); err != nil {
 		t.Fatalf("pause queued job: %v", err)
 	}
@@ -420,7 +503,7 @@ func TestPauseIsRejectedAfterIrreversibleCommit(t *testing.T) {
 		t.Fatal(err)
 	}
 	startTestRuntime(t, runtime)
-	job := enqueueTestJob(t, runtime, "pause-commit", "test.pause.commit", QueueStorage, 1)
+	job := enqueuePausableTestJob(t, runtime, "pause-commit", "test.pause.commit", QueueStorage, 1)
 	select {
 	case <-committed:
 	case <-time.After(2 * time.Second):

--- a/background/store.go
+++ b/background/store.go
@@ -49,6 +49,7 @@ func (r *Runtime) Enqueue(ctx context.Context, spec JobSpec) (*Job, bool, error)
 			SubjectID:      boundedMessage(spec.SubjectID, 128),
 			IdempotencyKey: spec.IdempotencyKey,
 			Label:          boundedMessage(spec.Label, 255),
+			Pausable:       spec.Pausable,
 			Progress:       0,
 		}
 		if err := tx.Create(&job).Error; err != nil {
@@ -101,7 +102,7 @@ func validateIdempotentReuse(tx *gorm.DB, job Job, spec JobSpec) error {
 	}
 	ownerMatches := (job.OwnerID == nil && spec.OwnerID == nil) ||
 		(job.OwnerID != nil && spec.OwnerID != nil && *job.OwnerID == *spec.OwnerID)
-	if job.Kind != spec.Kind || job.Visibility != visibility || !ownerMatches ||
+	if job.Kind != spec.Kind || job.Visibility != visibility || job.Pausable != spec.Pausable || !ownerMatches ||
 		job.SubjectType != boundedMessage(spec.SubjectType, 64) || job.SubjectID != boundedMessage(spec.SubjectID, 128) {
 		return ErrIdempotencyConflict
 	}
@@ -313,7 +314,9 @@ func pausableJobStatus(status string) bool {
 
 func populateJobCapabilities(job *Job) {
 	job.CanCancel = cancellableJobStatus(job.Status)
-	job.CanPause = pausableJobStatus(job.Status)
+	job.CanPause = job.Pausable && pausableJobStatus(job.Status)
+	// A job paused by an older release must remain resumable even if that job
+	// kind no longer opts in to initiating new pauses.
 	job.CanResume = job.Status == JobPauseRequested || job.Status == JobPaused
 }
 

--- a/background/store.go
+++ b/background/store.go
@@ -169,6 +169,7 @@ func createTask(tx *gorm.DB, jobID string, spec TaskSpec) (*Task, error) {
 		Required:       spec.Required,
 		Weight:         spec.Weight,
 		MaxAttempts:    spec.MaxAttempts,
+		RunAfter:       spec.RunAfter,
 	}
 	if err := tx.Create(task).Error; err != nil {
 		return nil, err
@@ -204,7 +205,7 @@ func (r *Runtime) Job(ctx context.Context, id string, ownerID *uint, admin bool)
 		Find(&job.Tasks).Error; err != nil {
 		return nil, err
 	}
-	job.CanCancel = cancellableJobStatus(job.Status)
+	populateJobCapabilities(&job)
 	if job.CanCancel {
 		for _, task := range job.Tasks {
 			if task.CommitStartedAt != nil && (task.Status == TaskRunning || task.Status == TaskCancelRequested) {
@@ -294,6 +295,15 @@ func (r *Runtime) ListJobs(ctx context.Context, filter ListFilter) ([]Job, error
 
 func cancellableJobStatus(status string) bool {
 	switch status {
+	case JobQueued, JobRunning, JobRetryWait, JobPauseRequested, JobPaused:
+		return true
+	default:
+		return false
+	}
+}
+
+func pausableJobStatus(status string) bool {
+	switch status {
 	case JobQueued, JobRunning, JobRetryWait:
 		return true
 	default:
@@ -301,11 +311,17 @@ func cancellableJobStatus(status string) bool {
 	}
 }
 
+func populateJobCapabilities(job *Job) {
+	job.CanCancel = cancellableJobStatus(job.Status)
+	job.CanPause = pausableJobStatus(job.Status)
+	job.CanResume = job.Status == JobPauseRequested || job.Status == JobPaused
+}
+
 func (r *Runtime) populateCancellationCapabilities(ctx context.Context, jobs []Job) error {
 	jobIDs := make([]string, 0, len(jobs))
 	for index := range jobs {
-		jobs[index].CanCancel = cancellableJobStatus(jobs[index].Status)
-		if jobs[index].CanCancel {
+		populateJobCapabilities(&jobs[index])
+		if jobs[index].CanCancel || jobs[index].CanPause {
 			jobIDs = append(jobIDs, jobs[index].ID)
 		}
 	}
@@ -326,6 +342,7 @@ func (r *Runtime) populateCancellationCapabilities(ctx context.Context, jobs []J
 	for index := range jobs {
 		if _, exists := committing[jobs[index].ID]; exists {
 			jobs[index].CanCancel = false
+			jobs[index].CanPause = false
 		}
 	}
 	return nil
@@ -337,6 +354,9 @@ func (r *Runtime) Summary(ctx context.Context) (Summary, error) {
 		return result, err
 	}
 	if err := r.db.WithContext(ctx).Model(&Job{}).Where("status IN ?", []string{JobQueued, JobRetryWait, JobCancelRequested}).Count(&result.Waiting).Error; err != nil {
+		return result, err
+	}
+	if err := r.db.WithContext(ctx).Model(&Job{}).Where("status IN ?", []string{JobPauseRequested, JobPaused}).Count(&result.Paused).Error; err != nil {
 		return result, err
 	}
 	if err := r.db.WithContext(ctx).Model(&Job{}).Where("status = ? AND finished_at >= ?", JobFailed, time.Now().Add(-24*time.Hour)).Count(&result.Failed24h).Error; err != nil {

--- a/background/types.go
+++ b/background/types.go
@@ -65,6 +65,7 @@ type Job struct {
 	ResultID          string     `gorm:"size:128" json:"resultId,omitempty"`
 	ErrorCode         string     `gorm:"size:80" json:"errorCode,omitempty"`
 	ErrorMessage      string     `gorm:"size:512" json:"errorMessage,omitempty"`
+	Pausable          bool       `json:"pausable"`
 	PauseRequestedAt  *time.Time `gorm:"index" json:"pauseRequestedAt,omitempty"`
 	PausedAt          *time.Time `gorm:"index" json:"pausedAt,omitempty"`
 	CancelRequestedAt *time.Time `json:"cancelRequestedAt,omitempty"`
@@ -203,6 +204,7 @@ type JobSpec struct {
 	SubjectID      string
 	IdempotencyKey string
 	Label          string
+	Pausable       bool
 	Tasks          []TaskSpec
 }
 
@@ -300,6 +302,14 @@ func marshalPayload(value any) (string, error) {
 
 func Migrate(db *gorm.DB) error {
 	if err := db.AutoMigrate(&Job{}, &Task{}, &Attempt{}, &Event{}, &QueueState{}, &ScheduleState{}, &MigrationState{}); err != nil {
+		return err
+	}
+	// Storage migration pause support shipped before pause eligibility became an
+	// explicit persisted capability. Preserve pause/resume for jobs created by
+	// that version while keeping every other job opted out by default.
+	if err := db.Model(&Job{}).Where("pausable = ? AND kind IN ?", false, []string{
+		"storage.migration", "storage.migration.cleanup", "storage.migration.abort_cleanup",
+	}).Update("pausable", true).Error; err != nil {
 		return err
 	}
 	if db.Dialector.Name() != "sqlite" {

--- a/background/types.go
+++ b/background/types.go
@@ -13,6 +13,8 @@ const (
 	JobQueued                = "queued"
 	JobRunning               = "running"
 	JobRetryWait             = "retry_wait"
+	JobPauseRequested        = "pause_requested"
+	JobPaused                = "paused"
 	JobCancelRequested       = "cancel_requested"
 	JobSucceeded             = "succeeded"
 	JobSucceededWithWarnings = "succeeded_with_warnings"
@@ -63,7 +65,11 @@ type Job struct {
 	ResultID          string     `gorm:"size:128" json:"resultId,omitempty"`
 	ErrorCode         string     `gorm:"size:80" json:"errorCode,omitempty"`
 	ErrorMessage      string     `gorm:"size:512" json:"errorMessage,omitempty"`
+	PauseRequestedAt  *time.Time `gorm:"index" json:"pauseRequestedAt,omitempty"`
+	PausedAt          *time.Time `gorm:"index" json:"pausedAt,omitempty"`
 	CancelRequestedAt *time.Time `json:"cancelRequestedAt,omitempty"`
+	CanPause          bool       `gorm:"-" json:"canPause"`
+	CanResume         bool       `gorm:"-" json:"canResume"`
 	CanCancel         bool       `gorm:"-" json:"canCancel"`
 	StartedAt         *time.Time `json:"startedAt,omitempty"`
 	FinishedAt        *time.Time `gorm:"index" json:"finishedAt,omitempty"`
@@ -185,6 +191,7 @@ type TaskSpec struct {
 	Required       bool
 	Weight         int
 	MaxAttempts    int
+	RunAfter       *time.Time
 	ParentTaskID   string
 }
 
@@ -238,6 +245,7 @@ type QueueSummary struct {
 type Summary struct {
 	Running      int64 `json:"running"`
 	Waiting      int64 `json:"waiting"`
+	Paused       int64 `json:"paused"`
 	Failed24h    int64 `json:"failed24h"`
 	PausedQueues int64 `json:"pausedQueues"`
 }

--- a/controllers/BackgroundJobController.go
+++ b/controllers/BackgroundJobController.go
@@ -67,6 +67,30 @@ func (h *Handlers) RetryMyBackgroundJob(c echo.Context) error {
 	return c.NoContent(http.StatusAccepted)
 }
 
+func (h *Handlers) PauseMyBackgroundJob(c echo.Context) error {
+	userID := c.Get("UserID").(uint)
+	if _, err := h.background().Job(c.Request().Context(), c.Param("id"), &userID, false); err != nil {
+		return backgroundAPIError(c, err)
+	}
+	username, _ := c.Get("Username").(string)
+	if err := h.background().PauseJob(c.Request().Context(), c.Param("id"), userID, username); err != nil {
+		return backgroundAPIError(c, err)
+	}
+	return c.NoContent(http.StatusAccepted)
+}
+
+func (h *Handlers) ResumeMyBackgroundJob(c echo.Context) error {
+	userID := c.Get("UserID").(uint)
+	if _, err := h.background().Job(c.Request().Context(), c.Param("id"), &userID, false); err != nil {
+		return backgroundAPIError(c, err)
+	}
+	username, _ := c.Get("Username").(string)
+	if err := h.background().ResumeJob(c.Request().Context(), c.Param("id"), userID, username); err != nil {
+		return backgroundAPIError(c, err)
+	}
+	return c.NoContent(http.StatusAccepted)
+}
+
 func (h *Handlers) ListAdminBackgroundJobs(c echo.Context) error {
 	return h.listBackgroundJobs(c, background.ListFilter{IncludeSystem: queryBool(c.QueryParam("includeSystem"))})
 }
@@ -88,19 +112,63 @@ func (h *Handlers) GetAdminBackgroundSummary(c echo.Context) error {
 }
 
 func (h *Handlers) CancelAdminBackgroundJob(c echo.Context) error {
+	detail, err := h.background().Job(c.Request().Context(), c.Param("id"), nil, true)
+	if err != nil {
+		return backgroundAPIError(c, err)
+	}
 	actorID, actorName := backgroundActor(c)
 	if err := h.background().CancelJob(c.Request().Context(), c.Param("id"), actorID, actorName); err != nil {
 		return backgroundAPIError(c, err)
+	}
+	if err := h.Logic.ReflectStorageMigrationJobControl(c.Request().Context(), detail.Job, "cancel", actorID, actorName); err != nil {
+		return storageMigrationError(c, err)
 	}
 	return c.NoContent(http.StatusAccepted)
 }
 
 func (h *Handlers) RetryAdminBackgroundJob(c echo.Context) error {
+	detail, err := h.background().Job(c.Request().Context(), c.Param("id"), nil, true)
+	if err != nil {
+		return backgroundAPIError(c, err)
+	}
 	actorID, actorName := backgroundActor(c)
 	if err := h.background().RetryJob(c.Request().Context(), c.Param("id"), actorID, actorName); err != nil {
 		return backgroundAPIError(c, err)
 	}
+	if err := h.Logic.ReflectStorageMigrationJobControl(c.Request().Context(), detail.Job, "retry", actorID, actorName); err != nil {
+		return storageMigrationError(c, err)
+	}
 	h.background().Wake()
+	return c.NoContent(http.StatusAccepted)
+}
+
+func (h *Handlers) PauseAdminBackgroundJob(c echo.Context) error {
+	detail, err := h.background().Job(c.Request().Context(), c.Param("id"), nil, true)
+	if err != nil {
+		return backgroundAPIError(c, err)
+	}
+	actorID, actorName := backgroundActor(c)
+	if err := h.background().PauseJob(c.Request().Context(), c.Param("id"), actorID, actorName); err != nil {
+		return backgroundAPIError(c, err)
+	}
+	if err := h.Logic.ReflectStorageMigrationJobControl(c.Request().Context(), detail.Job, "pause", actorID, actorName); err != nil {
+		return storageMigrationError(c, err)
+	}
+	return c.NoContent(http.StatusAccepted)
+}
+
+func (h *Handlers) ResumeAdminBackgroundJob(c echo.Context) error {
+	detail, err := h.background().Job(c.Request().Context(), c.Param("id"), nil, true)
+	if err != nil {
+		return backgroundAPIError(c, err)
+	}
+	actorID, actorName := backgroundActor(c)
+	if err := h.background().ResumeJob(c.Request().Context(), c.Param("id"), actorID, actorName); err != nil {
+		return backgroundAPIError(c, err)
+	}
+	if err := h.Logic.ReflectStorageMigrationJobControl(c.Request().Context(), detail.Job, "resume", actorID, actorName); err != nil {
+		return storageMigrationError(c, err)
+	}
 	return c.NoContent(http.StatusAccepted)
 }
 

--- a/controllers/StorageMigrationController.go
+++ b/controllers/StorageMigrationController.go
@@ -1,0 +1,133 @@
+package controllers
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"ch/kirari04/videocms/logic"
+
+	"github.com/labstack/echo/v4"
+	"gorm.io/gorm"
+)
+
+func (h *Handlers) PreviewStorageMigration(c echo.Context) error {
+	request := new(logic.StorageMigrationInput)
+	if err := c.Bind(request); err != nil {
+		return c.JSON(http.StatusBadRequest, echo.Map{"error": "invalid_request"})
+	}
+	preview, err := h.Logic.PreviewStorageMigration(c.Request().Context(), *request)
+	if err != nil {
+		return storageMigrationError(c, err)
+	}
+	return c.JSON(http.StatusOK, preview)
+}
+
+func (h *Handlers) CreateStorageMigration(c echo.Context) error {
+	request := new(logic.StorageMigrationInput)
+	if err := c.Bind(request); err != nil || request.SourcePoolID == 0 || request.DestinationPoolID == 0 {
+		return c.JSON(http.StatusBadRequest, echo.Map{"error": "invalid_request"})
+	}
+	actorID, actorName := backgroundActor(c)
+	migration, job, err := h.Logic.StartStorageMigration(c.Request().Context(), *request, actorID, actorName)
+	if err != nil {
+		return storageMigrationError(c, err)
+	}
+	location := "/api/v2/admin/storage/migrations/" + migration.UUID
+	c.Response().Header().Set("Location", location)
+	c.Response().Header().Set("Retry-After", "2")
+	return c.JSON(http.StatusAccepted, echo.Map{"migration": migration, "job": job, "retryAfterSeconds": 2})
+}
+
+func (h *Handlers) ListStorageMigrations(c echo.Context) error {
+	limit, _ := strconv.Atoi(c.QueryParam("limit"))
+	if limit < 1 || limit > 200 {
+		limit = 50
+	}
+	beforeID, _ := strconv.ParseUint(c.QueryParam("beforeId"), 10, 64)
+	migrations, err := h.Logic.ListStorageMigrations(c.Request().Context(), limit, uint(beforeID))
+	if err != nil {
+		return storageMigrationError(c, err)
+	}
+	summary, err := h.Logic.GetStorageMigrationSummary(c.Request().Context())
+	if err != nil {
+		return storageMigrationError(c, err)
+	}
+	response := echo.Map{"migrations": migrations, "summary": summary}
+	if len(migrations) == limit {
+		response["nextBeforeId"] = migrations[len(migrations)-1].ID
+	}
+	return c.JSON(http.StatusOK, response)
+}
+
+func (h *Handlers) GetStorageMigration(c echo.Context) error {
+	migration, err := h.Logic.GetStorageMigration(c.Request().Context(), c.Param("id"))
+	if err != nil {
+		return storageMigrationError(c, err)
+	}
+	response := echo.Map{"migration": migration}
+	if migration.BackgroundJobID != "" && h.Deps.Background != nil {
+		if job, jobErr := h.Deps.Background.Job(c.Request().Context(), migration.BackgroundJobID, nil, true); jobErr == nil {
+			response["job"] = job
+		}
+	}
+	if migration.CleanupJobID != "" && h.Deps.Background != nil {
+		if job, jobErr := h.Deps.Background.Job(c.Request().Context(), migration.CleanupJobID, nil, true); jobErr == nil {
+			response["cleanupJob"] = job
+		}
+	}
+	return c.JSON(http.StatusOK, response)
+}
+
+func (h *Handlers) ListStorageMigrationItems(c echo.Context) error {
+	migration, err := h.Logic.GetStorageMigration(c.Request().Context(), c.Param("id"))
+	if err != nil {
+		return storageMigrationError(c, err)
+	}
+	limit, _ := strconv.Atoi(c.QueryParam("limit"))
+	if limit < 1 || limit > 500 {
+		limit = 100
+	}
+	afterID, _ := strconv.ParseUint(c.QueryParam("afterId"), 10, 64)
+	items, err := h.Logic.ListStorageMigrationItems(c.Request().Context(), migration.ID, c.QueryParam("status"), limit, uint(afterID))
+	if err != nil {
+		return storageMigrationError(c, err)
+	}
+	response := echo.Map{"items": items}
+	if len(items) == limit {
+		response["nextAfterId"] = items[len(items)-1].ID
+	}
+	return c.JSON(http.StatusOK, response)
+}
+
+func (h *Handlers) KeepStorageMigrationOriginals(c echo.Context) error {
+	actorID, actorName := backgroundActor(c)
+	migration, err := h.Logic.KeepStorageMigrationOriginals(c.Request().Context(), c.Param("id"), actorID, actorName)
+	if err != nil {
+		return storageMigrationError(c, err)
+	}
+	return c.JSON(http.StatusOK, migration)
+}
+
+func (h *Handlers) CancelFailedStorageMigration(c echo.Context) error {
+	migration, err := h.Logic.CancelFailedStorageMigration(c.Request().Context(), c.Param("id"))
+	if err != nil {
+		return storageMigrationError(c, err)
+	}
+	return c.JSON(http.StatusAccepted, migration)
+}
+
+func storageMigrationError(c echo.Context, err error) error {
+	switch {
+	case errors.Is(err, gorm.ErrRecordNotFound):
+		return c.JSON(http.StatusNotFound, echo.Map{"error": "storage_migration_not_found"})
+	case errors.Is(err, logic.ErrStorageMigrationConflict):
+		return c.JSON(http.StatusConflict, echo.Map{"error": "storage_migration_conflict", "message": err.Error()})
+	case errors.Is(err, logic.ErrStorageMigrationEmpty):
+		return c.JSON(http.StatusUnprocessableEntity, echo.Map{"error": "storage_migration_empty", "message": err.Error()})
+	case errors.Is(err, logic.ErrStorageMigrationUnavailable):
+		return c.JSON(http.StatusUnprocessableEntity, echo.Map{"error": "storage_migration_unavailable", "message": err.Error()})
+	default:
+		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "storage_migration_failed"})
+	}
+}

--- a/controllers/StorageMigrationController.go
+++ b/controllers/StorageMigrationController.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"ch/kirari04/videocms/logic"
 
@@ -13,7 +14,7 @@ import (
 
 func (h *Handlers) PreviewStorageMigration(c echo.Context) error {
 	request := new(logic.StorageMigrationInput)
-	if err := c.Bind(request); err != nil {
+	if err := c.Bind(request); err != nil || request.SourcePoolID == 0 || request.DestinationPoolID == 0 {
 		return c.JSON(http.StatusBadRequest, echo.Map{"error": "invalid_request"})
 	}
 	preview, err := h.Logic.PreviewStorageMigration(c.Request().Context(), *request)
@@ -27,6 +28,10 @@ func (h *Handlers) CreateStorageMigration(c echo.Context) error {
 	request := new(logic.StorageMigrationInput)
 	if err := c.Bind(request); err != nil || request.SourcePoolID == 0 || request.DestinationPoolID == 0 {
 		return c.JSON(http.StatusBadRequest, echo.Map{"error": "invalid_request"})
+	}
+	request.IdempotencyKey = strings.TrimSpace(c.Request().Header.Get("Idempotency-Key"))
+	if request.IdempotencyKey == "" || strings.TrimSpace(request.PlanFingerprint) == "" {
+		return c.JSON(http.StatusBadRequest, echo.Map{"error": "migration_confirmation_required"})
 	}
 	actorID, actorName := backgroundActor(c)
 	migration, job, err := h.Logic.StartStorageMigration(c.Request().Context(), *request, actorID, actorName)
@@ -45,7 +50,11 @@ func (h *Handlers) ListStorageMigrations(c echo.Context) error {
 		limit = 50
 	}
 	beforeID, _ := strconv.ParseUint(c.QueryParam("beforeId"), 10, 64)
-	migrations, err := h.Logic.ListStorageMigrations(c.Request().Context(), limit, uint(beforeID))
+	filter := strings.TrimSpace(c.QueryParam("status"))
+	if _, valid := logic.StorageMigrationStatusesForFilter(filter); !valid {
+		return c.JSON(http.StatusBadRequest, echo.Map{"error": "invalid_status_filter"})
+	}
+	migrations, err := h.Logic.ListStorageMigrations(c.Request().Context(), filter, limit, uint(beforeID))
 	if err != nil {
 		return storageMigrationError(c, err)
 	}

--- a/inits/Models.go
+++ b/inits/Models.go
@@ -58,6 +58,8 @@ func MigrateModels(gormDB *gorm.DB) error {
 		&models.StorageMount{},
 		&models.StoragePool{},
 		&models.StoragePoolMount{},
+		&models.StorageMigration{},
+		&models.StorageMigrationItem{},
 		&models.User{},
 		&models.Folder{},
 		&models.File{},

--- a/logic/LinkThumbnail.go
+++ b/logic/LinkThumbnail.go
@@ -47,6 +47,14 @@ func (s *Service) UpdateLinkThumbnail(linkID uint, userID uint, isAdmin bool, in
 	if err != nil {
 		return status, err
 	}
+	releaseFile := s.Deps.StorageLifecycle.FileReadLock(dbLink.FileID)
+	defer releaseFile()
+	dbLink, status, err = s.loadThumbnailLink(linkID, userID, isAdmin)
+	if err != nil {
+		return status, err
+	}
+	releaseMount := s.Deps.StorageLifecycle.ReadLock(dbLink.File.StorageID)
+	defer releaseMount()
 
 	if fileSize <= 0 {
 		return http.StatusBadRequest, errors.New("thumbnail is empty")
@@ -159,6 +167,14 @@ func (s *Service) ResetLinkThumbnail(linkID uint, userID uint, isAdmin bool) (st
 	if err != nil {
 		return status, err
 	}
+	releaseFile := s.Deps.StorageLifecycle.FileReadLock(dbLink.FileID)
+	defer releaseFile()
+	dbLink, status, err = s.loadThumbnailLink(linkID, userID, isAdmin)
+	if err != nil {
+		return status, err
+	}
+	releaseMount := s.Deps.StorageLifecycle.ReadLock(dbLink.File.StorageID)
+	defer releaseMount()
 	if dbLink.Thumbnail == "" {
 		return http.StatusOK, nil
 	}
@@ -202,6 +218,13 @@ func (s *Service) RemoveLinkThumbnailFile(link models.Link) {
 	if link.Thumbnail == "" {
 		return
 	}
+	releaseFile := s.Deps.StorageLifecycle.FileReadLock(link.FileID)
+	defer releaseFile()
+	if err := s.Deps.DB.Preload("File").First(&link, link.ID).Error; err != nil || link.Thumbnail == "" {
+		return
+	}
+	releaseMount := s.Deps.StorageLifecycle.ReadLock(link.File.StorageID)
+	defer releaseMount()
 	store, layout, err := s.mediaStorage(link.File.StorageID)
 	if err != nil {
 		log.Printf("Failed to resolve custom thumbnail storage for link %s: %v", link.UUID, err)

--- a/logic/StorageAdmin.go
+++ b/logic/StorageAdmin.go
@@ -249,9 +249,15 @@ func (s *Service) UpdateStorageMount(ctx context.Context, mountID uint, input St
 	if mount.System {
 		return models.StorageMount{}, errors.New("storage mount cannot be edited")
 	}
+	if err := s.ensureStorageMountNotMigrating(mount.UUID); err != nil {
+		return models.StorageMount{}, err
+	}
 	releaseMount := s.Deps.StorageLifecycle.WriteLock(mount.UUID)
 	defer releaseMount()
 	if err := s.Deps.DB.First(&mount, mountID).Error; err != nil {
+		return models.StorageMount{}, err
+	}
+	if err := s.ensureStorageMountNotMigrating(mount.UUID); err != nil {
 		return models.StorageMount{}, err
 	}
 	input.Name = strings.TrimSpace(input.Name)
@@ -364,9 +370,15 @@ func (s *Service) UnmountStorageMount(mountID uint) (int64, error) {
 	if mount.System {
 		return 0, errors.New("built-in local storage cannot be unmounted")
 	}
+	if err := s.ensureStorageMountNotMigrating(mount.UUID); err != nil {
+		return 0, err
+	}
 	releaseMount := s.Deps.StorageLifecycle.WriteLock(mount.UUID)
 	defer releaseMount()
 	if err := s.Deps.DB.First(&mount, mountID).Error; err != nil {
+		return 0, err
+	}
+	if err := s.ensureStorageMountNotMigrating(mount.UUID); err != nil {
 		return 0, err
 	}
 	if !mount.Mounted {
@@ -415,10 +427,16 @@ func (s *Service) DeleteStorageMount(mountID uint) (int64, error) {
 	if mount.System {
 		return 0, errors.New("built-in local storage cannot be deleted")
 	}
+	if err := s.ensureStorageMountNotMigrating(mount.UUID); err != nil {
+		return 0, err
+	}
 
 	releaseMount := s.Deps.StorageLifecycle.WriteLock(mount.UUID)
 	defer releaseMount()
 	if err := s.Deps.DB.First(&mount, mountID).Error; err != nil {
+		return 0, err
+	}
+	if err := s.ensureStorageMountNotMigrating(mount.UUID); err != nil {
 		return 0, err
 	}
 	if mount.Mounted {
@@ -786,9 +804,19 @@ func (s *Service) UpdateStoragePool(poolID uint, input StoragePoolInput) (models
 }
 
 func (s *Service) saveStoragePool(pool *models.StoragePool, input StoragePoolInput) error {
+	var releasePool func()
+	if pool.ID > 0 {
+		releasePool = s.Deps.StorageLifecycle.PoolWriteLock(pool.ID)
+		defer releasePool()
+	}
 	input.Name = strings.TrimSpace(input.Name)
 	if input.Name == "" {
 		return errors.New("storage pool name is required")
+	}
+	if pool.ID > 0 {
+		if err := s.ensureStoragePoolNotMigrating(pool.ID); err != nil {
+			return err
+		}
 	}
 	mountIDs := uniqueUintValues(input.MountIDs)
 	if len(mountIDs) == 0 {
@@ -847,6 +875,11 @@ func (s *Service) SetDefaultStoragePool(poolID uint) error {
 }
 
 func (s *Service) DeleteStoragePool(poolID uint) error {
+	releasePool := s.Deps.StorageLifecycle.PoolWriteLock(poolID)
+	defer releasePool()
+	if err := s.ensureStoragePoolNotMigrating(poolID); err != nil {
+		return err
+	}
 	return s.Deps.DB.Transaction(func(tx *gorm.DB) error {
 		var pool models.StoragePool
 		if err := tx.First(&pool, poolID).Error; err != nil {

--- a/logic/StorageMigration.go
+++ b/logic/StorageMigration.go
@@ -2,6 +2,7 @@ package logic
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"sort"
@@ -23,8 +24,10 @@ var (
 )
 
 type StorageMigrationInput struct {
-	SourcePoolID      uint `json:"sourcePoolId" validate:"required"`
-	DestinationPoolID uint `json:"destinationPoolId" validate:"required"`
+	SourcePoolID      uint   `json:"sourcePoolId" validate:"required"`
+	DestinationPoolID uint   `json:"destinationPoolId" validate:"required"`
+	PlanFingerprint   string `json:"planFingerprint,omitempty"`
+	IdempotencyKey    string `json:"-"`
 }
 
 type StorageMigrationMountPreview struct {
@@ -54,6 +57,7 @@ type StorageMigrationPreview struct {
 	DestinationPlacements []StorageMigrationPlacementPreview `json:"destinationPlacements"`
 	Warnings              []string                           `json:"warnings"`
 	CleanupGraceHours     int                                `json:"cleanupGraceHours"`
+	PlanFingerprint       string                             `json:"planFingerprint"`
 }
 
 type StorageMigrationSummary struct {
@@ -86,6 +90,13 @@ func (s *Service) StartStorageMigration(ctx context.Context, input StorageMigrat
 	if s == nil || s.Deps == nil || s.Deps.Background == nil {
 		return nil, nil, errors.New("background work is not configured")
 	}
+	requestKey := storageMigrationRequestKey(actorID, input.IdempotencyKey)
+	if requestKey == "" {
+		return nil, nil, fmt.Errorf("%w: an idempotency key is required", ErrStorageMigrationConflict)
+	}
+	if migration, job, found, err := s.storageMigrationByRequest(ctx, requestKey, input); found || err != nil {
+		return migration, job, err
+	}
 	releasePools := s.Deps.StorageLifecycle.PoolReadLocks(input.SourcePoolID, input.DestinationPoolID)
 	defer releasePools()
 	plan, err := s.buildStorageMigrationPlan(ctx, input)
@@ -115,9 +126,15 @@ func (s *Service) StartStorageMigration(ctx context.Context, input StorageMigrat
 		return nil, nil, fmt.Errorf("%w: source videos changed during migration setup; review the preview again", ErrStorageMigrationConflict)
 	}
 	plan = validatedPlan
+	wantedFingerprint := strings.TrimSpace(input.PlanFingerprint)
+	if wantedFingerprint == "" || wantedFingerprint != plan.preview.PlanFingerprint {
+		return nil, nil, fmt.Errorf("%w: the migration preview changed; review it again before starting", ErrStorageMigrationConflict)
+	}
 	now := time.Now().UTC()
 	migration := &models.StorageMigration{
 		UUID:                uuid.NewString(),
+		RequestKey:          requestKey,
+		PlanFingerprint:     plan.preview.PlanFingerprint,
 		SourcePoolID:        input.SourcePoolID,
 		DestinationPoolID:   input.DestinationPoolID,
 		SourcePoolName:      plan.preview.SourcePoolName,
@@ -151,20 +168,15 @@ func (s *Service) StartStorageMigration(ctx context.Context, input StorageMigrat
 		return nil
 	})
 	if err != nil {
+		if isStorageMigrationUniqueError(err) {
+			if existing, job, found, loadErr := s.storageMigrationByRequest(context.WithoutCancel(ctx), requestKey, input); found || loadErr != nil {
+				return existing, job, loadErr
+			}
+		}
 		return nil, nil, err
 	}
 
-	job, _, enqueueErr := s.Deps.Background.Enqueue(ctx, background.JobSpec{
-		Kind: "storage.migration", Visibility: background.VisibilityAdmin,
-		SubjectType: "storage_migration", SubjectID: migration.UUID,
-		IdempotencyKey: "storage-migration:" + migration.UUID,
-		Label:          fmt.Sprintf("Migrate %s to %s", migration.SourcePoolName, migration.DestinationPoolName),
-		Tasks: []background.TaskSpec{{
-			Kind: "storage.migration.run", Queue: background.QueueStorage, Phase: "Migrating videos",
-			Payload: map[string]any{"migrationId": migration.ID}, DedupeKey: fmt.Sprintf("storage-migration:%d", migration.ID),
-			Priority: 20, Required: true, Weight: 1, MaxAttempts: 4,
-		}},
-	})
+	job, enqueueErr := s.ensureStorageMigrationJob(ctx, migration)
 	if enqueueErr != nil {
 		_ = s.Deps.DB.WithContext(context.WithoutCancel(ctx)).Transaction(func(tx *gorm.DB) error {
 			if err := tx.Model(&models.StorageMigrationItem{}).Where("migration_id = ?", migration.ID).Update("reservation_key", "").Error; err != nil {
@@ -187,6 +199,107 @@ func (s *Service) StartStorageMigration(ctx context.Context, input StorageMigrat
 	migration.BackgroundJobID = job.ID
 	migration.StartedAt = &now
 	return migration, job, nil
+}
+
+func storageMigrationRequestKey(actorID uint, value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%d:%s", actorID, value)))
+	return fmt.Sprintf("storage-migration-request:%x", sum)
+}
+
+func (s *Service) storageMigrationByRequest(ctx context.Context, requestKey string, input StorageMigrationInput) (*models.StorageMigration, *background.Job, bool, error) {
+	var migration models.StorageMigration
+	err := s.Deps.DB.WithContext(ctx).Where("request_key = ?", requestKey).First(&migration).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil, false, nil
+	}
+	if err != nil {
+		return nil, nil, false, err
+	}
+	if migration.SourcePoolID != input.SourcePoolID || migration.DestinationPoolID != input.DestinationPoolID ||
+		migration.PlanFingerprint != strings.TrimSpace(input.PlanFingerprint) {
+		return nil, nil, true, fmt.Errorf("%w: the idempotency key was already used for another migration request", ErrStorageMigrationConflict)
+	}
+	job, err := s.ensureStorageMigrationJob(context.WithoutCancel(ctx), &migration)
+	if err == nil && migration.Status == models.StorageMigrationFailed && migration.ErrorCode == "queue_failed" {
+		now := time.Now().UTC()
+		err = s.Deps.DB.WithContext(context.WithoutCancel(ctx)).Model(&migration).Updates(map[string]any{
+			"status": models.StorageMigrationQueued, "phase": "Waiting to start", "started_at": &now,
+			"background_job_id": job.ID, "error_code": "", "error_message": "",
+		}).Error
+		if err == nil {
+			migration.Status = models.StorageMigrationQueued
+			migration.Phase = "Waiting to start"
+			migration.StartedAt = &now
+			migration.BackgroundJobID = job.ID
+			migration.ErrorCode = ""
+			migration.ErrorMessage = ""
+		}
+	}
+	return &migration, job, true, err
+}
+
+func storageMigrationJobSpec(migration models.StorageMigration) background.JobSpec {
+	return background.JobSpec{
+		Kind: "storage.migration", Visibility: background.VisibilityAdmin,
+		SubjectType: "storage_migration", SubjectID: migration.UUID,
+		IdempotencyKey: "storage-migration:" + migration.UUID,
+		Label:          fmt.Sprintf("Migrate %s to %s", migration.SourcePoolName, migration.DestinationPoolName),
+		Pausable:       true,
+		Tasks: []background.TaskSpec{{
+			Kind: "storage.migration.run", Queue: background.QueueStorage, Phase: "Migrating videos",
+			Payload: map[string]any{"migrationId": migration.ID}, DedupeKey: fmt.Sprintf("storage-migration:%d", migration.ID),
+			Priority: 20, Required: true, Weight: 1, MaxAttempts: 4,
+		}},
+	}
+}
+
+func (s *Service) ensureStorageMigrationJob(ctx context.Context, migration *models.StorageMigration) (*background.Job, error) {
+	if migration == nil || migration.ID == 0 || s.Deps.Background == nil {
+		return nil, errors.New("background work is not configured")
+	}
+	if migration.BackgroundJobID != "" {
+		if detail, err := s.Deps.Background.Job(ctx, migration.BackgroundJobID, nil, true); err == nil {
+			return &detail.Job, nil
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, err
+		}
+	}
+	var existing background.Job
+	if err := s.Deps.DB.WithContext(ctx).
+		Where("kind = ? AND subject_type = ? AND subject_id = ?", "storage.migration", "storage_migration", migration.UUID).
+		Order("created_at DESC").First(&existing).Error; err == nil {
+		// The worker repairs this association when it starts. Once the durable
+		// job exists, an association write failure must not release reservations
+		// or encourage the caller to create another migration.
+		_ = s.Deps.DB.WithContext(context.WithoutCancel(ctx)).Model(migration).Update("background_job_id", existing.ID).Error
+		migration.BackgroundJobID = existing.ID
+		detail, err := s.Deps.Background.Job(context.WithoutCancel(ctx), existing.ID, nil, true)
+		if err != nil {
+			return nil, err
+		}
+		return &detail.Job, nil
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
+	job, _, err := s.Deps.Background.Enqueue(ctx, storageMigrationJobSpec(*migration))
+	if err != nil {
+		return nil, err
+	}
+	_ = s.Deps.DB.WithContext(context.WithoutCancel(ctx)).Model(migration).Update("background_job_id", job.ID).Error
+	migration.BackgroundJobID = job.ID
+	return job, nil
+}
+
+func (s *Service) EnsureStorageMigrationJob(ctx context.Context, migrationID uint) (*background.Job, error) {
+	var migration models.StorageMigration
+	if err := s.Deps.DB.WithContext(ctx).First(&migration, migrationID).Error; err != nil {
+		return nil, err
+	}
+	return s.ensureStorageMigrationJob(ctx, &migration)
 }
 
 func sameStorageMigrationFiles(first, second []models.File) bool {
@@ -326,7 +439,7 @@ func (s *Service) buildStorageMigrationPlan(ctx context.Context, input StorageMi
 	if overrideCount > 0 {
 		warnings = append(warnings, fmt.Sprintf("%d users still upload to the source pool.", overrideCount))
 	}
-	return storageMigrationPlan{
+	plan := storageMigrationPlan{
 		preview: StorageMigrationPreview{
 			SourcePoolID: sourcePool.ID, SourcePoolName: sourcePool.Name,
 			DestinationPoolID: destinationPool.ID, DestinationPoolName: destinationPool.Name,
@@ -335,7 +448,26 @@ func (s *Service) buildStorageMigrationPlan(ctx context.Context, input StorageMi
 			DestinationPlacements: placements, Warnings: warnings, CleanupGraceHours: 24,
 		},
 		files: files, destination: destination,
-	}, nil
+	}
+	plan.preview.PlanFingerprint = storageMigrationPlanFingerprint(plan)
+	return plan, nil
+}
+
+func storageMigrationPlanFingerprint(plan storageMigrationPlan) string {
+	digest := sha256.New()
+	_, _ = fmt.Fprintf(digest, "source-pool:%d\ndestination-pool:%d\n", plan.preview.SourcePoolID, plan.preview.DestinationPoolID)
+	for _, mount := range plan.preview.SourceMounts {
+		_, _ = fmt.Fprintf(digest, "source-mount:%s\n", mount.UUID)
+	}
+	for _, mount := range plan.preview.DestinationMounts {
+		_, _ = fmt.Fprintf(digest, "destination-mount:%s\n", mount.UUID)
+	}
+	files := append([]models.File(nil), plan.files...)
+	sort.Slice(files, func(i, j int) bool { return files[i].ID < files[j].ID })
+	for _, file := range files {
+		_, _ = fmt.Fprintf(digest, "file:%d:%s:%s:%d:%s\n", file.ID, file.UUID, file.StorageID, file.Size, plan.destination[file.ID])
+	}
+	return fmt.Sprintf("%x", digest.Sum(nil))
 }
 
 func (s *Service) storageMigrationMounts(ctx context.Context, pool models.StoragePool) ([]StorageMigrationMountPreview, []string, error) {
@@ -372,11 +504,35 @@ func isStorageMigrationUniqueError(err error) bool {
 	return errors.Is(err, gorm.ErrDuplicatedKey) || strings.Contains(message, "unique constraint") || strings.Contains(message, "duplicate key")
 }
 
-func (s *Service) ListStorageMigrations(ctx context.Context, limit int, beforeID uint) ([]models.StorageMigration, error) {
+func StorageMigrationStatusesForFilter(filter string) ([]string, bool) {
+	switch strings.TrimSpace(filter) {
+	case "":
+		return nil, true
+	case "active":
+		return []string{models.StorageMigrationQueued, models.StorageMigrationRunning, models.StorageMigrationPaused}, true
+	case "retention":
+		return []string{models.StorageMigrationRetainingOriginals, models.StorageMigrationCleaningOriginals, models.StorageMigrationOriginalsRetained}, true
+	case "attention":
+		return []string{models.StorageMigrationFailed, models.StorageMigrationCanceled}, true
+	case "complete":
+		return []string{models.StorageMigrationCompleted}, true
+	default:
+		return nil, false
+	}
+}
+
+func (s *Service) ListStorageMigrations(ctx context.Context, filter string, limit int, beforeID uint) ([]models.StorageMigration, error) {
 	if limit < 1 || limit > 200 {
 		limit = 50
 	}
+	statuses, valid := StorageMigrationStatusesForFilter(filter)
+	if !valid {
+		return nil, fmt.Errorf("%w: unknown migration status filter", ErrStorageMigrationConflict)
+	}
 	query := s.Deps.DB.WithContext(ctx).Model(&models.StorageMigration{})
+	if len(statuses) > 0 {
+		query = query.Where("status IN ?", statuses)
+	}
 	if beforeID > 0 {
 		query = query.Where("id < ?", beforeID)
 	}
@@ -514,9 +670,14 @@ func (s *Service) KeepStorageMigrationOriginals(ctx context.Context, migrationUU
 			if item.Status == models.StorageMigrationItemCleaned {
 				return nil
 			}
+			status := models.StorageMigrationItemOriginalKept
+			message := "Original retained by administrator"
+			if item.Status == models.StorageMigrationItemCleaning {
+				status = models.StorageMigrationItemOriginalPartial
+				message = "Original cleanup was incomplete; remaining data retained"
+			}
 			return tx.Model(item).Updates(map[string]any{
-				"status": models.StorageMigrationItemOriginalKept, "reservation_key": "",
-				"progress_message": "Original retained by administrator",
+				"status": status, "reservation_key": "", "progress_message": message,
 			}).Error
 		})
 		releaseFile()
@@ -524,7 +685,7 @@ func (s *Service) KeepStorageMigrationOriginals(ctx context.Context, migrationUU
 			return models.StorageMigration{}, err
 		}
 	}
-	var cleaned int64
+	var cleaned, partial int64
 	now := time.Now().UTC()
 	err = s.Deps.DB.WithContext(durableCtx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Model(&models.StorageMigrationItem{}).
@@ -532,9 +693,20 @@ func (s *Service) KeepStorageMigrationOriginals(ctx context.Context, migrationUU
 			Count(&cleaned).Error; err != nil {
 			return err
 		}
+		if err := tx.Model(&models.StorageMigrationItem{}).
+			Where("migration_id = ? AND status = ?", migration.ID, models.StorageMigrationItemOriginalPartial).
+			Count(&partial).Error; err != nil {
+			return err
+		}
 		phase := "Original copies retained"
 		if cleaned > 0 {
 			phase = fmt.Sprintf("Originals retained; %d had already been removed", cleaned)
+		}
+		if partial > 0 {
+			phase = fmt.Sprintf("Originals retained; %d may be incomplete after a storage error", partial)
+			if cleaned > 0 {
+				phase = fmt.Sprintf("Originals retained; %d removed and %d may be incomplete", cleaned, partial)
+			}
 		}
 		return tx.Model(&migration).Updates(map[string]any{
 			"status": models.StorageMigrationOriginalsRetained, "phase": phase, "keep_originals": true,
@@ -684,6 +856,7 @@ func (s *Service) queueStorageMigrationAbort(ctx context.Context, migration *mod
 		SubjectType: "storage_migration", SubjectID: migration.UUID,
 		IdempotencyKey: fmt.Sprintf("storage-migration-abort:%s:%d", migration.UUID, cancelGeneration),
 		Label:          fmt.Sprintf("Clean canceled migration to %s", migration.DestinationPoolName),
+		Pausable:       true,
 		Tasks: []background.TaskSpec{{
 			Kind: "storage.migration.abort_cleanup", Queue: background.QueueStorage, Phase: "Cleaning canceled migration",
 			Payload: map[string]any{"migrationId": migration.ID}, DedupeKey: fmt.Sprintf("storage-abort:%d", migration.ID),

--- a/logic/StorageMigration.go
+++ b/logic/StorageMigration.go
@@ -1,0 +1,703 @@
+package logic
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"ch/kirari04/videocms/background"
+	"ch/kirari04/videocms/models"
+	"ch/kirari04/videocms/storage"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+var (
+	ErrStorageMigrationConflict    = errors.New("storage migration conflicts with existing work")
+	ErrStorageMigrationEmpty       = errors.New("source pool contains no available videos")
+	ErrStorageMigrationUnavailable = errors.New("storage migration requires available mounts and media")
+)
+
+type StorageMigrationInput struct {
+	SourcePoolID      uint `json:"sourcePoolId" validate:"required"`
+	DestinationPoolID uint `json:"destinationPoolId" validate:"required"`
+}
+
+type StorageMigrationMountPreview struct {
+	ID        uint   `json:"id"`
+	UUID      string `json:"uuid"`
+	Name      string `json:"name"`
+	Provider  string `json:"provider"`
+	UsedBytes int64  `json:"usedBytes"`
+}
+
+type StorageMigrationPlacementPreview struct {
+	MountID      string `json:"mountId"`
+	MountName    string `json:"mountName"`
+	FileCount    int64  `json:"fileCount"`
+	PlannedBytes int64  `json:"plannedBytes"`
+}
+
+type StorageMigrationPreview struct {
+	SourcePoolID          uint                               `json:"sourcePoolId"`
+	SourcePoolName        string                             `json:"sourcePoolName"`
+	DestinationPoolID     uint                               `json:"destinationPoolId"`
+	DestinationPoolName   string                             `json:"destinationPoolName"`
+	FileCount             int64                              `json:"fileCount"`
+	PlannedBytes          int64                              `json:"plannedBytes"`
+	SourceMounts          []StorageMigrationMountPreview     `json:"sourceMounts"`
+	DestinationMounts     []StorageMigrationMountPreview     `json:"destinationMounts"`
+	DestinationPlacements []StorageMigrationPlacementPreview `json:"destinationPlacements"`
+	Warnings              []string                           `json:"warnings"`
+	CleanupGraceHours     int                                `json:"cleanupGraceHours"`
+}
+
+type StorageMigrationSummary struct {
+	Active             int64 `json:"active"`
+	RetainingOriginals int64 `json:"retainingOriginals"`
+	NeedsAttention     int64 `json:"needsAttention"`
+	VideosMoved        int64 `json:"videosMoved"`
+}
+
+type storageMigrationPlan struct {
+	preview     StorageMigrationPreview
+	files       []models.File
+	destination map[uint]string
+}
+
+type storageMountUsageRow struct {
+	UUID      string
+	UsedBytes int64
+}
+
+func (s *Service) PreviewStorageMigration(ctx context.Context, input StorageMigrationInput) (StorageMigrationPreview, error) {
+	plan, err := s.buildStorageMigrationPlan(ctx, input)
+	if err != nil {
+		return StorageMigrationPreview{}, err
+	}
+	return plan.preview, nil
+}
+
+func (s *Service) StartStorageMigration(ctx context.Context, input StorageMigrationInput, actorID uint, actorName string) (*models.StorageMigration, *background.Job, error) {
+	if s == nil || s.Deps == nil || s.Deps.Background == nil {
+		return nil, nil, errors.New("background work is not configured")
+	}
+	releasePools := s.Deps.StorageLifecycle.PoolReadLocks(input.SourcePoolID, input.DestinationPoolID)
+	defer releasePools()
+	plan, err := s.buildStorageMigrationPlan(ctx, input)
+	if err != nil {
+		return nil, nil, err
+	}
+	mountIDs := make([]string, 0, len(plan.preview.SourceMounts)+len(plan.preview.DestinationMounts))
+	for _, mount := range plan.preview.SourceMounts {
+		mountIDs = append(mountIDs, mount.UUID)
+	}
+	for _, mount := range plan.preview.DestinationMounts {
+		mountIDs = append(mountIDs, mount.UUID)
+	}
+	releaseMounts := s.Deps.StorageLifecycle.ReadLocks(mountIDs...)
+	defer releaseMounts()
+	fileIDs := make([]uint, 0, len(plan.files))
+	for _, file := range plan.files {
+		fileIDs = append(fileIDs, file.ID)
+	}
+	releaseFiles := s.Deps.StorageLifecycle.FileReadLocks(fileIDs...)
+	defer releaseFiles()
+	validatedPlan, err := s.buildStorageMigrationPlan(ctx, input)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !sameStorageMigrationFiles(plan.files, validatedPlan.files) {
+		return nil, nil, fmt.Errorf("%w: source videos changed during migration setup; review the preview again", ErrStorageMigrationConflict)
+	}
+	plan = validatedPlan
+	now := time.Now().UTC()
+	migration := &models.StorageMigration{
+		UUID:                uuid.NewString(),
+		SourcePoolID:        input.SourcePoolID,
+		DestinationPoolID:   input.DestinationPoolID,
+		SourcePoolName:      plan.preview.SourcePoolName,
+		DestinationPoolName: plan.preview.DestinationPoolName,
+		Status:              models.StorageMigrationQueued,
+		Phase:               "Waiting to start",
+		FileCount:           plan.preview.FileCount,
+		PlannedBytes:        plan.preview.PlannedBytes,
+		CreatedByID:         actorID,
+		CreatedByName:       strings.TrimSpace(actorName),
+	}
+	err = s.Deps.DB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Create(migration).Error; err != nil {
+			return err
+		}
+		items := make([]models.StorageMigrationItem, 0, len(plan.files))
+		for _, file := range plan.files {
+			items = append(items, models.StorageMigrationItem{
+				MigrationID: migration.ID, FileID: file.ID, FileUUID: file.UUID,
+				SourceMountID: file.StorageID, DestinationMountID: plan.destination[file.ID],
+				Status: models.StorageMigrationItemPending, ReservationKey: fmt.Sprintf("file:%d", file.ID),
+				PlannedBytes: file.Size, ProgressMessage: "Waiting to copy",
+			})
+		}
+		if err := tx.CreateInBatches(&items, 100).Error; err != nil {
+			if isStorageMigrationUniqueError(err) {
+				return ErrStorageMigrationConflict
+			}
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	job, _, enqueueErr := s.Deps.Background.Enqueue(ctx, background.JobSpec{
+		Kind: "storage.migration", Visibility: background.VisibilityAdmin,
+		SubjectType: "storage_migration", SubjectID: migration.UUID,
+		IdempotencyKey: "storage-migration:" + migration.UUID,
+		Label:          fmt.Sprintf("Migrate %s to %s", migration.SourcePoolName, migration.DestinationPoolName),
+		Tasks: []background.TaskSpec{{
+			Kind: "storage.migration.run", Queue: background.QueueStorage, Phase: "Migrating videos",
+			Payload: map[string]any{"migrationId": migration.ID}, DedupeKey: fmt.Sprintf("storage-migration:%d", migration.ID),
+			Priority: 20, Required: true, Weight: 1, MaxAttempts: 4,
+		}},
+	})
+	if enqueueErr != nil {
+		_ = s.Deps.DB.WithContext(context.WithoutCancel(ctx)).Transaction(func(tx *gorm.DB) error {
+			if err := tx.Model(&models.StorageMigrationItem{}).Where("migration_id = ?", migration.ID).Update("reservation_key", "").Error; err != nil {
+				return err
+			}
+			return tx.Model(migration).Updates(map[string]any{
+				"status": models.StorageMigrationFailed, "phase": "Could not queue migration",
+				"error_code": "queue_failed", "error_message": enqueueErr.Error(),
+			}).Error
+		})
+		return nil, nil, enqueueErr
+	}
+	if err := s.Deps.DB.WithContext(context.WithoutCancel(ctx)).Model(migration).Updates(map[string]any{
+		"background_job_id": job.ID, "phase": "Waiting to start", "started_at": &now,
+	}).Error; err != nil {
+		// The queued task also repairs this association when it starts. Once the
+		// durable job exists, returning an error would encourage a duplicate start.
+		migration.Phase = "Waiting to start"
+	}
+	migration.BackgroundJobID = job.ID
+	migration.StartedAt = &now
+	return migration, job, nil
+}
+
+func sameStorageMigrationFiles(first, second []models.File) bool {
+	if len(first) != len(second) {
+		return false
+	}
+	ids := make(map[uint]struct{}, len(first))
+	for _, file := range first {
+		ids[file.ID] = struct{}{}
+	}
+	for _, file := range second {
+		if _, ok := ids[file.ID]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *Service) buildStorageMigrationPlan(ctx context.Context, input StorageMigrationInput) (storageMigrationPlan, error) {
+	if s == nil || s.Deps == nil || s.Deps.DB == nil || s.Deps.Storage == nil {
+		return storageMigrationPlan{}, storage.ErrStoreNotConfigured
+	}
+	if input.SourcePoolID == 0 || input.DestinationPoolID == 0 || input.SourcePoolID == input.DestinationPoolID {
+		return storageMigrationPlan{}, fmt.Errorf("%w: source and destination pools must be different", ErrStorageMigrationConflict)
+	}
+	var sourcePool, destinationPool models.StoragePool
+	preload := func(db *gorm.DB) *gorm.DB { return db.Preload("Members.StorageMount") }
+	if err := preload(s.Deps.DB.WithContext(ctx)).First(&sourcePool, input.SourcePoolID).Error; err != nil {
+		return storageMigrationPlan{}, err
+	}
+	if err := preload(s.Deps.DB.WithContext(ctx)).First(&destinationPool, input.DestinationPoolID).Error; err != nil {
+		return storageMigrationPlan{}, err
+	}
+	sourceMounts, sourceIDs, err := s.storageMigrationMounts(ctx, sourcePool)
+	if err != nil {
+		return storageMigrationPlan{}, err
+	}
+	destinationMounts, destinationIDs, err := s.storageMigrationMounts(ctx, destinationPool)
+	if err != nil {
+		return storageMigrationPlan{}, err
+	}
+	seen := make(map[string]bool, len(sourceIDs))
+	for _, id := range sourceIDs {
+		seen[id] = true
+	}
+	for _, id := range destinationIDs {
+		if seen[id] {
+			return storageMigrationPlan{}, fmt.Errorf("%w: source and destination pools share mount %s", ErrStorageMigrationConflict, id)
+		}
+	}
+
+	var unavailable int64
+	if err := s.Deps.DB.WithContext(ctx).Model(&models.File{}).
+		Where("storage_id IN ? AND storage_state = ?", sourceIDs, models.FileStorageUnavailable).
+		Count(&unavailable).Error; err != nil {
+		return storageMigrationPlan{}, err
+	}
+	if unavailable > 0 {
+		return storageMigrationPlan{}, fmt.Errorf("%w: source pool contains %d unavailable videos", ErrStorageMigrationUnavailable, unavailable)
+	}
+	var files []models.File
+	if err := s.Deps.DB.WithContext(ctx).
+		Where("storage_id IN ? AND storage_state = ?", sourceIDs, models.FileStorageAvailable).
+		Order("size DESC, id ASC").Find(&files).Error; err != nil {
+		return storageMigrationPlan{}, err
+	}
+	if len(files) == 0 {
+		return storageMigrationPlan{}, ErrStorageMigrationEmpty
+	}
+	var plannedBytes int64
+	for _, file := range files {
+		plannedBytes += file.Size
+	}
+	var reserved int64
+	if err := s.Deps.DB.WithContext(ctx).Model(&models.StorageMigrationItem{}).
+		Where(`reservation_key <> '' AND EXISTS (
+			SELECT 1 FROM files
+			WHERE files.id = storage_migration_items.file_id
+			AND files.deleted_at IS NULL
+			AND files.storage_id IN ?
+			AND files.storage_state = ?
+		)`, sourceIDs, models.FileStorageAvailable).Count(&reserved).Error; err != nil {
+		return storageMigrationPlan{}, err
+	}
+	if reserved > 0 {
+		return storageMigrationPlan{}, fmt.Errorf("%w: %d videos are already reserved by another migration", ErrStorageMigrationConflict, reserved)
+	}
+
+	usage := make(map[string]int64, len(destinationIDs))
+	var usageRows []storageMountUsageRow
+	if err := s.Deps.DB.WithContext(ctx).Model(&models.File{}).
+		Select("storage_id AS uuid, COALESCE(SUM(size), 0) AS used_bytes").
+		Where("storage_id IN ? AND storage_state = ?", destinationIDs, models.FileStorageAvailable).
+		Group("storage_id").Scan(&usageRows).Error; err != nil {
+		return storageMigrationPlan{}, err
+	}
+	for _, id := range destinationIDs {
+		usage[id] = 0
+	}
+	for _, row := range usageRows {
+		usage[row.UUID] = row.UsedBytes
+	}
+	destination := make(map[uint]string, len(files))
+	placementCounts := make(map[string]int64, len(destinationIDs))
+	placementBytes := make(map[string]int64, len(destinationIDs))
+	for _, file := range files {
+		selected := destinationIDs[0]
+		for _, candidate := range destinationIDs[1:] {
+			if usage[candidate] < usage[selected] || (usage[candidate] == usage[selected] && candidate < selected) {
+				selected = candidate
+			}
+		}
+		destination[file.ID] = selected
+		usage[selected] += file.Size
+		placementCounts[selected]++
+		placementBytes[selected] += file.Size
+	}
+	mountNames := make(map[string]string, len(destinationMounts))
+	for _, mount := range destinationMounts {
+		mountNames[mount.UUID] = mount.Name
+	}
+	placements := make([]StorageMigrationPlacementPreview, 0, len(destinationIDs))
+	for _, id := range destinationIDs {
+		placements = append(placements, StorageMigrationPlacementPreview{
+			MountID: id, MountName: mountNames[id], FileCount: placementCounts[id], PlannedBytes: placementBytes[id],
+		})
+	}
+
+	warnings := []string{"Videos uploaded after this snapshot will not be included.", "Upload routing is not changed automatically."}
+	if sourcePool.IsDefault {
+		warnings = append(warnings, "The source is still the default upload pool.")
+	}
+	var overrideCount int64
+	if err := s.Deps.DB.WithContext(ctx).Model(&models.User{}).Where("storage_pool_id = ?", sourcePool.ID).Count(&overrideCount).Error; err != nil {
+		return storageMigrationPlan{}, err
+	}
+	if overrideCount > 0 {
+		warnings = append(warnings, fmt.Sprintf("%d users still upload to the source pool.", overrideCount))
+	}
+	return storageMigrationPlan{
+		preview: StorageMigrationPreview{
+			SourcePoolID: sourcePool.ID, SourcePoolName: sourcePool.Name,
+			DestinationPoolID: destinationPool.ID, DestinationPoolName: destinationPool.Name,
+			FileCount: int64(len(files)), PlannedBytes: plannedBytes,
+			SourceMounts: sourceMounts, DestinationMounts: destinationMounts,
+			DestinationPlacements: placements, Warnings: warnings, CleanupGraceHours: 24,
+		},
+		files: files, destination: destination,
+	}, nil
+}
+
+func (s *Service) storageMigrationMounts(ctx context.Context, pool models.StoragePool) ([]StorageMigrationMountPreview, []string, error) {
+	if len(pool.Members) == 0 {
+		return nil, nil, fmt.Errorf("%w: pool %s has no mounts", ErrStorageMigrationUnavailable, pool.Name)
+	}
+	mounts := make([]StorageMigrationMountPreview, 0, len(pool.Members))
+	ids := make([]string, 0, len(pool.Members))
+	for _, member := range pool.Members {
+		mount := member.StorageMount
+		if !mount.Mounted || strings.TrimSpace(mount.LastError) != "" {
+			return nil, nil, fmt.Errorf("%w: mount %s is not available", ErrStorageMigrationUnavailable, mount.Name)
+		}
+		if _, err := s.Deps.Storage.Store(mount.UUID); err != nil {
+			return nil, nil, fmt.Errorf("%w: mount %s is not connected", ErrStorageMigrationUnavailable, mount.Name)
+		}
+		var usedBytes int64
+		if err := s.Deps.DB.WithContext(ctx).Model(&models.File{}).Where("storage_id = ? AND storage_state = ?", mount.UUID, models.FileStorageAvailable).
+			Select("COALESCE(SUM(size), 0)").Scan(&usedBytes).Error; err != nil {
+			return nil, nil, err
+		}
+		mounts = append(mounts, StorageMigrationMountPreview{
+			ID: mount.ID, UUID: mount.UUID, Name: mount.Name, Provider: mount.Provider, UsedBytes: usedBytes,
+		})
+		ids = append(ids, mount.UUID)
+	}
+	sort.Slice(mounts, func(i, j int) bool { return mounts[i].UUID < mounts[j].UUID })
+	sort.Strings(ids)
+	return mounts, ids, nil
+}
+
+func isStorageMigrationUniqueError(err error) bool {
+	message := strings.ToLower(err.Error())
+	return errors.Is(err, gorm.ErrDuplicatedKey) || strings.Contains(message, "unique constraint") || strings.Contains(message, "duplicate key")
+}
+
+func (s *Service) ListStorageMigrations(ctx context.Context, limit int, beforeID uint) ([]models.StorageMigration, error) {
+	if limit < 1 || limit > 200 {
+		limit = 50
+	}
+	query := s.Deps.DB.WithContext(ctx).Model(&models.StorageMigration{})
+	if beforeID > 0 {
+		query = query.Where("id < ?", beforeID)
+	}
+	var migrations []models.StorageMigration
+	err := query.Order("id DESC").Limit(limit).Find(&migrations).Error
+	return migrations, err
+}
+
+func (s *Service) GetStorageMigrationSummary(ctx context.Context) (StorageMigrationSummary, error) {
+	var summary StorageMigrationSummary
+	err := s.Deps.DB.WithContext(ctx).Model(&models.StorageMigration{}).
+		Select(`COALESCE(SUM(CASE WHEN status IN ? THEN 1 ELSE 0 END), 0) AS active,
+			COALESCE(SUM(CASE WHEN status IN ? THEN 1 ELSE 0 END), 0) AS retaining_originals,
+			COALESCE(SUM(CASE WHEN status IN ? THEN 1 ELSE 0 END), 0) AS needs_attention,
+			COALESCE(SUM(cutover_count), 0) AS videos_moved`,
+			[]string{models.StorageMigrationQueued, models.StorageMigrationRunning, models.StorageMigrationPaused},
+			[]string{models.StorageMigrationRetainingOriginals, models.StorageMigrationCleaningOriginals},
+			[]string{models.StorageMigrationFailed, models.StorageMigrationCanceled}).
+		Scan(&summary).Error
+	return summary, err
+}
+
+func (s *Service) GetStorageMigration(ctx context.Context, migrationUUID string) (models.StorageMigration, error) {
+	var migration models.StorageMigration
+	err := s.Deps.DB.WithContext(ctx).Where("uuid = ?", strings.TrimSpace(migrationUUID)).First(&migration).Error
+	if err != nil {
+		return models.StorageMigration{}, err
+	}
+	err = s.Deps.DB.WithContext(context.WithoutCancel(ctx)).First(&migration, migration.ID).Error
+	return migration, err
+}
+
+type StorageMigrationItemView struct {
+	models.StorageMigrationItem
+	VideoName string `json:"VideoName"`
+}
+
+func (s *Service) ListStorageMigrationItems(ctx context.Context, migrationID uint, status string, limit int, afterID uint) ([]StorageMigrationItemView, error) {
+	if limit < 1 || limit > 500 {
+		limit = 100
+	}
+	query := s.Deps.DB.WithContext(ctx).Table("storage_migration_items AS migration_items").
+		Select("migration_items.*, COALESCE(MIN(links.name), migration_items.file_uuid) AS video_name").
+		Joins("LEFT JOIN links ON links.file_id = migration_items.file_id AND links.deleted_at IS NULL").
+		Where("migration_items.migration_id = ? AND migration_items.deleted_at IS NULL", migrationID)
+	if status = strings.TrimSpace(status); status != "" {
+		query = query.Where("migration_items.status = ?", status)
+	}
+	if afterID > 0 {
+		query = query.Where("migration_items.id > ?", afterID)
+	}
+	var items []StorageMigrationItemView
+	err := query.Group("migration_items.id").Order("migration_items.id ASC").Limit(limit).Scan(&items).Error
+	return items, err
+}
+
+func (s *Service) ensureStorageMountNotMigrating(mountUUID string) error {
+	if !s.Deps.DB.Migrator().HasTable(&models.StorageMigrationItem{}) {
+		return nil
+	}
+	var count int64
+	err := s.Deps.DB.Model(&models.StorageMigrationItem{}).
+		Joins("JOIN storage_migrations ON storage_migrations.id = storage_migration_items.migration_id AND storage_migrations.deleted_at IS NULL").
+		Where("(source_mount_id = ? OR destination_mount_id = ?) AND (reservation_key <> '' OR (storage_migrations.status IN ? AND storage_migrations.cleanup_after > ?))", mountUUID, mountUUID, []string{models.StorageMigrationCanceled, models.StorageMigrationOriginalsRetained}, time.Now().UTC()).
+		Count(&count).Error
+	if err != nil {
+		return err
+	}
+	if count > 0 {
+		return fmt.Errorf("%w: storage mount is reserved by an active migration", ErrStorageMigrationConflict)
+	}
+	return nil
+}
+
+func (s *Service) ensureStoragePoolNotMigrating(poolID uint) error {
+	if !s.Deps.DB.Migrator().HasTable(&models.StorageMigration{}) {
+		return nil
+	}
+	var count int64
+	err := s.Deps.DB.Model(&models.StorageMigration{}).
+		Where("(source_pool_id = ? OR destination_pool_id = ?) AND status NOT IN ?", poolID, poolID, []string{
+			models.StorageMigrationCompleted, models.StorageMigrationCanceled, models.StorageMigrationOriginalsRetained,
+		}).Count(&count).Error
+	if err != nil {
+		return err
+	}
+	if count > 0 {
+		return fmt.Errorf("%w: storage pool is used by an active migration", ErrStorageMigrationConflict)
+	}
+	return nil
+}
+
+func (s *Service) KeepStorageMigrationOriginals(ctx context.Context, migrationUUID string, actorID uint, actorName string) (models.StorageMigration, error) {
+	migration, err := s.GetStorageMigration(ctx, migrationUUID)
+	if err != nil {
+		return models.StorageMigration{}, err
+	}
+	if migration.Status != models.StorageMigrationRetainingOriginals && migration.Status != models.StorageMigrationCleaningOriginals && migration.Status != models.StorageMigrationPaused {
+		return models.StorageMigration{}, fmt.Errorf("%w: originals can only be retained after video cutover", ErrStorageMigrationConflict)
+	}
+	if migration.Status == models.StorageMigrationPaused && migration.CleanupJobID == "" {
+		return models.StorageMigration{}, fmt.Errorf("%w: the video migration is paused before cleanup", ErrStorageMigrationConflict)
+	}
+	if migration.CleanupJobID != "" && s.Deps.Background != nil {
+		detail, jobErr := s.Deps.Background.Job(ctx, migration.CleanupJobID, nil, true)
+		if jobErr == nil {
+			if detail.Status == background.JobSucceeded || detail.Status == background.JobSucceededWithWarnings {
+				return models.StorageMigration{}, fmt.Errorf("%w: original cleanup has already completed", ErrStorageMigrationConflict)
+			}
+			if !backgroundJobTerminal(detail.Status) {
+				if err := s.Deps.Background.CancelJob(ctx, detail.ID, actorID, actorName); err != nil && !errors.Is(err, background.ErrConflict) {
+					return models.StorageMigration{}, err
+				}
+			}
+		}
+	}
+	durableCtx := context.WithoutCancel(ctx)
+	if err := s.Deps.DB.WithContext(durableCtx).Model(&migration).Updates(map[string]any{
+		"keep_originals": true, "phase": "Stopping original cleanup",
+	}).Error; err != nil {
+		return models.StorageMigration{}, err
+	}
+	var items []models.StorageMigrationItem
+	if err := s.Deps.DB.WithContext(durableCtx).Select("id", "file_id", "status").
+		Where("migration_id = ?", migration.ID).Order("file_id ASC").Find(&items).Error; err != nil {
+		return models.StorageMigration{}, err
+	}
+	for index := range items {
+		item := &items[index]
+		releaseFile := s.Deps.StorageLifecycle.FileWriteLock(item.FileID)
+		err := s.Deps.DB.WithContext(durableCtx).Transaction(func(tx *gorm.DB) error {
+			if err := tx.Select("id", "status").First(item, item.ID).Error; err != nil {
+				return err
+			}
+			if item.Status == models.StorageMigrationItemCleaned {
+				return nil
+			}
+			return tx.Model(item).Updates(map[string]any{
+				"status": models.StorageMigrationItemOriginalKept, "reservation_key": "",
+				"progress_message": "Original retained by administrator",
+			}).Error
+		})
+		releaseFile()
+		if err != nil {
+			return models.StorageMigration{}, err
+		}
+	}
+	var cleaned int64
+	now := time.Now().UTC()
+	err = s.Deps.DB.WithContext(durableCtx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&models.StorageMigrationItem{}).
+			Where("migration_id = ? AND status = ?", migration.ID, models.StorageMigrationItemCleaned).
+			Count(&cleaned).Error; err != nil {
+			return err
+		}
+		phase := "Original copies retained"
+		if cleaned > 0 {
+			phase = fmt.Sprintf("Originals retained; %d had already been removed", cleaned)
+		}
+		return tx.Model(&migration).Updates(map[string]any{
+			"status": models.StorageMigrationOriginalsRetained, "phase": phase, "keep_originals": true,
+			"cleaned_count": cleaned, "completed_at": &now, "error_code": "", "error_message": "",
+		}).Error
+	})
+	if err != nil {
+		return models.StorageMigration{}, err
+	}
+	err = s.Deps.DB.WithContext(context.WithoutCancel(ctx)).First(&migration, migration.ID).Error
+	return migration, err
+}
+
+func (s *Service) CancelFailedStorageMigration(ctx context.Context, migrationUUID string) (models.StorageMigration, error) {
+	migration, err := s.GetStorageMigration(ctx, migrationUUID)
+	if err != nil {
+		return models.StorageMigration{}, err
+	}
+	if migration.Status != models.StorageMigrationFailed {
+		return models.StorageMigration{}, fmt.Errorf("%w: only a failed migration can be abandoned from this state", ErrStorageMigrationConflict)
+	}
+	if migration.BackgroundJobID != "" && s.Deps.Background != nil {
+		job, jobErr := s.Deps.Background.Job(ctx, migration.BackgroundJobID, nil, true)
+		if jobErr != nil {
+			return models.StorageMigration{}, jobErr
+		}
+		if job.Status != background.JobFailed {
+			return models.StorageMigration{}, fmt.Errorf("%w: the migration is still retrying", ErrStorageMigrationConflict)
+		}
+	}
+	if err := s.EnsureStorageMigrationAbortCleanup(ctx, migration.ID); err != nil {
+		return models.StorageMigration{}, err
+	}
+	if err := s.Deps.DB.WithContext(context.WithoutCancel(ctx)).First(&migration, migration.ID).Error; err != nil {
+		return models.StorageMigration{}, err
+	}
+	return migration, nil
+}
+
+func backgroundJobTerminal(status string) bool {
+	switch status {
+	case background.JobSucceeded, background.JobSucceededWithWarnings, background.JobFailed, background.JobCanceled:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *Service) ReflectStorageMigrationJobControl(ctx context.Context, job background.Job, action string, actorID uint, actorName string) error {
+	if job.SubjectType != "storage_migration" || job.SubjectID == "" {
+		return nil
+	}
+	migration, err := s.GetStorageMigration(ctx, job.SubjectID)
+	if err != nil {
+		return err
+	}
+	switch action {
+	case "pause":
+		if job.Kind == "storage.migration.abort_cleanup" {
+			return s.Deps.DB.WithContext(context.WithoutCancel(ctx)).Model(&migration).Updates(map[string]any{
+				"status": models.StorageMigrationCanceled, "phase": "Canceled; incomplete destination cleanup paused",
+			}).Error
+		}
+		phase := "Migration paused"
+		if job.Kind == "storage.migration.cleanup" {
+			phase = "Original cleanup paused"
+		}
+		return s.Deps.DB.WithContext(context.WithoutCancel(ctx)).Model(&migration).Updates(map[string]any{
+			"status": models.StorageMigrationPaused, "phase": phase,
+		}).Error
+	case "resume":
+		if job.Kind == "storage.migration.abort_cleanup" {
+			return s.Deps.DB.WithContext(context.WithoutCancel(ctx)).Model(&migration).Updates(map[string]any{
+				"status": models.StorageMigrationCanceled, "phase": "Canceled; cleaning incomplete destination data",
+			}).Error
+		}
+		status, phase := models.StorageMigrationRunning, "Migrating videos"
+		if job.Kind == "storage.migration.cleanup" {
+			status, phase = models.StorageMigrationCleaningOriginals, "Cleaning original copies"
+			if migration.CleanupAfter != nil && migration.CleanupAfter.After(time.Now().UTC()) {
+				status, phase = models.StorageMigrationRetainingOriginals, "Retaining originals until cleanup begins"
+			}
+		}
+		return s.Deps.DB.WithContext(context.WithoutCancel(ctx)).Model(&migration).Updates(map[string]any{
+			"status": status, "phase": phase,
+		}).Error
+	case "cancel":
+		if job.Kind == "storage.migration.cleanup" {
+			_, err := s.KeepStorageMigrationOriginals(ctx, migration.UUID, actorID, actorName)
+			return err
+		}
+		if job.Kind == "storage.migration" {
+			return s.EnsureStorageMigrationAbortCleanup(ctx, migration.ID)
+		}
+		if job.Kind == "storage.migration.abort_cleanup" {
+			return s.Deps.DB.WithContext(context.WithoutCancel(ctx)).Model(&migration).Update("phase", "Canceled; incomplete destination cleanup stopped").Error
+		}
+	case "retry":
+		if job.Kind == "storage.migration" {
+			return s.Deps.DB.WithContext(context.WithoutCancel(ctx)).Model(&migration).Updates(map[string]any{
+				"status": models.StorageMigrationQueued, "phase": "Waiting to resume migration",
+				"cleanup_job_id": "", "cleanup_after": nil, "canceled_at": nil, "keep_originals": false,
+				"error_code": "", "error_message": "",
+			}).Error
+		}
+		if job.Kind == "storage.migration.abort_cleanup" {
+			return s.Deps.DB.WithContext(context.WithoutCancel(ctx)).Model(&migration).Updates(map[string]any{
+				"status": models.StorageMigrationCanceled, "phase": "Canceled; retrying incomplete destination cleanup",
+			}).Error
+		}
+	}
+	return nil
+}
+
+func (s *Service) EnsureStorageMigrationAbortCleanup(ctx context.Context, migrationID uint) error {
+	if s == nil || s.Deps == nil || s.Deps.Background == nil {
+		return errors.New("background work is not configured")
+	}
+	var migration models.StorageMigration
+	if err := s.Deps.DB.WithContext(context.WithoutCancel(ctx)).First(&migration, migrationID).Error; err != nil {
+		return err
+	}
+	if migration.CleanupJobID != "" {
+		if detail, err := s.Deps.Background.Job(context.WithoutCancel(ctx), migration.CleanupJobID, nil, true); err == nil {
+			if detail.Kind == "storage.migration.abort_cleanup" {
+				return nil
+			}
+			if detail.Kind == "storage.migration.cleanup" && !backgroundJobTerminal(detail.Status) {
+				if err := s.Deps.Background.CancelJob(context.WithoutCancel(ctx), detail.ID, 0, "VideoCMS"); err != nil && !errors.Is(err, background.ErrConflict) {
+					return err
+				}
+			}
+		}
+	}
+	return s.queueStorageMigrationAbort(ctx, &migration)
+}
+
+func (s *Service) queueStorageMigrationAbort(ctx context.Context, migration *models.StorageMigration) error {
+	if s.Deps.Background == nil {
+		return errors.New("background work is not configured")
+	}
+	now := time.Now().UTC()
+	protectUntil := now.Add(storageMigrationCancellationGrace)
+	cancelGeneration := migration.CancelGeneration + 1
+	job, _, err := s.Deps.Background.Enqueue(context.WithoutCancel(ctx), background.JobSpec{
+		Kind: "storage.migration.abort_cleanup", Visibility: background.VisibilityAdmin,
+		SubjectType: "storage_migration", SubjectID: migration.UUID,
+		IdempotencyKey: fmt.Sprintf("storage-migration-abort:%s:%d", migration.UUID, cancelGeneration),
+		Label:          fmt.Sprintf("Clean canceled migration to %s", migration.DestinationPoolName),
+		Tasks: []background.TaskSpec{{
+			Kind: "storage.migration.abort_cleanup", Queue: background.QueueStorage, Phase: "Cleaning canceled migration",
+			Payload: map[string]any{"migrationId": migration.ID}, DedupeKey: fmt.Sprintf("storage-abort:%d", migration.ID),
+			Priority: 15, Required: true, Weight: 1, MaxAttempts: 8,
+		}},
+	})
+	if err != nil {
+		return err
+	}
+	return s.Deps.DB.WithContext(context.WithoutCancel(ctx)).Model(migration).Updates(map[string]any{
+		"status": models.StorageMigrationCanceled, "phase": "Canceled; cleaning incomplete destination data",
+		"cleanup_job_id": job.ID, "cleanup_after": &protectUntil, "canceled_at": &now, "keep_originals": true,
+		"cancel_generation": cancelGeneration,
+	}).Error
+}
+
+const storageMigrationCancellationGrace = 24 * time.Hour

--- a/logic/StorageMigration_test.go
+++ b/logic/StorageMigration_test.go
@@ -1,0 +1,275 @@
+package logic
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"ch/kirari04/videocms/app"
+	"ch/kirari04/videocms/background"
+	"ch/kirari04/videocms/models"
+	"ch/kirari04/videocms/storage"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func TestStorageMigrationPreviewAndStartSnapshotDeterministically(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.StorageMount{}, &models.StoragePool{}, &models.StoragePoolMount{}, &models.User{}, &models.File{}, &models.Link{}, &models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := background.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	stores := make(map[string]storage.Store)
+	mounts := make([]models.StorageMount, 0, 3)
+	for _, id := range []string{"source", "destination-a", "destination-b"} {
+		store, err := storage.NewLocalStore(t.TempDir())
+		if err != nil {
+			t.Fatal(err)
+		}
+		stores[id] = store
+		mount := models.StorageMount{UUID: id, Name: id, Provider: models.StorageProviderLocal, Mounted: true}
+		if err := db.Create(&mount).Error; err != nil {
+			t.Fatal(err)
+		}
+		mounts = append(mounts, mount)
+	}
+	storageService, err := storage.NewService("source", storage.LegacyMediaLayout{}, stores)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = storageService.Close() })
+	sourcePool := models.StoragePool{UUID: "source-pool", Name: "Source", IsDefault: true}
+	destinationPool := models.StoragePool{UUID: "destination-pool", Name: "Destination"}
+	if err := db.Create(&sourcePool).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&destinationPool).Error; err != nil {
+		t.Fatal(err)
+	}
+	for _, membership := range []models.StoragePoolMount{
+		{StoragePoolID: sourcePool.ID, StorageMountID: mounts[0].ID},
+		{StoragePoolID: destinationPool.ID, StorageMountID: mounts[1].ID},
+		{StoragePoolID: destinationPool.ID, StorageMountID: mounts[2].ID},
+	} {
+		if err := db.Create(&membership).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, file := range []models.File{
+		{UUID: "550e8400-e29b-41d4-a716-446655440301", StorageID: "source", StorageState: models.FileStorageAvailable, Size: 100},
+		{UUID: "550e8400-e29b-41d4-a716-446655440302", StorageID: "source", StorageState: models.FileStorageAvailable, Size: 50},
+	} {
+		if err := db.Create(&file).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	runtime := background.New(db, background.Options{})
+	service := NewService(&app.Deps{DB: db, Storage: storageService, Background: runtime})
+	input := StorageMigrationInput{SourcePoolID: sourcePool.ID, DestinationPoolID: destinationPool.ID}
+	preview, err := service.PreviewStorageMigration(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preview.FileCount != 2 || preview.PlannedBytes != 150 || preview.CleanupGraceHours != 24 || len(preview.DestinationPlacements) != 2 {
+		t.Fatalf("unexpected preview: %#v", preview)
+	}
+	migration, job, err := service.StartStorageMigration(context.Background(), input, 7, "admin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if migration.FileCount != 2 || migration.BackgroundJobID == "" || job.Kind != "storage.migration" {
+		t.Fatalf("unexpected migration: %#v job=%#v", migration, job)
+	}
+	summary, err := service.GetStorageMigrationSummary(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if summary.Active != 1 || summary.RetainingOriginals != 0 || summary.NeedsAttention != 0 || summary.VideosMoved != 0 {
+		t.Fatalf("unexpected migration summary: %#v", summary)
+	}
+	var items []models.StorageMigrationItem
+	if err := db.Where("migration_id = ?", migration.ID).Order("file_id ASC").Find(&items).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 2 || items[0].DestinationMountID == items[1].DestinationMountID || items[0].ReservationKey == "" || items[1].ReservationKey == "" {
+		t.Fatalf("unexpected deterministic assignments: %#v", items)
+	}
+	if _, _, err := service.StartStorageMigration(context.Background(), input, 7, "admin"); !errors.Is(err, ErrStorageMigrationConflict) {
+		t.Fatalf("expected active reservation conflict, got %v", err)
+	}
+}
+
+func TestStorageMigrationRejectsOverlappingPools(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.StorageMount{}, &models.StoragePool{}, &models.StoragePoolMount{}, &models.File{}, &models.StorageMigrationItem{}); err != nil {
+		t.Fatal(err)
+	}
+	store, _ := storage.NewLocalStore(t.TempDir())
+	storageService, _ := storage.NewService("shared", storage.LegacyMediaLayout{}, map[string]storage.Store{"shared": store})
+	t.Cleanup(func() { _ = storageService.Close() })
+	mount := models.StorageMount{UUID: "shared", Name: "Shared", Provider: models.StorageProviderLocal, Mounted: true}
+	db.Create(&mount)
+	first := models.StoragePool{UUID: "first", Name: "First"}
+	second := models.StoragePool{UUID: "second", Name: "Second"}
+	db.Create(&first)
+	db.Create(&second)
+	db.Create(&models.StoragePoolMount{StoragePoolID: first.ID, StorageMountID: mount.ID})
+	db.Create(&models.StoragePoolMount{StoragePoolID: second.ID, StorageMountID: mount.ID})
+	service := NewService(&app.Deps{DB: db, Storage: storageService})
+	_, err = service.PreviewStorageMigration(context.Background(), StorageMigrationInput{SourcePoolID: first.ID, DestinationPoolID: second.ID})
+	if !errors.Is(err, ErrStorageMigrationConflict) {
+		t.Fatalf("expected overlap conflict, got %v", err)
+	}
+}
+
+func TestKeepStorageMigrationOriginalsWaitsForInFlightCleanup(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
+		t.Fatal(err)
+	}
+	migration := models.StorageMigration{UUID: "keep-originals", Status: models.StorageMigrationCleaningOriginals, FileCount: 1}
+	if err := db.Create(&migration).Error; err != nil {
+		t.Fatal(err)
+	}
+	item := models.StorageMigrationItem{MigrationID: migration.ID, FileID: 42, FileUUID: "file", Status: models.StorageMigrationItemCleaning, ReservationKey: "file:42"}
+	if err := db.Create(&item).Error; err != nil {
+		t.Fatal(err)
+	}
+	deps := &app.Deps{DB: db}
+	service := NewService(deps)
+	releaseCleanup := deps.StorageLifecycle.FileWriteLock(item.FileID)
+	result := make(chan models.StorageMigration, 1)
+	failures := make(chan error, 1)
+	go func() {
+		kept, keepErr := service.KeepStorageMigrationOriginals(context.Background(), migration.UUID, 1, "admin")
+		if keepErr != nil {
+			failures <- keepErr
+			return
+		}
+		result <- kept
+	}()
+	select {
+	case <-result:
+		t.Fatal("keep originals did not wait for active cleanup")
+	case err := <-failures:
+		t.Fatalf("keep originals failed early: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	now := time.Now().UTC()
+	if err := db.Model(&item).Updates(map[string]any{"status": models.StorageMigrationItemCleaned, "cleaned_at": &now, "reservation_key": ""}).Error; err != nil {
+		t.Fatal(err)
+	}
+	releaseCleanup()
+	select {
+	case kept := <-result:
+		if kept.Status != models.StorageMigrationOriginalsRetained || kept.CleanedCount != 1 {
+			t.Fatalf("unexpected retained state: %#v", kept)
+		}
+	case err := <-failures:
+		t.Fatal(err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("keep originals did not finish after cleanup checkpoint")
+	}
+	if err := db.First(&item, item.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if item.Status != models.StorageMigrationItemCleaned {
+		t.Fatalf("completed cleanup was overwritten: %#v", item)
+	}
+}
+
+func TestCanceledStorageMigrationProtectsMountsDuringSafetyWindow(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
+		t.Fatal(err)
+	}
+	protectUntil := time.Now().UTC().Add(time.Hour)
+	migration := models.StorageMigration{UUID: "canceled-grace", Status: models.StorageMigrationCanceled, CleanupAfter: &protectUntil}
+	if err := db.Create(&migration).Error; err != nil {
+		t.Fatal(err)
+	}
+	item := models.StorageMigrationItem{MigrationID: migration.ID, FileID: 1, SourceMountID: "source", DestinationMountID: "destination", Status: models.StorageMigrationItemCanceled}
+	if err := db.Create(&item).Error; err != nil {
+		t.Fatal(err)
+	}
+	service := NewService(&app.Deps{DB: db})
+	if err := service.ensureStorageMountNotMigrating("source"); !errors.Is(err, ErrStorageMigrationConflict) {
+		t.Fatalf("source mount was not protected: %v", err)
+	}
+	if err := service.ensureStorageMountNotMigrating("destination"); !errors.Is(err, ErrStorageMigrationConflict) {
+		t.Fatalf("destination mount was not protected: %v", err)
+	}
+	expired := time.Now().UTC().Add(-time.Hour)
+	if err := db.Model(&migration).Update("cleanup_after", &expired).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := service.ensureStorageMountNotMigrating("source"); err != nil {
+		t.Fatalf("expired safety window still blocked mount: %v", err)
+	}
+}
+
+func TestFailedStorageMigrationCanBeCanceledForReconciliation(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := background.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	migration := models.StorageMigration{UUID: "failed-cancel", SourcePoolName: "Source", DestinationPoolName: "Destination", Status: models.StorageMigrationFailed, FileCount: 1}
+	if err := db.Create(&migration).Error; err != nil {
+		t.Fatal(err)
+	}
+	item := models.StorageMigrationItem{MigrationID: migration.ID, FileID: 1, FileUUID: "file", SourceMountID: "source", DestinationMountID: "destination", Status: models.StorageMigrationItemFailed, ReservationKey: "file:1", DestinationOwned: true}
+	if err := db.Create(&item).Error; err != nil {
+		t.Fatal(err)
+	}
+	runtime := background.New(db, background.Options{})
+	service := NewService(&app.Deps{DB: db, Background: runtime})
+	canceled, err := service.CancelFailedStorageMigration(context.Background(), migration.UUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if canceled.Status != models.StorageMigrationCanceled || canceled.CleanupJobID == "" || canceled.CleanupAfter == nil || canceled.CanceledAt == nil {
+		t.Fatalf("failed migration was not queued for safe reconciliation: %#v", canceled)
+	}
+	job, err := runtime.Job(context.Background(), canceled.CleanupJobID, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if job.Kind != "storage.migration.abort_cleanup" || job.Status != background.JobQueued {
+		t.Fatalf("unexpected reconciliation job: %#v", job)
+	}
+	firstCleanupJobID := canceled.CleanupJobID
+	if err := db.Model(&canceled).Updates(map[string]any{"status": models.StorageMigrationFailed, "cleanup_job_id": ""}).Error; err != nil {
+		t.Fatal(err)
+	}
+	canceledAgain, err := service.CancelFailedStorageMigration(context.Background(), migration.UUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if canceledAgain.CancelGeneration != 2 || canceledAgain.CleanupJobID == firstCleanupJobID {
+		t.Fatalf("later cancellation reused stale cleanup job: first=%s migration=%#v", firstCleanupJobID, canceledAgain)
+	}
+}

--- a/logic/StorageMigration_test.go
+++ b/logic/StorageMigration_test.go
@@ -82,6 +82,17 @@ func TestStorageMigrationPreviewAndStartSnapshotDeterministically(t *testing.T) 
 	if preview.FileCount != 2 || preview.PlannedBytes != 150 || preview.CleanupGraceHours != 24 || len(preview.DestinationPlacements) != 2 {
 		t.Fatalf("unexpected preview: %#v", preview)
 	}
+	input.PlanFingerprint = preview.PlanFingerprint
+	input.IdempotencyKey = "migration-request"
+	if err := db.Model(&models.File{}).Where("uuid = ?", "550e8400-e29b-41d4-a716-446655440301").Update("size", 101).Error; err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := service.StartStorageMigration(context.Background(), input, 7, "admin"); !errors.Is(err, ErrStorageMigrationConflict) {
+		t.Fatalf("expected changed preview to be rejected, got %v", err)
+	}
+	if err := db.Model(&models.File{}).Where("uuid = ?", "550e8400-e29b-41d4-a716-446655440301").Update("size", 100).Error; err != nil {
+		t.Fatal(err)
+	}
 	migration, job, err := service.StartStorageMigration(context.Background(), input, 7, "admin")
 	if err != nil {
 		t.Fatal(err)
@@ -103,6 +114,27 @@ func TestStorageMigrationPreviewAndStartSnapshotDeterministically(t *testing.T) 
 	if len(items) != 2 || items[0].DestinationMountID == items[1].DestinationMountID || items[0].ReservationKey == "" || items[1].ReservationKey == "" {
 		t.Fatalf("unexpected deterministic assignments: %#v", items)
 	}
+	reusedMigration, reusedJob, err := service.StartStorageMigration(context.Background(), input, 7, "admin")
+	if err != nil || reusedMigration.ID != migration.ID || reusedJob.ID != job.ID {
+		t.Fatalf("idempotent migration request was not reused: migration=%#v job=%#v err=%v", reusedMigration, reusedJob, err)
+	}
+	input.PlanFingerprint = strings.Repeat("0", 64)
+	if _, _, err := service.StartStorageMigration(context.Background(), input, 7, "admin"); !errors.Is(err, ErrStorageMigrationConflict) {
+		t.Fatalf("expected changed idempotent request to conflict, got %v", err)
+	}
+	input.PlanFingerprint = preview.PlanFingerprint
+	active, err := service.ListStorageMigrations(context.Background(), "active", 50, 0)
+	if err != nil || len(active) != 1 || active[0].ID != migration.ID {
+		t.Fatalf("active server filter did not return migration: %#v err=%v", active, err)
+	}
+	complete, err := service.ListStorageMigrations(context.Background(), "complete", 50, 0)
+	if err != nil || len(complete) != 0 {
+		t.Fatalf("complete server filter returned active migration: %#v err=%v", complete, err)
+	}
+	if _, err := service.ListStorageMigrations(context.Background(), "unknown", 50, 0); !errors.Is(err, ErrStorageMigrationConflict) {
+		t.Fatalf("expected invalid status filter to fail, got %v", err)
+	}
+	input.IdempotencyKey = "another-migration-request"
 	if _, _, err := service.StartStorageMigration(context.Background(), input, 7, "admin"); !errors.Is(err, ErrStorageMigrationConflict) {
 		t.Fatalf("expected active reservation conflict, got %v", err)
 	}
@@ -142,12 +174,16 @@ func TestKeepStorageMigrationOriginalsWaitsForInFlightCleanup(t *testing.T) {
 	if err := db.AutoMigrate(&models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
 		t.Fatal(err)
 	}
-	migration := models.StorageMigration{UUID: "keep-originals", Status: models.StorageMigrationCleaningOriginals, FileCount: 1}
+	migration := models.StorageMigration{UUID: "keep-originals", Status: models.StorageMigrationCleaningOriginals, FileCount: 2}
 	if err := db.Create(&migration).Error; err != nil {
 		t.Fatal(err)
 	}
 	item := models.StorageMigrationItem{MigrationID: migration.ID, FileID: 42, FileUUID: "file", Status: models.StorageMigrationItemCleaning, ReservationKey: "file:42"}
 	if err := db.Create(&item).Error; err != nil {
+		t.Fatal(err)
+	}
+	partial := models.StorageMigrationItem{MigrationID: migration.ID, FileID: 43, FileUUID: "partial", Status: models.StorageMigrationItemCleaning, ReservationKey: "file:43"}
+	if err := db.Create(&partial).Error; err != nil {
 		t.Fatal(err)
 	}
 	deps := &app.Deps{DB: db}
@@ -190,6 +226,12 @@ func TestKeepStorageMigrationOriginalsWaitsForInFlightCleanup(t *testing.T) {
 	}
 	if item.Status != models.StorageMigrationItemCleaned {
 		t.Fatalf("completed cleanup was overwritten: %#v", item)
+	}
+	if err := db.First(&partial, partial.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if partial.Status != models.StorageMigrationItemOriginalPartial || partial.ReservationKey != "" {
+		t.Fatalf("incomplete cleanup was mislabeled as a complete original: %#v", partial)
 	}
 }
 

--- a/models/StorageMigration.go
+++ b/models/StorageMigration.go
@@ -13,21 +13,24 @@ const (
 	StorageMigrationCompleted          = "completed"
 	StorageMigrationOriginalsRetained  = "originals_retained"
 
-	StorageMigrationItemPending        = "pending"
-	StorageMigrationItemCopying        = "copying"
-	StorageMigrationItemVerifying      = "verifying"
-	StorageMigrationItemCutover        = "cutover"
-	StorageMigrationItemCleanupPending = "cleanup_pending"
-	StorageMigrationItemCleaning       = "cleaning"
-	StorageMigrationItemCleaned        = "cleaned"
-	StorageMigrationItemOriginalKept   = "original_kept"
-	StorageMigrationItemFailed         = "failed"
-	StorageMigrationItemCanceled       = "canceled"
+	StorageMigrationItemPending         = "pending"
+	StorageMigrationItemCopying         = "copying"
+	StorageMigrationItemVerifying       = "verifying"
+	StorageMigrationItemCutover         = "cutover"
+	StorageMigrationItemCleanupPending  = "cleanup_pending"
+	StorageMigrationItemCleaning        = "cleaning"
+	StorageMigrationItemCleaned         = "cleaned"
+	StorageMigrationItemOriginalKept    = "original_kept"
+	StorageMigrationItemOriginalPartial = "original_partial"
+	StorageMigrationItemFailed          = "failed"
+	StorageMigrationItemCanceled        = "canceled"
 )
 
 type StorageMigration struct {
 	Model
 	UUID                string `gorm:"uniqueIndex;size:64"`
+	RequestKey          string `gorm:"size:255;uniqueIndex:idx_storage_migration_request,where:request_key <> ''" json:"-"`
+	PlanFingerprint     string `gorm:"size:64" json:"-"`
 	SourcePoolID        uint   `gorm:"index"`
 	DestinationPoolID   uint   `gorm:"index"`
 	SourcePoolName      string `gorm:"size:120"`

--- a/models/StorageMigration.go
+++ b/models/StorageMigration.go
@@ -1,0 +1,82 @@
+package models
+
+import "time"
+
+const (
+	StorageMigrationQueued             = "queued"
+	StorageMigrationRunning            = "running"
+	StorageMigrationPaused             = "paused"
+	StorageMigrationFailed             = "failed"
+	StorageMigrationCanceled           = "canceled"
+	StorageMigrationRetainingOriginals = "retaining_originals"
+	StorageMigrationCleaningOriginals  = "cleaning_originals"
+	StorageMigrationCompleted          = "completed"
+	StorageMigrationOriginalsRetained  = "originals_retained"
+
+	StorageMigrationItemPending        = "pending"
+	StorageMigrationItemCopying        = "copying"
+	StorageMigrationItemVerifying      = "verifying"
+	StorageMigrationItemCutover        = "cutover"
+	StorageMigrationItemCleanupPending = "cleanup_pending"
+	StorageMigrationItemCleaning       = "cleaning"
+	StorageMigrationItemCleaned        = "cleaned"
+	StorageMigrationItemOriginalKept   = "original_kept"
+	StorageMigrationItemFailed         = "failed"
+	StorageMigrationItemCanceled       = "canceled"
+)
+
+type StorageMigration struct {
+	Model
+	UUID                string `gorm:"uniqueIndex;size:64"`
+	SourcePoolID        uint   `gorm:"index"`
+	DestinationPoolID   uint   `gorm:"index"`
+	SourcePoolName      string `gorm:"size:120"`
+	DestinationPoolName string `gorm:"size:120"`
+	BackgroundJobID     string `gorm:"size:36;index"`
+	CleanupJobID        string `gorm:"size:36;index"`
+	Status              string `gorm:"size:32;index"`
+	Phase               string `gorm:"size:120"`
+	FileCount           int64
+	PlannedBytes        int64
+	ActualBytes         int64
+	CopiedBytes         int64
+	CutoverCount        int64
+	CleanedCount        int64
+	CreatedByID         uint   `gorm:"index"`
+	CreatedByName       string `gorm:"size:120"`
+	CancelGeneration    int
+	KeepOriginals       bool
+	CleanupAfter        *time.Time `gorm:"index"`
+	StartedAt           *time.Time
+	CopyCompletedAt     *time.Time
+	CompletedAt         *time.Time
+	CanceledAt          *time.Time
+	ErrorCode           string `gorm:"size:80"`
+	ErrorMessage        string `gorm:"size:512"`
+
+	Items []StorageMigrationItem `gorm:"foreignKey:MigrationID" json:"-"`
+}
+
+type StorageMigrationItem struct {
+	Model
+	MigrationID        uint   `gorm:"index;uniqueIndex:idx_storage_migration_file"`
+	FileID             uint   `gorm:"index;uniqueIndex:idx_storage_migration_file"`
+	FileUUID           string `gorm:"size:64;index"`
+	SourceMountID      string `gorm:"size:64;index"`
+	DestinationMountID string `gorm:"size:64;index"`
+	Status             string `gorm:"size:32;index"`
+	ReservationKey     string `gorm:"size:80;uniqueIndex:idx_storage_migration_reservation,where:reservation_key <> ''" json:"-"`
+	DestinationOwned   bool
+	PlannedBytes       int64
+	BytesTotal         int64
+	BytesCopied        int64
+	ObjectCount        int
+	ObjectsVerified    int
+	ProgressMessage    string `gorm:"size:255"`
+	ErrorCode          string `gorm:"size:80"`
+	ErrorMessage       string `gorm:"size:512"`
+	CopyStartedAt      *time.Time
+	VerifiedAt         *time.Time
+	CutoverAt          *time.Time
+	CleanedAt          *time.Time
+}

--- a/routes/api.go
+++ b/routes/api.go
@@ -42,6 +42,8 @@ func Api(apiGroup *echo.Group, handlers *controllers.Handlers, middlewareFactory
 	v2.GET("/jobs/:id", handlers.GetMyBackgroundJob)
 	v2.POST("/jobs/:id/cancel", handlers.CancelMyBackgroundJob)
 	v2.POST("/jobs/:id/retry", handlers.RetryMyBackgroundJob)
+	v2.POST("/jobs/:id/pause", handlers.PauseMyBackgroundJob)
+	v2.POST("/jobs/:id/resume", handlers.ResumeMyBackgroundJob)
 	// Versioned submission endpoints return 202 + Location and can be followed
 	// through the generic jobs API above.
 	v2.POST("/uploads/simple", handlers.SimpleUploadController,
@@ -63,6 +65,8 @@ func Api(apiGroup *echo.Group, handlers *controllers.Handlers, middlewareFactory
 	adminV2.GET("/jobs/:id", handlers.GetAdminBackgroundJob)
 	adminV2.POST("/jobs/:id/cancel", handlers.CancelAdminBackgroundJob)
 	adminV2.POST("/jobs/:id/retry", handlers.RetryAdminBackgroundJob)
+	adminV2.POST("/jobs/:id/pause", handlers.PauseAdminBackgroundJob)
+	adminV2.POST("/jobs/:id/resume", handlers.ResumeAdminBackgroundJob)
 	adminV2.POST("/tasks/:id/cancel", handlers.CancelAdminBackgroundTask)
 	adminV2.POST("/tasks/:id/retry", handlers.RetryAdminBackgroundTask)
 	adminV2.GET("/task-queues", handlers.ListAdminBackgroundQueues)
@@ -71,6 +75,13 @@ func Api(apiGroup *echo.Group, handlers *controllers.Handlers, middlewareFactory
 	adminV2.GET("/task-schedules", handlers.ListAdminBackgroundSchedules)
 	adminV2.POST("/task-schedules/:key/run", handlers.RunAdminBackgroundSchedule)
 	adminV2.GET("/task-runtime", handlers.GetAdminBackgroundRuntime)
+	adminV2.POST("/storage/migrations/preview", handlers.PreviewStorageMigration)
+	adminV2.POST("/storage/migrations", handlers.CreateStorageMigration)
+	adminV2.GET("/storage/migrations", handlers.ListStorageMigrations)
+	adminV2.GET("/storage/migrations/:id", handlers.GetStorageMigration)
+	adminV2.GET("/storage/migrations/:id/items", handlers.ListStorageMigrationItems)
+	adminV2.POST("/storage/migrations/:id/cancel", handlers.CancelFailedStorageMigration)
+	adminV2.POST("/storage/migrations/:id/keep-originals", handlers.KeepStorageMigrationOriginals)
 	protectedApi.POST("/folder", handlers.CreateFolder)
 	protectedApi.PUT("/folder", handlers.UpdateFolder)
 	protectedApi.DELETE("/folder", handlers.DeleteFolderLegacy)

--- a/routes/api_test.go
+++ b/routes/api_test.go
@@ -57,3 +57,50 @@ func TestAPIRoutesKeepLegacyContractsAlongsideBackgroundJobV2Routes(t *testing.T
 		}
 	}
 }
+
+func TestAPIRoutesExposePauseResumeAndStorageMigrationAdminEndpoints(t *testing.T) {
+	ratelimit := false
+	uploads := true
+	deps := &app.Deps{Snapshots: app.NewSnapshotStore(app.Snapshot{Config: config.Config{
+		UploadEnabled:        &uploads,
+		RatelimitEnabled:     &ratelimit,
+		RatelimitRateAuth:    1,
+		RatelimitBurstAuth:   1,
+		RatelimitRateApi:     1,
+		RatelimitBurstApi:    1,
+		RatelimitRateUpload:  1,
+		RatelimitBurstUpload: 1,
+		MaxUploadFilesize:    1024,
+		MaxUploadChunkSize:   1024,
+		MaxItemsMultiDelete:  100,
+	}})}
+
+	server := echo.New()
+	Api(
+		server.Group("/api"),
+		controllers.NewHandlers(deps, nil, nil, nil, nil),
+		middlewares.NewFactory(deps, nil),
+	)
+
+	routes := make(map[string]bool)
+	for _, route := range server.Routes() {
+		routes[route.Method+" "+route.Path] = true
+	}
+	for _, expected := range []string{
+		http.MethodPost + " /api/v2/jobs/:id/pause",
+		http.MethodPost + " /api/v2/jobs/:id/resume",
+		http.MethodPost + " /api/v2/admin/jobs/:id/pause",
+		http.MethodPost + " /api/v2/admin/jobs/:id/resume",
+		http.MethodPost + " /api/v2/admin/storage/migrations/preview",
+		http.MethodPost + " /api/v2/admin/storage/migrations",
+		http.MethodGet + " /api/v2/admin/storage/migrations",
+		http.MethodGet + " /api/v2/admin/storage/migrations/:id",
+		http.MethodGet + " /api/v2/admin/storage/migrations/:id/items",
+		http.MethodPost + " /api/v2/admin/storage/migrations/:id/cancel",
+		http.MethodPost + " /api/v2/admin/storage/migrations/:id/keep-originals",
+	} {
+		if !routes[expected] {
+			t.Errorf("missing background-job/storage-migration route %q", expected)
+		}
+	}
+}

--- a/services/BackgroundHandlers.go
+++ b/services/BackgroundHandlers.go
@@ -37,6 +37,10 @@ const (
 	taskAuditCleanup      = "maintenance.audit_cleanup"
 	taskResourceCleanup   = "maintenance.resource_cleanup"
 	taskJobRetention      = "maintenance.job_retention"
+	taskStorageMigration  = "storage.migration.run"
+	taskStorageCleanup    = "storage.migration.cleanup"
+	taskStorageAbort      = "storage.migration.abort_cleanup"
+	taskStorageReconcile  = "maintenance.storage_migrations"
 )
 
 type encodingTaskPayload struct {
@@ -97,6 +101,10 @@ func (w *WorkerGroup) RegisterBackgroundHandlers(runtime *background.Runtime, tu
 		taskAuditCleanup:      w.auditCleanupHandler,
 		taskResourceCleanup:   w.resourceCleanupHandler,
 		taskJobRetention:      w.jobRetentionHandler(runtime),
+		taskStorageMigration:  w.storageMigrationHandler(runtime),
+		taskStorageCleanup:    w.storageMigrationCleanupHandler,
+		taskStorageAbort:      w.storageMigrationAbortHandler(runtime),
+		taskStorageReconcile:  w.storageMigrationReconcileHandler(runtime),
 	}
 	for _, kind := range sortedHandlerKinds(registrations) {
 		if err := runtime.Register(kind, registrations[kind]); err != nil {
@@ -112,6 +120,7 @@ func (w *WorkerGroup) RegisterBackgroundHandlers(runtime *background.Runtime, tu
 		maintenanceSchedule("api-audit-retention", taskAuditCleanup, time.Hour, true),
 		maintenanceSchedule("resource-retention", taskResourceCleanup, time.Hour, false),
 		maintenanceSchedule("background-history-retention", taskJobRetention, 24*time.Hour, false),
+		maintenanceSchedule("storage-migration-reconciliation", taskStorageReconcile, time.Minute, true),
 	}
 	for _, schedule := range schedules {
 		if err := runtime.RegisterSchedule(schedule); err != nil {
@@ -142,6 +151,8 @@ func sortedHandlerKinds(handlers map[string]background.Handler) []string {
 		taskMediaImport, taskMediaThumbnail, taskEncodeQuality, taskEncodeAudio, taskEncodeSubtitle,
 		taskRemoteFetch, taskDownloadPrepare, taskContentDelete, taskAuditRecord, taskSourceCleanup,
 		taskDeletionReconcile, taskDownloadCleanup, taskUploadCleanup, taskAuditCleanup, taskResourceCleanup, taskJobRetention,
+		taskStorageMigration, taskStorageCleanup, taskStorageAbort,
+		taskStorageReconcile,
 	}
 	return order
 }
@@ -231,6 +242,13 @@ func (w *WorkerGroup) thumbnailHandler(ctx context.Context, task background.Task
 	if err := w.deps.DB.First(&file, payload.FileID).Error; err != nil {
 		return background.Result{}, background.Permanent("source_unavailable", "The source video is no longer available", err)
 	}
+	releaseFile := w.deps.StorageLifecycle.FileReadLock(file.ID)
+	defer releaseFile()
+	if err := w.deps.DB.WithContext(ctx).First(&file, payload.FileID).Error; err != nil {
+		return background.Result{}, background.Permanent("source_unavailable", "The source video is no longer available", err)
+	}
+	releaseMount := w.deps.StorageLifecycle.ReadLock(file.StorageID)
+	defer releaseMount()
 	if file.AvgFrameRate <= 0 || file.SourceKey == "" {
 		return background.Result{Phase: "Thumbnail not required"}, nil
 	}

--- a/services/Deleter.go
+++ b/services/Deleter.go
@@ -66,8 +66,18 @@ func (w *WorkerGroup) runDeleter() error {
 	var successDeletion int
 	for _, todo := range todos {
 		w.CancelDownloadPreparationsForFile(todo.ID)
+		w.cancelActiveEncodingsForFile(todo.ID, "file queued for deletion")
+		releaseFile := w.deps.StorageLifecycle.FileWriteLock(todo.ID)
+		if err := w.deps.DB.Unscoped().Preload("Qualitys").Preload("Subtitles").Preload("Audios").Preload("Links").First(&todo, todo.ID).Error; err != nil {
+			releaseFile()
+			if !errors.Is(err, gorm.ErrRecordNotFound) {
+				deletionErrors = append(deletionErrors, err)
+			}
+			continue
+		}
 		if w.HasActiveDownloadPreparationForFile(todo.ID) {
 			skippingDeletion++
+			releaseFile()
 			continue
 		}
 
@@ -93,11 +103,9 @@ func (w *WorkerGroup) runDeleter() error {
 		}
 
 		if encoding {
-			// Cancel any active source transfer, encode, or output publication.
-			w.cancelActiveEncodingsForFile(todo.ID, "file queued for deletion")
-
 			// we will try again in the next loop (the encoding process may be finished until then)
 			skippingDeletion++
+			releaseFile()
 			continue
 		}
 
@@ -105,6 +113,7 @@ func (w *WorkerGroup) runDeleter() error {
 			log.Printf("Failed to delete stored data for file %d: %v", todo.ID, err)
 			deletionErrors = append(deletionErrors, err)
 			skippingDeletion++
+			releaseFile()
 			continue
 		}
 
@@ -122,9 +131,11 @@ func (w *WorkerGroup) runDeleter() error {
 		}); err != nil {
 			log.Printf("Failed to delete file %d from database: %v", todo.ID, err)
 			deletionErrors = append(deletionErrors, err)
+			releaseFile()
 			continue
 		}
 		successDeletion++
+		releaseFile()
 	}
 	if skippingDeletion > 0 {
 		log.Printf("Skipped %d files from deletion", skippingDeletion)
@@ -136,6 +147,8 @@ func (w *WorkerGroup) runDeleter() error {
 }
 
 func (w *WorkerGroup) deleteStoredFile(file models.File) error {
+	releaseMount := w.deps.StorageLifecycle.ReadLock(file.StorageID)
+	defer releaseMount()
 	if file.Path != "" {
 		info, err := os.Stat(file.Path)
 		switch {

--- a/services/EncoderCleanup.go
+++ b/services/EncoderCleanup.go
@@ -8,6 +8,8 @@ import (
 	"log"
 	"os"
 	"time"
+
+	"gorm.io/gorm"
 )
 
 func (w *WorkerGroup) EncoderCleanup(ctx context.Context) {
@@ -40,6 +42,17 @@ func (w *WorkerGroup) runEncoderCleanup() error {
 	}
 
 	for _, dbReadyFile := range dbReadyFiles {
+		releaseFile := w.deps.StorageLifecycle.FileWriteLock(dbReadyFile.ID)
+		if res := w.deps.DB.
+			Preload("Qualitys").Preload("Subtitles").Preload("Audios").
+			Where("storage_state = ?", models.FileStorageAvailable).First(&dbReadyFile, dbReadyFile.ID); res.Error != nil {
+			releaseFile()
+			if !errors.Is(res.Error, gorm.ErrRecordNotFound) {
+				cleanupErrors = append(cleanupErrors, res.Error)
+			}
+			continue
+		}
+		releaseMount := w.deps.StorageLifecycle.ReadLock(dbReadyFile.StorageID)
 		var qualityAmount int64
 		if res := w.deps.DB.
 			Model(&models.Quality{}).
@@ -50,6 +63,8 @@ func (w *WorkerGroup) runEncoderCleanup() error {
 			Count(&qualityAmount); res.Error != nil {
 			log.Printf("Failed to count quality by (delete candidate): Searcher ID %d inside database. Error: %v", dbReadyFile.ID, res.Error)
 			cleanupErrors = append(cleanupErrors, res.Error)
+			releaseMount()
+			releaseFile()
 			continue
 		}
 
@@ -63,6 +78,8 @@ func (w *WorkerGroup) runEncoderCleanup() error {
 			Count(&subtitleAmount); res.Error != nil {
 			log.Printf("Failed to count subtitle by (delete candidate): Searcher ID %d inside database. Error: %v", dbReadyFile.ID, res.Error)
 			cleanupErrors = append(cleanupErrors, res.Error)
+			releaseMount()
+			releaseFile()
 			continue
 		}
 
@@ -76,6 +93,8 @@ func (w *WorkerGroup) runEncoderCleanup() error {
 			Count(&audioAmount); res.Error != nil {
 			log.Printf("Failed to count audio by (delete candidate): Searcher ID %d inside database. Error: %v", dbReadyFile.ID, res.Error)
 			cleanupErrors = append(cleanupErrors, res.Error)
+			releaseMount()
+			releaseFile()
 			continue
 		}
 
@@ -87,23 +106,31 @@ func (w *WorkerGroup) runEncoderCleanup() error {
 				if w.deps.Storage == nil {
 					log.Printf("Failed to delete source object for file %d: storage is not configured", dbReadyFile.ID)
 					cleanupErrors = append(cleanupErrors, storage.ErrStoreNotConfigured)
+					releaseMount()
+					releaseFile()
 					continue
 				}
 				store, err := w.deps.Storage.StoreOrDefault(dbReadyFile.StorageID)
 				if err != nil {
 					log.Printf("Failed to resolve source store for file %d: %v", dbReadyFile.ID, err)
 					cleanupErrors = append(cleanupErrors, err)
+					releaseMount()
+					releaseFile()
 					continue
 				}
 				key, err := storage.ParseKey(dbReadyFile.SourceKey)
 				if err != nil {
 					log.Printf("Failed to parse source key for file %d: %v", dbReadyFile.ID, err)
 					cleanupErrors = append(cleanupErrors, err)
+					releaseMount()
+					releaseFile()
 					continue
 				}
 				if err := store.Delete(context.Background(), key); err != nil {
 					log.Printf("Failed to delete source object %s: %v", dbReadyFile.SourceKey, err)
 					cleanupErrors = append(cleanupErrors, err)
+					releaseMount()
+					releaseFile()
 					continue
 				}
 			}
@@ -111,6 +138,8 @@ func (w *WorkerGroup) runEncoderCleanup() error {
 				if err := os.Remove(dbReadyFile.Path); err != nil && !errors.Is(err, os.ErrNotExist) {
 					log.Printf("Failed to delete file from path (%v): %v", dbReadyFile.Path, err)
 					cleanupErrors = append(cleanupErrors, err)
+					releaseMount()
+					releaseFile()
 					continue
 				}
 			}
@@ -129,6 +158,8 @@ func (w *WorkerGroup) runEncoderCleanup() error {
 				cleanupErrors = append(cleanupErrors, err)
 			}
 		}
+		releaseMount()
+		releaseFile()
 	}
 	return errors.Join(cleanupErrors...)
 }

--- a/services/Storage.go
+++ b/services/Storage.go
@@ -56,7 +56,15 @@ func (w *WorkerGroup) publishEncodingOutput(ctx context.Context, file models.Fil
 	if w.deps == nil || w.deps.Storage == nil {
 		return nil
 	}
-	_, err := w.deps.Storage.PublishPrefix(ctx, file.StorageID, prefix, directory, storage.PutOptions{
+	releaseFile := w.deps.StorageLifecycle.FileReadLock(file.ID)
+	defer releaseFile()
+	var current models.File
+	if err := w.deps.DB.WithContext(ctx).First(&current, file.ID).Error; err != nil {
+		return err
+	}
+	releaseMount := w.deps.StorageLifecycle.ReadLock(current.StorageID)
+	defer releaseMount()
+	_, err := w.deps.Storage.PublishPrefix(ctx, current.StorageID, prefix, directory, storage.PutOptions{
 		CacheControl: "public, max-age=3600",
 	})
 	return err

--- a/services/StorageMigration.go
+++ b/services/StorageMigration.go
@@ -376,7 +376,7 @@ func (w *WorkerGroup) refreshStorageMigrationProgress(ctx context.Context, migra
 			COALESCE(SUM(bytes_copied), 0) AS copied_bytes,
 			SUM(CASE WHEN status IN ? THEN 1 ELSE 0 END) AS cutover_count,
 			SUM(CASE WHEN status = ? THEN 1 ELSE 0 END) AS cleaned_count,
-			COUNT(*) AS file_count`, []string{models.StorageMigrationItemCleanupPending, models.StorageMigrationItemCleaning, models.StorageMigrationItemCleaned, models.StorageMigrationItemOriginalKept}, models.StorageMigrationItemCleaned).
+			COUNT(*) AS file_count`, []string{models.StorageMigrationItemCleanupPending, models.StorageMigrationItemCleaning, models.StorageMigrationItemCleaned, models.StorageMigrationItemOriginalKept, models.StorageMigrationItemOriginalPartial}, models.StorageMigrationItemCleaned).
 		Where("migration_id = ?", migrationID).Scan(&aggregate).Error
 	if err != nil {
 		return err
@@ -406,11 +406,15 @@ func (w *WorkerGroup) scheduleStorageMigrationCleanup(ctx context.Context, runti
 		return nil
 	}
 	cleanupAfter := time.Now().UTC().Add(storageMigrationCleanupGrace)
+	if migration.CleanupAfter != nil {
+		cleanupAfter = migration.CleanupAfter.UTC()
+	}
 	job, _, err := runtime.Enqueue(ctx, background.JobSpec{
 		Kind: "storage.migration.cleanup", Visibility: background.VisibilityAdmin,
 		SubjectType: "storage_migration", SubjectID: migration.UUID,
 		IdempotencyKey: "storage-migration-cleanup:" + migration.UUID,
 		Label:          fmt.Sprintf("Clean originals from %s", migration.SourcePoolName),
+		Pausable:       true,
 		Tasks: []background.TaskSpec{{
 			Kind: taskStorageCleanup, Queue: background.QueueStorage, Phase: "Retaining originals",
 			Payload: storageMigrationTaskPayload{MigrationID: migration.ID}, DedupeKey: fmt.Sprintf("storage-cleanup:%d", migration.ID),
@@ -472,6 +476,14 @@ func (w *WorkerGroup) storageMigrationCleanupHandler(ctx context.Context, task b
 			return background.Result{}, background.Transient("cleanup_progress_failed", "Original cleanup progress could not be recorded", err)
 		}
 		background.ReportProgress(ctx, float64(index+1)/float64(len(items)), fmt.Sprintf("Cleaned %d of %d originals", index+1, len(items)))
+		if err := ctx.Err(); err != nil {
+			status, phase := models.StorageMigrationCanceled, "Cleanup canceled; remaining originals retained"
+			if background.PauseRequested(ctx) {
+				status, phase = models.StorageMigrationPaused, "Cleanup paused"
+			}
+			_ = w.deps.DB.WithContext(context.WithoutCancel(ctx)).Model(&migration).Updates(map[string]any{"status": status, "phase": phase}).Error
+			return background.Result{}, err
+		}
 	}
 	if err := w.deps.DB.WithContext(context.WithoutCancel(ctx)).First(&migration, migration.ID).Error; err == nil && migration.KeepOriginals {
 		return background.Result{ResultType: "storage_migration", ResultID: migration.UUID, Phase: "Originals retained"}, nil
@@ -487,17 +499,23 @@ func (w *WorkerGroup) storageMigrationCleanupHandler(ctx context.Context, task b
 }
 
 func (w *WorkerGroup) cleanupStorageMigrationItem(ctx context.Context, item *models.StorageMigrationItem) error {
-	if item.Status == models.StorageMigrationItemCleaned || item.Status == models.StorageMigrationItemOriginalKept {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if item.Status == models.StorageMigrationItemCleaned || item.Status == models.StorageMigrationItemOriginalKept || item.Status == models.StorageMigrationItemOriginalPartial {
 		return nil
 	}
 	releaseFile := w.deps.StorageLifecycle.FileWriteLock(item.FileID)
 	defer releaseFile()
 	releaseMount := w.deps.StorageLifecycle.ReadLock(item.SourceMountID)
 	defer releaseMount()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if err := w.deps.DB.WithContext(ctx).First(item, item.ID).Error; err != nil {
 		return err
 	}
-	if item.Status == models.StorageMigrationItemCleaned || item.Status == models.StorageMigrationItemOriginalKept {
+	if item.Status == models.StorageMigrationItemCleaned || item.Status == models.StorageMigrationItemOriginalKept || item.Status == models.StorageMigrationItemOriginalPartial {
 		return nil
 	}
 	var file models.File
@@ -521,11 +539,15 @@ func (w *WorkerGroup) cleanupStorageMigrationItem(ctx context.Context, item *mod
 	}).Error; err != nil {
 		return err
 	}
-	if err := storage.DeletePrefix(ctx, store, prefix); err != nil {
+	// Once cleanup begins for a video, finish that whole video before honoring a
+	// pause or cancel. This prevents a retained original from being only partly
+	// deleted while still presenting cleanup as safely stopped.
+	commitCtx := context.WithoutCancel(ctx)
+	if err := storage.DeletePrefix(commitCtx, store, prefix); err != nil {
 		return err
 	}
 	now := time.Now().UTC()
-	return w.deps.DB.WithContext(context.WithoutCancel(ctx)).Model(item).Updates(map[string]any{
+	return w.deps.DB.WithContext(commitCtx).Model(item).Updates(map[string]any{
 		"status": models.StorageMigrationItemCleaned, "cleaned_at": &now, "reservation_key": "",
 		"progress_message": "Original removed", "error_code": "", "error_message": "",
 	}).Error
@@ -558,6 +580,14 @@ func (w *WorkerGroup) storageMigrationAbortHandler(runtime *background.Runtime) 
 				return background.Result{}, background.Transient("abort_cleanup_failed", "Incomplete destination data could not be cleaned", err)
 			}
 			background.ReportProgress(ctx, float64(index+1)/float64(len(items)), fmt.Sprintf("Reconciled %d of %d videos", index+1, len(items)))
+			if err := ctx.Err(); err != nil {
+				phase := "Canceled; incomplete destination cleanup stopped"
+				if background.PauseRequested(ctx) {
+					phase = "Canceled; incomplete destination cleanup paused"
+				}
+				_ = w.deps.DB.WithContext(context.WithoutCancel(ctx)).Model(&migration).Update("phase", phase).Error
+				return background.Result{}, err
+			}
 		}
 		if err := w.refreshStorageMigrationProgress(context.WithoutCancel(ctx), migration.ID); err != nil {
 			return background.Result{}, background.Transient("abort_progress_failed", "Canceled migration progress could not be reconciled", err)
@@ -573,10 +603,16 @@ func (w *WorkerGroup) storageMigrationAbortHandler(runtime *background.Runtime) 
 }
 
 func (w *WorkerGroup) cleanupCanceledStorageMigrationItem(ctx context.Context, item *models.StorageMigrationItem) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	releaseFile := w.deps.StorageLifecycle.FileWriteLock(item.FileID)
 	defer releaseFile()
 	releaseMount := w.deps.StorageLifecycle.ReadLock(item.DestinationMountID)
 	defer releaseMount()
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if err := w.deps.DB.WithContext(ctx).First(item, item.ID).Error; err != nil {
 		return err
 	}
@@ -603,7 +639,7 @@ func (w *WorkerGroup) cleanupCanceledStorageMigrationItem(ctx context.Context, i
 		if err != nil {
 			return err
 		}
-		if err := storage.DeletePrefix(ctx, store, prefix); err != nil {
+		if err := storage.DeletePrefix(context.WithoutCancel(ctx), store, prefix); err != nil {
 			return err
 		}
 	}
@@ -629,55 +665,207 @@ func (w *WorkerGroup) storageMigrationReconcileHandler(runtime *background.Runti
 		}
 		var migrations []models.StorageMigration
 		if err := w.deps.DB.WithContext(ctx).
-			Where(`(cleanup_job_id = '' AND status IN ?) OR
-				(cleanup_job_id <> '' AND status IN ?)`,
-				[]string{models.StorageMigrationQueued, models.StorageMigrationRunning, models.StorageMigrationPaused, models.StorageMigrationCanceled},
-				[]string{models.StorageMigrationRetainingOriginals, models.StorageMigrationCleaningOriginals, models.StorageMigrationPaused}).
+			Where("status IN ?", []string{
+				models.StorageMigrationQueued, models.StorageMigrationRunning, models.StorageMigrationPaused,
+				models.StorageMigrationCanceled, models.StorageMigrationRetainingOriginals, models.StorageMigrationCleaningOriginals,
+			}).
 			Order("id ASC").Find(&migrations).Error; err != nil {
 			return background.Result{}, background.Transient("migration_reconcile_load_failed", "Storage migrations could not be inspected", err)
 		}
 		reconciled := 0
 		for index := range migrations {
+			if err := ctx.Err(); err != nil {
+				return background.Result{}, err
+			}
 			migration := &migrations[index]
-			mainCanceled := false
-			var mainJob background.Job
+			durableCtx := context.WithoutCancel(ctx)
+			if migration.CleanupJobID != "" {
+				cleanupJob, err := runtime.Job(ctx, migration.CleanupJobID, nil, true)
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					if migration.Status == models.StorageMigrationCanceled {
+						if err := w.logic.EnsureStorageMigrationAbortCleanup(durableCtx, migration.ID); err != nil {
+							return background.Result{}, background.Transient("migration_reconcile_abort_failed", "Canceled migration cleanup could not be restored", err)
+						}
+					} else {
+						wasPaused := migration.Status == models.StorageMigrationPaused
+						if err := w.deps.DB.WithContext(durableCtx).Model(migration).Update("cleanup_job_id", "").Error; err != nil {
+							return background.Result{}, background.Transient("migration_reconcile_link_failed", "Original cleanup could not be relinked", err)
+						}
+						migration.CleanupJobID = ""
+						if err := w.scheduleStorageMigrationCleanup(durableCtx, runtime, migration); err != nil {
+							return background.Result{}, background.Transient("migration_reconcile_cleanup_failed", "Original cleanup could not be restored", err)
+						}
+						if wasPaused {
+							if err := runtime.PauseJob(durableCtx, migration.CleanupJobID, 0, "VideoCMS"); err != nil && !errors.Is(err, background.ErrConflict) {
+								return background.Result{}, background.Transient("migration_reconcile_pause_failed", "Paused original cleanup could not be restored", err)
+							}
+							if err := w.deps.DB.WithContext(durableCtx).Model(migration).Updates(map[string]any{
+								"status": models.StorageMigrationPaused, "phase": "Original cleanup paused",
+							}).Error; err != nil {
+								return background.Result{}, background.Transient("migration_reconcile_state_failed", "Paused cleanup status could not be restored", err)
+							}
+						}
+					}
+					reconciled++
+				} else if err != nil {
+					return background.Result{}, background.Transient("migration_reconcile_job_failed", "Original cleanup status could not be inspected", err)
+				} else if cleanupJob.Kind == "storage.migration.cleanup" {
+					switch cleanupJob.Status {
+					case background.JobCanceled:
+						if _, err := w.logic.KeepStorageMigrationOriginals(durableCtx, migration.UUID, 0, "VideoCMS"); err != nil {
+							return background.Result{}, background.Transient("migration_reconcile_retention_failed", "Canceled original cleanup could not be reconciled", err)
+						}
+						reconciled++
+					case background.JobPauseRequested, background.JobPaused:
+						if migration.Status != models.StorageMigrationPaused {
+							if err := w.deps.DB.WithContext(durableCtx).Model(migration).Updates(map[string]any{"status": models.StorageMigrationPaused, "phase": "Original cleanup paused"}).Error; err != nil {
+								return background.Result{}, background.Transient("migration_reconcile_state_failed", "Paused cleanup status could not be repaired", err)
+							}
+							reconciled++
+						}
+					case background.JobQueued, background.JobRetryWait, background.JobRunning:
+						status, phase := models.StorageMigrationCleaningOriginals, "Cleaning original copies"
+						if cleanupJob.Status != background.JobRunning && migration.CleanupAfter != nil && migration.CleanupAfter.After(time.Now().UTC()) {
+							status, phase = models.StorageMigrationRetainingOriginals, "Retaining originals until cleanup begins"
+						}
+						if migration.Status != status || migration.Phase != phase {
+							if err := w.deps.DB.WithContext(durableCtx).Model(migration).Updates(map[string]any{"status": status, "phase": phase}).Error; err != nil {
+								return background.Result{}, background.Transient("migration_reconcile_state_failed", "Cleanup status could not be repaired", err)
+							}
+							reconciled++
+						}
+					case background.JobSucceeded, background.JobSucceededWithWarnings:
+						completedAt := time.Now().UTC()
+						if err := w.refreshStorageMigrationProgress(durableCtx, migration.ID); err != nil {
+							return background.Result{}, background.Transient("migration_reconcile_progress_failed", "Cleanup progress could not be repaired", err)
+						}
+						if err := w.deps.DB.WithContext(durableCtx).Model(migration).Updates(map[string]any{
+							"status": models.StorageMigrationCompleted, "phase": "Migration and cleanup complete", "completed_at": &completedAt,
+						}).Error; err != nil {
+							return background.Result{}, background.Transient("migration_reconcile_state_failed", "Completed cleanup status could not be repaired", err)
+						}
+						reconciled++
+					case background.JobFailed:
+						if migration.Phase != "Original cleanup needs attention" {
+							if err := w.deps.DB.WithContext(durableCtx).Model(migration).Updates(map[string]any{
+								"phase": "Original cleanup needs attention", "error_code": cleanupJob.ErrorCode, "error_message": cleanupJob.ErrorMessage,
+							}).Error; err != nil {
+								return background.Result{}, background.Transient("migration_reconcile_state_failed", "Failed cleanup status could not be repaired", err)
+							}
+							reconciled++
+						}
+					}
+				} else if cleanupJob.Kind == "storage.migration.abort_cleanup" {
+					phase := "Canceled; cleaning incomplete destination data"
+					if cleanupJob.Status == background.JobPauseRequested || cleanupJob.Status == background.JobPaused {
+						phase = "Canceled; incomplete destination cleanup paused"
+					} else if cleanupJob.Status == background.JobCanceled {
+						phase = "Canceled; incomplete destination cleanup stopped"
+					} else if cleanupJob.Status == background.JobFailed {
+						phase = "Canceled; incomplete destination cleanup needs attention"
+					} else if cleanupJob.Status == background.JobSucceeded || cleanupJob.Status == background.JobSucceededWithWarnings {
+						phase = "Canceled; incomplete destination data cleaned and originals retained"
+					}
+					if migration.Status != models.StorageMigrationCanceled || migration.Phase != phase {
+						if err := w.deps.DB.WithContext(durableCtx).Model(migration).Updates(map[string]any{"status": models.StorageMigrationCanceled, "phase": phase}).Error; err != nil {
+							return background.Result{}, background.Transient("migration_reconcile_state_failed", "Canceled migration status could not be repaired", err)
+						}
+						reconciled++
+					}
+				}
+				background.ReportProgress(ctx, float64(index+1)/float64(len(migrations)), fmt.Sprintf("Inspected %d of %d migrations", index+1, len(migrations)))
+				continue
+			}
+
+			if migration.Status == models.StorageMigrationCanceled {
+				if err := w.logic.EnsureStorageMigrationAbortCleanup(durableCtx, migration.ID); err != nil {
+					return background.Result{}, background.Transient("migration_reconcile_abort_failed", "A canceled migration could not be reconciled", err)
+				}
+				reconciled++
+				background.ReportProgress(ctx, float64(index+1)/float64(len(migrations)), fmt.Sprintf("Inspected %d of %d migrations", index+1, len(migrations)))
+				continue
+			}
+			if migration.Status == models.StorageMigrationRetainingOriginals || migration.Status == models.StorageMigrationCleaningOriginals {
+				if err := w.scheduleStorageMigrationCleanup(durableCtx, runtime, migration); err != nil {
+					return background.Result{}, background.Transient("migration_reconcile_cleanup_failed", "Original cleanup could not be restored", err)
+				}
+				reconciled++
+				background.ReportProgress(ctx, float64(index+1)/float64(len(migrations)), fmt.Sprintf("Inspected %d of %d migrations", index+1, len(migrations)))
+				continue
+			}
+
+			mainMissing := false
+			var persistedMain background.Job
 			mainQuery := w.deps.DB.WithContext(ctx)
 			if migration.BackgroundJobID != "" {
 				mainQuery = mainQuery.Where("id = ?", migration.BackgroundJobID)
 			} else {
 				mainQuery = mainQuery.Where("kind = ? AND subject_type = ? AND subject_id = ?", "storage.migration", "storage_migration", migration.UUID).Order("created_at DESC")
 			}
-			if err := mainQuery.First(&mainJob).Error; err == nil {
-				if migration.BackgroundJobID == "" {
-					_ = w.deps.DB.WithContext(context.WithoutCancel(ctx)).Model(migration).Update("background_job_id", mainJob.ID).Error
-				}
-				mainCanceled = mainJob.Status == background.JobCanceled
+			if err := mainQuery.First(&persistedMain).Error; errors.Is(err, gorm.ErrRecordNotFound) {
+				mainMissing = true
+			} else if err != nil {
+				return background.Result{}, background.Transient("migration_reconcile_main_failed", "The migration job could not be inspected", err)
 			}
-			if mainCanceled {
-				if err := w.logic.EnsureStorageMigrationAbortCleanup(context.WithoutCancel(ctx), migration.ID); err != nil {
+			mainJob, err := w.logic.EnsureStorageMigrationJob(durableCtx, migration.ID)
+			if err != nil {
+				return background.Result{}, background.Transient("migration_reconcile_main_failed", "The migration job could not be restored", err)
+			}
+			if migration.BackgroundJobID != mainJob.ID {
+				migration.BackgroundJobID = mainJob.ID
+				reconciled++
+			}
+			if mainMissing && migration.Status == models.StorageMigrationPaused && mainJob.Status != background.JobPaused && mainJob.Status != background.JobPauseRequested {
+				if err := runtime.PauseJob(durableCtx, mainJob.ID, 0, "VideoCMS"); err != nil && !errors.Is(err, background.ErrConflict) {
+					return background.Result{}, background.Transient("migration_reconcile_pause_failed", "Paused migration status could not be restored", err)
+				}
+				mainJob, err = w.logic.EnsureStorageMigrationJob(durableCtx, migration.ID)
+				if err != nil {
+					return background.Result{}, background.Transient("migration_reconcile_main_failed", "The paused migration job could not be reloaded", err)
+				}
+			}
+			switch mainJob.Status {
+			case background.JobCanceled:
+				if err := w.logic.EnsureStorageMigrationAbortCleanup(durableCtx, migration.ID); err != nil {
 					return background.Result{}, background.Transient("migration_reconcile_abort_failed", "A canceled migration could not be reconciled", err)
 				}
 				reconciled++
-				background.ReportProgress(ctx, float64(index+1)/float64(len(migrations)), fmt.Sprintf("Inspected %d of %d migrations", index+1, len(migrations)))
-				continue
-			}
-			if migration.CleanupJobID != "" {
-				if cleanupJob, err := runtime.Job(ctx, migration.CleanupJobID, nil, true); err == nil &&
-					cleanupJob.Kind == "storage.migration.cleanup" && cleanupJob.Status == background.JobCanceled {
-					if _, err := w.logic.KeepStorageMigrationOriginals(context.WithoutCancel(ctx), migration.UUID, 0, "VideoCMS"); err != nil {
-						return background.Result{}, background.Transient("migration_reconcile_retention_failed", "Canceled original cleanup could not be reconciled", err)
+			case background.JobPauseRequested, background.JobPaused:
+				if migration.Status != models.StorageMigrationPaused {
+					if err := w.deps.DB.WithContext(durableCtx).Model(migration).Updates(map[string]any{"status": models.StorageMigrationPaused, "phase": "Migration paused"}).Error; err != nil {
+						return background.Result{}, background.Transient("migration_reconcile_state_failed", "Paused migration status could not be repaired", err)
 					}
 					reconciled++
 				}
-				background.ReportProgress(ctx, float64(index+1)/float64(len(migrations)), fmt.Sprintf("Inspected %d of %d migrations", index+1, len(migrations)))
-				continue
-			}
-			needsAbort := migration.Status == models.StorageMigrationCanceled && migration.CleanupJobID == ""
-			if needsAbort {
-				if err := w.logic.EnsureStorageMigrationAbortCleanup(context.WithoutCancel(ctx), migration.ID); err != nil {
-					return background.Result{}, background.Transient("migration_reconcile_abort_failed", "A canceled migration could not be reconciled", err)
+			case background.JobQueued, background.JobRetryWait:
+				if migration.Status != models.StorageMigrationQueued {
+					if err := w.deps.DB.WithContext(durableCtx).Model(migration).Updates(map[string]any{"status": models.StorageMigrationQueued, "phase": "Waiting to resume migration"}).Error; err != nil {
+						return background.Result{}, background.Transient("migration_reconcile_state_failed", "Queued migration status could not be repaired", err)
+					}
+					reconciled++
+				}
+			case background.JobRunning:
+				if migration.Status != models.StorageMigrationRunning {
+					if err := w.deps.DB.WithContext(durableCtx).Model(migration).Updates(map[string]any{"status": models.StorageMigrationRunning, "phase": "Migrating videos"}).Error; err != nil {
+						return background.Result{}, background.Transient("migration_reconcile_state_failed", "Running migration status could not be repaired", err)
+					}
+					reconciled++
+				}
+			case background.JobSucceeded, background.JobSucceededWithWarnings:
+				if err := w.scheduleStorageMigrationCleanup(durableCtx, runtime, migration); err != nil {
+					return background.Result{}, background.Transient("migration_reconcile_cleanup_failed", "Original cleanup could not be restored", err)
 				}
 				reconciled++
+			case background.JobFailed:
+				if migration.Status != models.StorageMigrationFailed {
+					if err := w.deps.DB.WithContext(durableCtx).Model(migration).Updates(map[string]any{
+						"status": models.StorageMigrationFailed, "phase": "Migration needs attention",
+						"error_code": mainJob.ErrorCode, "error_message": mainJob.ErrorMessage,
+					}).Error; err != nil {
+						return background.Result{}, background.Transient("migration_reconcile_state_failed", "Failed migration status could not be repaired", err)
+					}
+					reconciled++
+				}
 			}
 			background.ReportProgress(ctx, float64(index+1)/float64(len(migrations)), fmt.Sprintf("Inspected %d of %d migrations", index+1, len(migrations)))
 		}

--- a/services/StorageMigration.go
+++ b/services/StorageMigration.go
@@ -1,0 +1,686 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"ch/kirari04/videocms/background"
+	"ch/kirari04/videocms/models"
+	"ch/kirari04/videocms/storage"
+
+	"gorm.io/gorm"
+)
+
+const storageMigrationCleanupGrace = 24 * time.Hour
+
+var errStorageMigrationStateConflict = errors.New("storage migration state changed")
+
+type storageMigrationTaskPayload struct {
+	MigrationID uint `json:"migrationId"`
+}
+
+func (w *WorkerGroup) storageMigrationHandler(runtime *background.Runtime) background.Handler {
+	return func(ctx context.Context, task background.Task) (background.Result, error) {
+		var payload storageMigrationTaskPayload
+		if err := decodeTaskPayload(task, &payload); err != nil {
+			return background.Result{}, err
+		}
+		var migration models.StorageMigration
+		if err := w.deps.DB.WithContext(ctx).First(&migration, payload.MigrationID).Error; err != nil {
+			return background.Result{}, background.Permanent("migration_missing", "The storage migration no longer exists", err)
+		}
+		if migration.CanceledAt != nil && migration.CleanupJobID != "" {
+			if cleanup, cleanupErr := runtime.Job(ctx, migration.CleanupJobID, nil, true); cleanupErr == nil && !storageMigrationJobTerminal(cleanup.Status) {
+				return background.Result{}, &background.TaskError{Code: "abort_cleanup_running", Public: "Canceled migration cleanup is still running", Class: background.ErrorTransient, RetryAfter: 5 * time.Second}
+			}
+		}
+		if migration.Status == models.StorageMigrationRetainingOriginals || migration.Status == models.StorageMigrationCompleted || migration.Status == models.StorageMigrationOriginalsRetained {
+			if migration.CleanupJobID == "" && migration.Status == models.StorageMigrationRetainingOriginals {
+				if err := w.scheduleStorageMigrationCleanup(ctx, runtime, &migration); err != nil {
+					return background.Result{}, background.Transient("cleanup_queue_failed", "Cleanup could not be scheduled", err)
+				}
+			}
+			return background.Result{ResultType: "storage_migration", ResultID: migration.UUID, Phase: "Migration complete"}, nil
+		}
+		if err := w.prepareStorageMigrationRetry(ctx, &migration); err != nil {
+			if errors.Is(err, errStorageMigrationStateConflict) {
+				return background.Result{}, background.Permanent("migration_conflict", "A video is reserved by another migration", err)
+			}
+			return background.Result{}, background.Transient("migration_reservation_failed", "Migration videos could not be reserved", err)
+		}
+		now := time.Now().UTC()
+		if err := w.deps.DB.WithContext(ctx).Model(&migration).Updates(map[string]any{
+			"status": models.StorageMigrationRunning, "phase": "Migrating videos", "started_at": gorm.Expr("COALESCE(started_at, ?)", now),
+			"background_job_id": task.JobID, "error_code": "", "error_message": "",
+		}).Error; err != nil {
+			return background.Result{}, background.Transient("migration_state_failed", "Migration state could not be updated", err)
+		}
+
+		var items []models.StorageMigrationItem
+		if err := w.deps.DB.WithContext(ctx).
+			Where("migration_id = ? AND status NOT IN ?", migration.ID, []string{models.StorageMigrationItemCleanupPending, models.StorageMigrationItemCleaned}).
+			Order("id ASC").Find(&items).Error; err != nil {
+			return background.Result{}, background.Transient("migration_items_failed", "Migration videos could not be loaded", err)
+		}
+		if err := w.runStorageMigrationItems(ctx, migration, items); err != nil {
+			status, phase := models.StorageMigrationRunning, "A copy failed; retry will be scheduled"
+			permanentFailure := errors.Is(err, errStorageMigrationStateConflict)
+			if permanentFailure || task.AttemptCount >= task.MaxAttempts {
+				status, phase = models.StorageMigrationFailed, "Migration needs attention"
+			}
+			if ctx.Err() != nil {
+				status, phase = models.StorageMigrationCanceled, "Migration canceled"
+				if background.PauseRequested(ctx) {
+					status, phase = models.StorageMigrationPaused, "Migration paused"
+				}
+			}
+			updates := map[string]any{"status": status, "phase": phase}
+			if status == models.StorageMigrationFailed || status == models.StorageMigrationRunning {
+				updates["error_code"] = "video_migration_failed"
+				updates["error_message"] = boundedServiceError(err.Error())
+			}
+			if status == models.StorageMigrationCanceled {
+				updates["canceled_at"] = time.Now().UTC()
+			}
+			_ = w.deps.DB.WithContext(context.WithoutCancel(ctx)).Model(&migration).Updates(updates).Error
+			if status == models.StorageMigrationCanceled && w.logic != nil {
+				if abortErr := w.logic.EnsureStorageMigrationAbortCleanup(context.WithoutCancel(ctx), migration.ID); abortErr != nil {
+					_ = w.deps.DB.WithContext(context.WithoutCancel(ctx)).Model(&migration).Updates(map[string]any{
+						"phase":      "Canceled; cleanup will be reconciled automatically",
+						"error_code": "abort_cleanup_pending", "error_message": boundedServiceError(abortErr.Error()),
+					}).Error
+				}
+			}
+			if ctx.Err() != nil {
+				return background.Result{}, ctx.Err()
+			}
+			if errors.Is(err, errStorageMigrationStateConflict) {
+				return background.Result{}, background.Permanent("migration_conflict", "A video changed storage while it was being migrated", err)
+			}
+			return background.Result{}, background.Transient("storage_copy_failed", "A video could not be copied and verified", err)
+		}
+		if err := w.refreshStorageMigrationProgress(context.WithoutCancel(ctx), migration.ID); err != nil {
+			return background.Result{}, background.Transient("migration_progress_failed", "Migration progress could not be finalized", err)
+		}
+		if err := ctx.Err(); err != nil {
+			return background.Result{}, err
+		}
+		if err := w.scheduleStorageMigrationCleanup(context.WithoutCancel(ctx), runtime, &migration); err != nil {
+			return background.Result{}, background.Transient("cleanup_queue_failed", "Cleanup could not be scheduled", err)
+		}
+		return background.Result{ResultType: "storage_migration", ResultID: migration.UUID, Phase: "Migration complete"}, nil
+	}
+}
+
+func (w *WorkerGroup) prepareStorageMigrationRetry(ctx context.Context, migration *models.StorageMigration) error {
+	return w.deps.DB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var items []models.StorageMigrationItem
+		if err := tx.Where("migration_id = ?", migration.ID).Order("id ASC").Find(&items).Error; err != nil {
+			return err
+		}
+		for index := range items {
+			item := &items[index]
+			var file models.File
+			if err := tx.First(&file, item.FileID).Error; err != nil {
+				return err
+			}
+			status := models.StorageMigrationItemPending
+			if file.StorageID == item.DestinationMountID && item.CutoverAt != nil {
+				status = models.StorageMigrationItemCleanupPending
+			} else if file.StorageID != item.SourceMountID {
+				return fmt.Errorf("%w: file %d moved to %s", errStorageMigrationStateConflict, file.ID, file.StorageID)
+			}
+			updates := map[string]any{"reservation_key": fmt.Sprintf("file:%d", item.FileID), "status": status, "error_code": "", "error_message": ""}
+			if status == models.StorageMigrationItemPending && item.Status == models.StorageMigrationItemCanceled {
+				updates["destination_owned"] = false
+				updates["bytes_copied"] = 0
+				updates["objects_verified"] = 0
+			}
+			if err := tx.Model(item).Updates(updates).Error; err != nil {
+				if strings.Contains(strings.ToLower(err.Error()), "unique") {
+					return errStorageMigrationStateConflict
+				}
+				return err
+			}
+		}
+		return tx.Model(migration).Updates(map[string]any{"keep_originals": false, "cleanup_job_id": "", "cleanup_after": nil, "canceled_at": nil}).Error
+	})
+}
+
+func (w *WorkerGroup) runStorageMigrationItems(ctx context.Context, migration models.StorageMigration, items []models.StorageMigrationItem) error {
+	if len(items) == 0 {
+		return nil
+	}
+	workCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	queue := make(chan models.StorageMigrationItem, len(items))
+	for _, item := range items {
+		queue <- item
+	}
+	close(queue)
+	var workers sync.WaitGroup
+	var firstErr error
+	var errorMu sync.Mutex
+	workerCount := 2
+	if len(items) < workerCount {
+		workerCount = len(items)
+	}
+	for index := 0; index < workerCount; index++ {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			for item := range queue {
+				if workCtx.Err() != nil {
+					return
+				}
+				if err := w.migrateStorageItem(workCtx, migration, &item); err != nil {
+					errorMu.Lock()
+					if firstErr == nil {
+						firstErr = err
+						cancel()
+					}
+					errorMu.Unlock()
+					return
+				}
+				_ = w.refreshStorageMigrationProgress(context.WithoutCancel(workCtx), migration.ID)
+			}
+		}()
+	}
+	workers.Wait()
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	return firstErr
+}
+
+func (w *WorkerGroup) migrateStorageItem(ctx context.Context, migration models.StorageMigration, item *models.StorageMigrationItem) (err error) {
+	if item.Status == models.StorageMigrationItemCleanupPending || item.Status == models.StorageMigrationItemCleaned {
+		return nil
+	}
+	now := time.Now().UTC()
+	if err := w.deps.DB.WithContext(ctx).Model(item).Updates(map[string]any{
+		"status": models.StorageMigrationItemCopying, "copy_started_at": gorm.Expr("COALESCE(copy_started_at, ?)", now),
+		"error_code": "", "error_message": "", "progress_message": "Copying and verifying media",
+	}).Error; err != nil {
+		return err
+	}
+	defer func() {
+		if err == nil {
+			return
+		}
+		status, code, message := models.StorageMigrationItemFailed, "copy_failed", boundedServiceError(err.Error())
+		if ctx.Err() != nil {
+			status, code, message = models.StorageMigrationItemPending, "", "Paused at a safe checkpoint"
+		}
+		_ = w.deps.DB.WithContext(context.WithoutCancel(ctx)).Model(item).Updates(map[string]any{
+			"status": status, "error_code": code, "error_message": message, "progress_message": message,
+		}).Error
+	}()
+
+	releaseFile := w.deps.StorageLifecycle.FileReadLock(item.FileID)
+	var file models.File
+	if err = w.deps.DB.WithContext(ctx).First(&file, item.FileID).Error; err != nil {
+		releaseFile()
+		return err
+	}
+	if file.StorageID != item.SourceMountID || file.StorageState != models.FileStorageAvailable {
+		releaseFile()
+		return fmt.Errorf("%w: file %d is no longer on source mount %s", errStorageMigrationStateConflict, file.ID, item.SourceMountID)
+	}
+	releaseMounts := w.deps.StorageLifecycle.ReadLocks(item.SourceMountID, item.DestinationMountID)
+	if err = w.copyStorageMigrationPrefix(ctx, item, file, false); err != nil {
+		releaseMounts()
+		releaseFile()
+		return err
+	}
+	releaseMounts()
+	releaseFile()
+
+	if err = ctx.Err(); err != nil {
+		return err
+	}
+	releaseFile = w.deps.StorageLifecycle.FileWriteLock(item.FileID)
+	defer releaseFile()
+	releaseMounts = w.deps.StorageLifecycle.ReadLocks(item.SourceMountID, item.DestinationMountID)
+	defer releaseMounts()
+	if err = w.deps.DB.WithContext(ctx).First(&file, item.FileID).Error; err != nil {
+		return err
+	}
+	if file.StorageID != item.SourceMountID || file.StorageState != models.FileStorageAvailable {
+		return fmt.Errorf("%w: file %d changed before cutover", errStorageMigrationStateConflict, file.ID)
+	}
+	if err = w.copyStorageMigrationPrefix(ctx, item, file, true); err != nil {
+		return err
+	}
+	if err = ctx.Err(); err != nil {
+		return err
+	}
+	cutoverAt := time.Now().UTC()
+	err = w.deps.DB.WithContext(context.WithoutCancel(ctx)).Transaction(func(tx *gorm.DB) error {
+		updated := tx.Model(&models.File{}).
+			Where("id = ? AND storage_id = ? AND storage_state = ?", file.ID, item.SourceMountID, models.FileStorageAvailable).
+			Update("storage_id", item.DestinationMountID)
+		if updated.Error != nil {
+			return updated.Error
+		}
+		if updated.RowsAffected != 1 {
+			return errStorageMigrationStateConflict
+		}
+		return tx.Model(item).Updates(map[string]any{
+			"status": models.StorageMigrationItemCleanupPending, "verified_at": &cutoverAt, "cutover_at": &cutoverAt,
+			"progress_message": "Destination active; original retained", "error_code": "", "error_message": "",
+		}).Error
+	})
+	return err
+}
+
+func (w *WorkerGroup) copyStorageMigrationPrefix(ctx context.Context, item *models.StorageMigrationItem, file models.File, finalSync bool) error {
+	source, err := w.deps.Storage.Store(item.SourceMountID)
+	if err != nil {
+		return err
+	}
+	destination, err := w.deps.Storage.Store(item.DestinationMountID)
+	if err != nil {
+		return err
+	}
+	prefix, err := w.deps.Storage.Layout().FilePrefix(file.UUID)
+	if err != nil {
+		return err
+	}
+	if !item.DestinationOwned {
+		existing, err := storage.PrefixInventory(ctx, destination, prefix)
+		if err != nil {
+			return err
+		}
+		if len(existing) > 0 {
+			return fmt.Errorf("%w: destination prefix %s already contains data", errStorageMigrationStateConflict, prefix.String())
+		}
+		if err := w.deps.DB.WithContext(ctx).Model(item).Update("destination_owned", true).Error; err != nil {
+			return err
+		}
+		item.DestinationOwned = true
+	}
+	objects, err := storage.PrefixInventory(ctx, source, prefix)
+	if err != nil {
+		return err
+	}
+	if len(objects) == 0 {
+		return fmt.Errorf("source prefix %s is empty", prefix.String())
+	}
+	var total int64
+	for _, object := range objects {
+		total += object.Size
+	}
+	status, message := models.StorageMigrationItemCopying, "Copying and verifying media"
+	if finalSync {
+		status, message = models.StorageMigrationItemVerifying, "Final synchronization and verification"
+	}
+	if err := w.deps.DB.WithContext(ctx).Model(item).Updates(map[string]any{
+		"status": status, "bytes_total": total, "object_count": len(objects), "progress_message": message,
+	}).Error; err != nil {
+		return err
+	}
+	verifiedKeys := make(map[string]bool, len(objects))
+	var verifiedBytes int64
+	lastProgressUpdate := time.Time{}
+	for index, object := range objects {
+		if _, err := storage.CopyObjectVerified(ctx, source, destination, object); err != nil {
+			return fmt.Errorf("copy %s: %w", object.Key.String(), err)
+		}
+		verifiedKeys[object.Key.String()] = true
+		verifiedBytes += object.Size
+		now := time.Now()
+		if index+1 == len(objects) || lastProgressUpdate.IsZero() || now.Sub(lastProgressUpdate) >= 500*time.Millisecond {
+			if err := w.deps.DB.WithContext(ctx).Model(item).Updates(map[string]any{
+				"bytes_copied": verifiedBytes, "objects_verified": index + 1,
+				"progress_message": fmt.Sprintf("Verified %d of %d objects", index+1, len(objects)),
+			}).Error; err != nil {
+				return err
+			}
+			if err := w.refreshStorageMigrationProgress(ctx, item.MigrationID); err != nil {
+				return err
+			}
+			lastProgressUpdate = now
+		}
+	}
+	if finalSync {
+		destinationObjects, err := storage.PrefixInventory(ctx, destination, prefix)
+		if err != nil {
+			return err
+		}
+		for _, object := range destinationObjects {
+			if !verifiedKeys[object.Key.String()] {
+				if err := destination.Delete(ctx, object.Key); err != nil {
+					return fmt.Errorf("remove stale destination object %s: %w", object.Key.String(), err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func (w *WorkerGroup) refreshStorageMigrationProgress(ctx context.Context, migrationID uint) error {
+	var aggregate struct {
+		ActualBytes  int64
+		CopiedBytes  int64
+		CutoverCount int64
+		CleanedCount int64
+		FileCount    int64
+	}
+	err := w.deps.DB.WithContext(ctx).Model(&models.StorageMigrationItem{}).
+		Select(`COALESCE(SUM(CASE WHEN bytes_total > 0 THEN bytes_total ELSE planned_bytes END), 0) AS actual_bytes,
+			COALESCE(SUM(bytes_copied), 0) AS copied_bytes,
+			SUM(CASE WHEN status IN ? THEN 1 ELSE 0 END) AS cutover_count,
+			SUM(CASE WHEN status = ? THEN 1 ELSE 0 END) AS cleaned_count,
+			COUNT(*) AS file_count`, []string{models.StorageMigrationItemCleanupPending, models.StorageMigrationItemCleaning, models.StorageMigrationItemCleaned, models.StorageMigrationItemOriginalKept}, models.StorageMigrationItemCleaned).
+		Where("migration_id = ?", migrationID).Scan(&aggregate).Error
+	if err != nil {
+		return err
+	}
+	if err := w.deps.DB.WithContext(ctx).Model(&models.StorageMigration{}).Where("id = ?", migrationID).Updates(map[string]any{
+		"actual_bytes": aggregate.ActualBytes, "copied_bytes": aggregate.CopiedBytes,
+		"cutover_count": aggregate.CutoverCount, "cleaned_count": aggregate.CleanedCount,
+	}).Error; err != nil {
+		return err
+	}
+	progress := 0.0
+	if aggregate.ActualBytes > 0 {
+		progress = float64(aggregate.CopiedBytes) / float64(aggregate.ActualBytes)
+	}
+	background.ReportProgress(ctx, progress, fmt.Sprintf("%d of %d videos active on destination", aggregate.CutoverCount, aggregate.FileCount))
+	return nil
+}
+
+func (w *WorkerGroup) scheduleStorageMigrationCleanup(ctx context.Context, runtime *background.Runtime, migration *models.StorageMigration) error {
+	if runtime == nil {
+		return errors.New("background runtime is unavailable")
+	}
+	if err := w.deps.DB.WithContext(ctx).First(migration, migration.ID).Error; err != nil {
+		return err
+	}
+	if migration.CleanupJobID != "" {
+		return nil
+	}
+	cleanupAfter := time.Now().UTC().Add(storageMigrationCleanupGrace)
+	job, _, err := runtime.Enqueue(ctx, background.JobSpec{
+		Kind: "storage.migration.cleanup", Visibility: background.VisibilityAdmin,
+		SubjectType: "storage_migration", SubjectID: migration.UUID,
+		IdempotencyKey: "storage-migration-cleanup:" + migration.UUID,
+		Label:          fmt.Sprintf("Clean originals from %s", migration.SourcePoolName),
+		Tasks: []background.TaskSpec{{
+			Kind: taskStorageCleanup, Queue: background.QueueStorage, Phase: "Retaining originals",
+			Payload: storageMigrationTaskPayload{MigrationID: migration.ID}, DedupeKey: fmt.Sprintf("storage-cleanup:%d", migration.ID),
+			Priority: 5, Required: true, Weight: 1, MaxAttempts: 4, RunAfter: &cleanupAfter,
+		}},
+	})
+	if err != nil {
+		return err
+	}
+	copyCompletedAt := time.Now().UTC()
+	if err := w.deps.DB.WithContext(ctx).Model(migration).Updates(map[string]any{
+		"status": models.StorageMigrationRetainingOriginals, "phase": "Retaining originals for 24 hours",
+		"cleanup_job_id": job.ID, "cleanup_after": &cleanupAfter, "copy_completed_at": &copyCompletedAt,
+		"error_code": "", "error_message": "",
+	}).Error; err != nil {
+		return err
+	}
+	migration.CleanupJobID = job.ID
+	return nil
+}
+
+func (w *WorkerGroup) storageMigrationCleanupHandler(ctx context.Context, task background.Task) (background.Result, error) {
+	var payload storageMigrationTaskPayload
+	if err := decodeTaskPayload(task, &payload); err != nil {
+		return background.Result{}, err
+	}
+	var migration models.StorageMigration
+	if err := w.deps.DB.WithContext(ctx).First(&migration, payload.MigrationID).Error; err != nil {
+		return background.Result{}, background.Permanent("migration_missing", "The storage migration no longer exists", err)
+	}
+	if migration.KeepOriginals || migration.Status == models.StorageMigrationOriginalsRetained {
+		return background.Result{ResultType: "storage_migration", ResultID: migration.UUID, Phase: "Originals retained"}, nil
+	}
+	if err := w.deps.DB.WithContext(ctx).Model(&migration).Updates(map[string]any{
+		"status": models.StorageMigrationCleaningOriginals, "phase": "Cleaning original copies",
+	}).Error; err != nil {
+		return background.Result{}, background.Transient("cleanup_state_failed", "Cleanup state could not be updated", err)
+	}
+	var items []models.StorageMigrationItem
+	if err := w.deps.DB.WithContext(ctx).Where("migration_id = ? AND status <> ?", migration.ID, models.StorageMigrationItemCleaned).Order("id ASC").Find(&items).Error; err != nil {
+		return background.Result{}, background.Transient("cleanup_items_failed", "Cleanup videos could not be loaded", err)
+	}
+	for index := range items {
+		if err := w.cleanupStorageMigrationItem(ctx, &items[index]); err != nil {
+			if ctx.Err() != nil {
+				if reloadErr := w.deps.DB.WithContext(context.WithoutCancel(ctx)).First(&migration, migration.ID).Error; reloadErr == nil && migration.KeepOriginals {
+					return background.Result{}, ctx.Err()
+				}
+				status, phase := models.StorageMigrationCanceled, "Cleanup canceled; remaining originals retained"
+				if background.PauseRequested(ctx) {
+					status, phase = models.StorageMigrationPaused, "Cleanup paused"
+				}
+				_ = w.deps.DB.WithContext(context.WithoutCancel(ctx)).Model(&migration).Updates(map[string]any{"status": status, "phase": phase}).Error
+				return background.Result{}, ctx.Err()
+			}
+			return background.Result{}, background.Transient("cleanup_failed", "An original copy could not be removed", err)
+		}
+		if err := w.refreshStorageMigrationProgress(context.WithoutCancel(ctx), migration.ID); err != nil {
+			return background.Result{}, background.Transient("cleanup_progress_failed", "Original cleanup progress could not be recorded", err)
+		}
+		background.ReportProgress(ctx, float64(index+1)/float64(len(items)), fmt.Sprintf("Cleaned %d of %d originals", index+1, len(items)))
+	}
+	if err := w.deps.DB.WithContext(context.WithoutCancel(ctx)).First(&migration, migration.ID).Error; err == nil && migration.KeepOriginals {
+		return background.Result{ResultType: "storage_migration", ResultID: migration.UUID, Phase: "Originals retained"}, nil
+	}
+	completedAt := time.Now().UTC()
+	if err := w.deps.DB.WithContext(context.WithoutCancel(ctx)).Model(&migration).Updates(map[string]any{
+		"status": models.StorageMigrationCompleted, "phase": "Migration and cleanup complete", "cleaned_count": migration.FileCount,
+		"completed_at": &completedAt,
+	}).Error; err != nil {
+		return background.Result{}, background.Transient("cleanup_state_failed", "Cleanup completion could not be recorded", err)
+	}
+	return background.Result{ResultType: "storage_migration", ResultID: migration.UUID, Phase: "Cleanup complete"}, nil
+}
+
+func (w *WorkerGroup) cleanupStorageMigrationItem(ctx context.Context, item *models.StorageMigrationItem) error {
+	if item.Status == models.StorageMigrationItemCleaned || item.Status == models.StorageMigrationItemOriginalKept {
+		return nil
+	}
+	releaseFile := w.deps.StorageLifecycle.FileWriteLock(item.FileID)
+	defer releaseFile()
+	releaseMount := w.deps.StorageLifecycle.ReadLock(item.SourceMountID)
+	defer releaseMount()
+	if err := w.deps.DB.WithContext(ctx).First(item, item.ID).Error; err != nil {
+		return err
+	}
+	if item.Status == models.StorageMigrationItemCleaned || item.Status == models.StorageMigrationItemOriginalKept {
+		return nil
+	}
+	var file models.File
+	err := w.deps.DB.WithContext(ctx).Unscoped().First(&file, item.FileID).Error
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return err
+	}
+	if err == nil && file.StorageID != item.DestinationMountID {
+		return fmt.Errorf("%w: file %d is no longer on expected destination", errStorageMigrationStateConflict, item.FileID)
+	}
+	store, err := w.deps.Storage.Store(item.SourceMountID)
+	if err != nil {
+		return err
+	}
+	prefix, err := w.deps.Storage.Layout().FilePrefix(item.FileUUID)
+	if err != nil {
+		return err
+	}
+	if err := w.deps.DB.WithContext(ctx).Model(item).Updates(map[string]any{
+		"status": models.StorageMigrationItemCleaning, "progress_message": "Removing original copy",
+	}).Error; err != nil {
+		return err
+	}
+	if err := storage.DeletePrefix(ctx, store, prefix); err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	return w.deps.DB.WithContext(context.WithoutCancel(ctx)).Model(item).Updates(map[string]any{
+		"status": models.StorageMigrationItemCleaned, "cleaned_at": &now, "reservation_key": "",
+		"progress_message": "Original removed", "error_code": "", "error_message": "",
+	}).Error
+}
+
+func (w *WorkerGroup) storageMigrationAbortHandler(runtime *background.Runtime) background.Handler {
+	return func(ctx context.Context, task background.Task) (background.Result, error) {
+		var payload storageMigrationTaskPayload
+		if err := decodeTaskPayload(task, &payload); err != nil {
+			return background.Result{}, err
+		}
+		var migration models.StorageMigration
+		if err := w.deps.DB.WithContext(ctx).First(&migration, payload.MigrationID).Error; err != nil {
+			return background.Result{}, background.Permanent("migration_missing", "The canceled migration no longer exists", err)
+		}
+		if migration.BackgroundJobID != "" && runtime != nil {
+			if mainJob, err := runtime.Job(ctx, migration.BackgroundJobID, nil, true); err == nil && !storageMigrationJobTerminal(mainJob.Status) {
+				return background.Result{}, &background.TaskError{Code: "migration_still_stopping", Public: "The migration is still stopping", Class: background.ErrorTransient, RetryAfter: 5 * time.Second}
+			}
+		}
+		var items []models.StorageMigrationItem
+		if err := w.deps.DB.WithContext(ctx).Where("migration_id = ?", migration.ID).Order("id ASC").Find(&items).Error; err != nil {
+			return background.Result{}, background.Transient("abort_items_failed", "Canceled migration videos could not be loaded", err)
+		}
+		for index := range items {
+			if err := w.cleanupCanceledStorageMigrationItem(ctx, &items[index]); err != nil {
+				if ctx.Err() != nil {
+					return background.Result{}, ctx.Err()
+				}
+				return background.Result{}, background.Transient("abort_cleanup_failed", "Incomplete destination data could not be cleaned", err)
+			}
+			background.ReportProgress(ctx, float64(index+1)/float64(len(items)), fmt.Sprintf("Reconciled %d of %d videos", index+1, len(items)))
+		}
+		if err := w.refreshStorageMigrationProgress(context.WithoutCancel(ctx), migration.ID); err != nil {
+			return background.Result{}, background.Transient("abort_progress_failed", "Canceled migration progress could not be reconciled", err)
+		}
+		if err := w.deps.DB.WithContext(context.WithoutCancel(ctx)).Model(&migration).Updates(map[string]any{
+			"status": models.StorageMigrationCanceled, "phase": "Canceled; incomplete destination data cleaned and originals retained",
+			"error_code": "", "error_message": "",
+		}).Error; err != nil {
+			return background.Result{}, background.Transient("abort_state_failed", "Canceled migration state could not be finalized", err)
+		}
+		return background.Result{ResultType: "storage_migration", ResultID: migration.UUID, Phase: "Canceled migration cleaned"}, nil
+	}
+}
+
+func (w *WorkerGroup) cleanupCanceledStorageMigrationItem(ctx context.Context, item *models.StorageMigrationItem) error {
+	releaseFile := w.deps.StorageLifecycle.FileWriteLock(item.FileID)
+	defer releaseFile()
+	releaseMount := w.deps.StorageLifecycle.ReadLock(item.DestinationMountID)
+	defer releaseMount()
+	if err := w.deps.DB.WithContext(ctx).First(item, item.ID).Error; err != nil {
+		return err
+	}
+	var file models.File
+	err := w.deps.DB.WithContext(ctx).First(&file, item.FileID).Error
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return err
+	}
+	if err == nil && file.StorageID == item.DestinationMountID && item.CutoverAt != nil {
+		return w.deps.DB.WithContext(context.WithoutCancel(ctx)).Model(item).Updates(map[string]any{
+			"status": models.StorageMigrationItemOriginalKept, "reservation_key": "",
+			"progress_message": "Destination remains active; original retained",
+		}).Error
+	}
+	if err == nil && file.StorageID != item.SourceMountID {
+		return fmt.Errorf("%w: file %d moved to unexpected mount %s", errStorageMigrationStateConflict, file.ID, file.StorageID)
+	}
+	if item.DestinationOwned {
+		store, err := w.deps.Storage.Store(item.DestinationMountID)
+		if err != nil {
+			return err
+		}
+		prefix, err := w.deps.Storage.Layout().FilePrefix(item.FileUUID)
+		if err != nil {
+			return err
+		}
+		if err := storage.DeletePrefix(ctx, store, prefix); err != nil {
+			return err
+		}
+	}
+	return w.deps.DB.WithContext(context.WithoutCancel(ctx)).Model(item).Updates(map[string]any{
+		"status": models.StorageMigrationItemCanceled, "reservation_key": "", "destination_owned": false,
+		"bytes_copied": 0, "objects_verified": 0, "progress_message": "Canceled before cutover",
+	}).Error
+}
+
+func storageMigrationJobTerminal(status string) bool {
+	switch status {
+	case background.JobSucceeded, background.JobSucceededWithWarnings, background.JobFailed, background.JobCanceled:
+		return true
+	default:
+		return false
+	}
+}
+
+func (w *WorkerGroup) storageMigrationReconcileHandler(runtime *background.Runtime) background.Handler {
+	return func(ctx context.Context, task background.Task) (background.Result, error) {
+		if runtime == nil || w.logic == nil {
+			return background.Result{}, background.Permanent("migration_runtime_missing", "Storage migration reconciliation is unavailable", errors.New("storage migration runtime is unavailable"))
+		}
+		var migrations []models.StorageMigration
+		if err := w.deps.DB.WithContext(ctx).
+			Where(`(cleanup_job_id = '' AND status IN ?) OR
+				(cleanup_job_id <> '' AND status IN ?)`,
+				[]string{models.StorageMigrationQueued, models.StorageMigrationRunning, models.StorageMigrationPaused, models.StorageMigrationCanceled},
+				[]string{models.StorageMigrationRetainingOriginals, models.StorageMigrationCleaningOriginals, models.StorageMigrationPaused}).
+			Order("id ASC").Find(&migrations).Error; err != nil {
+			return background.Result{}, background.Transient("migration_reconcile_load_failed", "Storage migrations could not be inspected", err)
+		}
+		reconciled := 0
+		for index := range migrations {
+			migration := &migrations[index]
+			mainCanceled := false
+			var mainJob background.Job
+			mainQuery := w.deps.DB.WithContext(ctx)
+			if migration.BackgroundJobID != "" {
+				mainQuery = mainQuery.Where("id = ?", migration.BackgroundJobID)
+			} else {
+				mainQuery = mainQuery.Where("kind = ? AND subject_type = ? AND subject_id = ?", "storage.migration", "storage_migration", migration.UUID).Order("created_at DESC")
+			}
+			if err := mainQuery.First(&mainJob).Error; err == nil {
+				if migration.BackgroundJobID == "" {
+					_ = w.deps.DB.WithContext(context.WithoutCancel(ctx)).Model(migration).Update("background_job_id", mainJob.ID).Error
+				}
+				mainCanceled = mainJob.Status == background.JobCanceled
+			}
+			if mainCanceled {
+				if err := w.logic.EnsureStorageMigrationAbortCleanup(context.WithoutCancel(ctx), migration.ID); err != nil {
+					return background.Result{}, background.Transient("migration_reconcile_abort_failed", "A canceled migration could not be reconciled", err)
+				}
+				reconciled++
+				background.ReportProgress(ctx, float64(index+1)/float64(len(migrations)), fmt.Sprintf("Inspected %d of %d migrations", index+1, len(migrations)))
+				continue
+			}
+			if migration.CleanupJobID != "" {
+				if cleanupJob, err := runtime.Job(ctx, migration.CleanupJobID, nil, true); err == nil &&
+					cleanupJob.Kind == "storage.migration.cleanup" && cleanupJob.Status == background.JobCanceled {
+					if _, err := w.logic.KeepStorageMigrationOriginals(context.WithoutCancel(ctx), migration.UUID, 0, "VideoCMS"); err != nil {
+						return background.Result{}, background.Transient("migration_reconcile_retention_failed", "Canceled original cleanup could not be reconciled", err)
+					}
+					reconciled++
+				}
+				background.ReportProgress(ctx, float64(index+1)/float64(len(migrations)), fmt.Sprintf("Inspected %d of %d migrations", index+1, len(migrations)))
+				continue
+			}
+			needsAbort := migration.Status == models.StorageMigrationCanceled && migration.CleanupJobID == ""
+			if needsAbort {
+				if err := w.logic.EnsureStorageMigrationAbortCleanup(context.WithoutCancel(ctx), migration.ID); err != nil {
+					return background.Result{}, background.Transient("migration_reconcile_abort_failed", "A canceled migration could not be reconciled", err)
+				}
+				reconciled++
+			}
+			background.ReportProgress(ctx, float64(index+1)/float64(len(migrations)), fmt.Sprintf("Inspected %d of %d migrations", index+1, len(migrations)))
+		}
+		return background.Result{Value: map[string]any{"reconciled": reconciled}, Phase: "Storage migrations reconciled"}, nil
+	}
+}

--- a/services/StorageMigration_integration_test.go
+++ b/services/StorageMigration_integration_test.go
@@ -1,0 +1,125 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"ch/kirari04/videocms/app"
+	"ch/kirari04/videocms/models"
+	"ch/kirari04/videocms/storage"
+
+	"github.com/google/uuid"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func TestStorageMigrationS3ToSFTPIntegration(t *testing.T) {
+	endpoint := os.Getenv("VIDEOCMS_S3_INTEGRATION_ENDPOINT")
+	host := os.Getenv("VIDEOCMS_SFTP_INTEGRATION_HOST")
+	if endpoint == "" || host == "" {
+		t.Skip("S3 and SFTP integration services are not configured")
+	}
+	port, err := strconv.Atoi(os.Getenv("VIDEOCMS_SFTP_INTEGRATION_PORT"))
+	if err != nil || port < 1 || port > 65535 {
+		t.Fatalf("VIDEOCMS_SFTP_INTEGRATION_PORT is invalid")
+	}
+	fingerprints := strings.FieldsFunc(os.Getenv("VIDEOCMS_SFTP_INTEGRATION_HOST_KEY_FINGERPRINTS"), func(value rune) bool {
+		return value == ',' || value == '\n' || value == '\r'
+	})
+	if len(fingerprints) == 0 {
+		t.Fatal("VIDEOCMS_SFTP_INTEGRATION_HOST_KEY_FINGERPRINTS is required")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	runID := uuid.NewString()
+	s3Store, err := storage.NewS3Store(ctx, storage.S3Options{
+		Bucket: os.Getenv("VIDEOCMS_S3_INTEGRATION_BUCKET"), Region: os.Getenv("VIDEOCMS_S3_INTEGRATION_REGION"), Endpoint: endpoint,
+		Prefix: "videocms-migration-integration/" + runID, AccessKeyID: os.Getenv("VIDEOCMS_S3_INTEGRATION_ACCESS_KEY_ID"),
+		SecretAccessKey: os.Getenv("VIDEOCMS_S3_INTEGRATION_SECRET_ACCESS_KEY"), UsePathStyle: true,
+		UploadPartSize: 5 * 1024 * 1024, UploadConcurrency: 2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := os.Getenv("VIDEOCMS_SFTP_INTEGRATION_ROOT")
+	if root == "" {
+		root = "/upload"
+	}
+	sftpStore, err := storage.NewSFTPStore(ctx, storage.SFTPOptions{
+		Host: host, Port: port, Username: os.Getenv("VIDEOCMS_SFTP_INTEGRATION_USERNAME"), Root: root,
+		Authentication: storage.SFTPAuthenticationPassword, HostKeyFingerprints: fingerprints,
+		Password: os.Getenv("VIDEOCMS_SFTP_INTEGRATION_PASSWORD"),
+	})
+	if err != nil {
+		_ = s3Store.Close()
+		t.Fatal(err)
+	}
+	storageService, err := storage.NewService("s3", storage.LegacyMediaLayout{}, map[string]storage.Store{"s3": s3Store, "sftp": sftpStore})
+	if err != nil {
+		_ = s3Store.Close()
+		_ = sftpStore.Close()
+		t.Fatal(err)
+	}
+
+	fileUUID := uuid.NewString()
+	prefix, err := storageService.Layout().FilePrefix(fileUUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = storage.DeletePrefix(context.Background(), s3Store, prefix)
+		_ = storage.DeletePrefix(context.Background(), sftpStore, prefix)
+		_ = storageService.Close()
+	})
+	key := migrationTestKey(t, prefix.String()+"/source/original.mp4")
+	putMigrationTestObject(t, s3Store, key, "garage-to-sftp-media")
+
+	db, err := gorm.Open(sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
+		t.Fatal(err)
+	}
+	file := models.File{UUID: fileUUID, StorageID: "s3", StorageState: models.FileStorageAvailable, Size: int64(len("garage-to-sftp-media"))}
+	if err := db.Create(&file).Error; err != nil {
+		t.Fatal(err)
+	}
+	migration := models.StorageMigration{UUID: runID, Status: models.StorageMigrationRunning, FileCount: 1, PlannedBytes: file.Size}
+	if err := db.Create(&migration).Error; err != nil {
+		t.Fatal(err)
+	}
+	item := models.StorageMigrationItem{
+		MigrationID: migration.ID, FileID: file.ID, FileUUID: file.UUID, SourceMountID: "s3", DestinationMountID: "sftp",
+		Status: models.StorageMigrationItemPending, ReservationKey: "file:" + strconv.FormatUint(uint64(file.ID), 10), PlannedBytes: file.Size,
+	}
+	if err := db.Create(&item).Error; err != nil {
+		t.Fatal(err)
+	}
+	worker := NewWorkerGroup(&app.Deps{DB: db, Storage: storageService}, nil)
+	if err := worker.migrateStorageItem(ctx, migration, &item); err != nil {
+		t.Fatal(err)
+	}
+	assertMigrationTestObject(t, s3Store, key, "garage-to-sftp-media")
+	assertMigrationTestObject(t, sftpStore, key, "garage-to-sftp-media")
+	if err := db.First(&file, file.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if file.StorageID != "sftp" {
+		t.Fatalf("file remained on %q after cutover", file.StorageID)
+	}
+	if err := worker.cleanupStorageMigrationItem(ctx, &item); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s3Store.Stat(ctx, key); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("S3 original remained after deferred cleanup: %v", err)
+	}
+	assertMigrationTestObject(t, sftpStore, key, "garage-to-sftp-media")
+}

--- a/services/StorageMigration_test.go
+++ b/services/StorageMigration_test.go
@@ -176,6 +176,84 @@ func TestStorageMigrationCopiesFinalChangesBeforeAtomicCutover(t *testing.T) {
 	}
 }
 
+func TestStorageMigrationCleanupStopsOnlyBetweenVideos(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
+		t.Fatal(err)
+	}
+	sourceLocal, err := storage.NewLocalStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	destination, err := storage.NewLocalStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := &migrationBlockingDeleteStore{Store: sourceLocal, started: make(chan struct{}), release: make(chan struct{})}
+	service, err := storage.NewService("source", storage.LegacyMediaLayout{}, map[string]storage.Store{"source": source, "destination": destination})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = service.Close() })
+	file := models.File{UUID: "550e8400-e29b-41d4-a716-446655440203", StorageID: "destination", StorageState: models.FileStorageAvailable}
+	if err := db.Create(&file).Error; err != nil {
+		t.Fatal(err)
+	}
+	first := migrationTestKey(t, file.UUID+"/source/first.ts")
+	second := migrationTestKey(t, file.UUID+"/source/second.m3u8")
+	putMigrationTestObject(t, source, first, "first")
+	putMigrationTestObject(t, source, second, "second")
+	migration := models.StorageMigration{UUID: "cleanup-checkpoint", Status: models.StorageMigrationCleaningOriginals, FileCount: 1}
+	if err := db.Create(&migration).Error; err != nil {
+		t.Fatal(err)
+	}
+	item := models.StorageMigrationItem{
+		MigrationID: migration.ID, FileID: file.ID, FileUUID: file.UUID, SourceMountID: "source", DestinationMountID: "destination",
+		Status: models.StorageMigrationItemCleanupPending, ReservationKey: fmt.Sprintf("file:%d", file.ID),
+	}
+	if err := db.Create(&item).Error; err != nil {
+		t.Fatal(err)
+	}
+	worker := NewWorkerGroup(&app.Deps{DB: db, Storage: service}, nil)
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() { result <- worker.cleanupStorageMigrationItem(ctx, &item) }()
+	select {
+	case <-source.started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cleanup did not begin")
+	}
+	cancel()
+	select {
+	case err := <-result:
+		t.Fatalf("cleanup stopped halfway through a video: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	close(source.release)
+	select {
+	case err := <-result:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("cleanup did not finish the current video")
+	}
+	for _, key := range []storage.Key{first, second} {
+		if _, err := source.Stat(context.Background(), key); !errors.Is(err, storage.ErrNotFound) {
+			t.Fatalf("source object %s remained after cleanup checkpoint: %v", key.String(), err)
+		}
+	}
+	if err := db.First(&item, item.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if item.Status != models.StorageMigrationItemCleaned || item.ReservationKey != "" {
+		t.Fatalf("cleanup checkpoint was not committed: %#v", item)
+	}
+}
+
 func TestStorageMigrationRefusesUnownedDestinationPrefix(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
 	if err != nil {
@@ -350,12 +428,79 @@ func TestStorageMigrationReconciliationRepairsCanceledJobCrashWindow(t *testing.
 	if retaining.Status != models.StorageMigrationOriginalsRetained || retainedItem.Status != models.StorageMigrationItemOriginalKept || retainedItem.ReservationKey != "" {
 		t.Fatalf("canceled original cleanup was not reconciled: migration=%#v item=%#v", retaining, retainedItem)
 	}
+
+	missing := models.StorageMigration{UUID: "reconcile-missing-main", SourcePoolName: "Source", DestinationPoolName: "Destination", Status: models.StorageMigrationQueued, FileCount: 1}
+	if err := db.Create(&missing).Error; err != nil {
+		t.Fatal(err)
+	}
+	missingItem := models.StorageMigrationItem{MigrationID: missing.ID, FileID: 3, FileUUID: "missing", SourceMountID: "source", DestinationMountID: "destination", Status: models.StorageMigrationItemPending, ReservationKey: "file:3"}
+	if err := db.Create(&missingItem).Error; err != nil {
+		t.Fatal(err)
+	}
+	if _, err := worker.storageMigrationReconcileHandler(runtime)(context.Background(), background.Task{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.First(&missing, missing.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if missing.BackgroundJobID == "" {
+		t.Fatal("missing migration job was not recreated")
+	}
+	recreated, err := runtime.Job(context.Background(), missing.BackgroundJobID, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recreated.Status != background.JobQueued || !recreated.Pausable {
+		t.Fatalf("unexpected recreated migration job: %#v", recreated.Job)
+	}
+	if err := runtime.PauseJob(context.Background(), recreated.ID, 1, "admin"); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Model(&missing).Updates(map[string]any{"status": models.StorageMigrationRunning, "phase": "stale"}).Error; err != nil {
+		t.Fatal(err)
+	}
+	if _, err := worker.storageMigrationReconcileHandler(runtime)(context.Background(), background.Task{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.First(&missing, missing.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if missing.Status != models.StorageMigrationPaused || missing.Phase != "Migration paused" {
+		t.Fatalf("paused job projection was not repaired: %#v", missing)
+	}
+	if err := runtime.ResumeJob(context.Background(), recreated.ID, 1, "admin"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := worker.storageMigrationReconcileHandler(runtime)(context.Background(), background.Task{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.First(&missing, missing.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if missing.Status != models.StorageMigrationQueued {
+		t.Fatalf("resumed job projection was not repaired: %#v", missing)
+	}
 }
 
 type migrationHookStore struct {
 	storage.Store
 	once sync.Once
 	hook func()
+}
+
+type migrationBlockingDeleteStore struct {
+	storage.Store
+	once    sync.Once
+	started chan struct{}
+	release chan struct{}
+}
+
+func (s *migrationBlockingDeleteStore) Delete(ctx context.Context, key storage.Key) error {
+	s.once.Do(func() {
+		close(s.started)
+		<-s.release
+	})
+	return s.Store.Delete(ctx, key)
 }
 
 func (s *migrationHookStore) Put(ctx context.Context, key storage.Key, source io.Reader, options storage.PutOptions) (storage.ObjectInfo, error) {
@@ -401,7 +546,7 @@ func assertMigrationTestObject(t *testing.T, store storage.Store, key storage.Ke
 
 func waitStorageMigrationJob(t *testing.T, runtime *background.Runtime, jobID string, status string) {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(12 * time.Second)
 	for time.Now().Before(deadline) {
 		detail, err := runtime.Job(context.Background(), jobID, nil, true)
 		if err == nil && detail.Status == status {

--- a/services/StorageMigration_test.go
+++ b/services/StorageMigration_test.go
@@ -1,0 +1,414 @@
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"ch/kirari04/videocms/app"
+	"ch/kirari04/videocms/background"
+	"ch/kirari04/videocms/models"
+	"ch/kirari04/videocms/storage"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func TestStorageMigrationBackgroundJobCutsOverAndSchedulesDeferredCleanup(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := background.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	source, _ := storage.NewLocalStore(t.TempDir())
+	destination, _ := storage.NewLocalStore(t.TempDir())
+	storageService, err := storage.NewService("source", storage.LegacyMediaLayout{}, map[string]storage.Store{"source": source, "destination": destination})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = storageService.Close() })
+	file := models.File{UUID: "550e8400-e29b-41d4-a716-446655440200", StorageID: "source", StorageState: models.FileStorageAvailable, Size: 5}
+	if err := db.Create(&file).Error; err != nil {
+		t.Fatal(err)
+	}
+	putMigrationTestObject(t, source, migrationTestKey(t, file.UUID+"/source/original.mp4"), "media")
+	migration := models.StorageMigration{UUID: "background-migration", SourcePoolName: "Source", DestinationPoolName: "Destination", Status: models.StorageMigrationQueued, FileCount: 1, PlannedBytes: 5}
+	if err := db.Create(&migration).Error; err != nil {
+		t.Fatal(err)
+	}
+	item := models.StorageMigrationItem{MigrationID: migration.ID, FileID: file.ID, FileUUID: file.UUID, SourceMountID: "source", DestinationMountID: "destination", Status: models.StorageMigrationItemPending, ReservationKey: fmt.Sprintf("file:%d", file.ID), PlannedBytes: 5}
+	if err := db.Create(&item).Error; err != nil {
+		t.Fatal(err)
+	}
+	deps := &app.Deps{DB: db, Storage: storageService}
+	worker := NewWorkerGroup(deps, nil)
+	runtime := background.New(db, background.Options{PollInterval: 5 * time.Millisecond, Capacity: func(string) int { return 1 }})
+	deps.Background = runtime
+	if err := runtime.Register(taskStorageMigration, worker.storageMigrationHandler(runtime)); err != nil {
+		t.Fatal(err)
+	}
+	if err := runtime.Register(taskStorageCleanup, worker.storageMigrationCleanupHandler); err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(func() { cancel(); runtime.Stop(2 * time.Second) })
+	if err := runtime.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	job, _, err := runtime.Enqueue(context.Background(), background.JobSpec{
+		Kind: "storage.migration", Visibility: background.VisibilityAdmin, SubjectType: "storage_migration", SubjectID: migration.UUID,
+		Tasks: []background.TaskSpec{{Kind: taskStorageMigration, Queue: background.QueueStorage, Payload: storageMigrationTaskPayload{MigrationID: migration.ID}, Required: true}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Model(&migration).Update("background_job_id", job.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	waitStorageMigrationJob(t, runtime, job.ID, background.JobSucceeded)
+	if err := db.First(&migration, migration.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if migration.Status != models.StorageMigrationRetainingOriginals || migration.CleanupJobID == "" || migration.CleanupAfter == nil {
+		t.Fatalf("cleanup was not scheduled: %#v", migration)
+	}
+	if delay := time.Until(*migration.CleanupAfter); delay < 23*time.Hour || delay > 25*time.Hour {
+		t.Fatalf("cleanup delay = %s", delay)
+	}
+	cleanup, err := runtime.Job(context.Background(), migration.CleanupJobID, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cleanup.Status != background.JobQueued || len(cleanup.Tasks) != 1 || cleanup.Tasks[0].RunAfter == nil {
+		t.Fatalf("unexpected cleanup job: %#v", cleanup)
+	}
+}
+
+func TestStorageMigrationCopiesFinalChangesBeforeAtomicCutover(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
+		t.Fatal(err)
+	}
+	source, err := storage.NewLocalStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	destinationLocal, err := storage.NewLocalStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	file := models.File{UUID: "550e8400-e29b-41d4-a716-446655440201", StorageID: "source", StorageState: models.FileStorageAvailable, Size: 12}
+	if err := db.Create(&file).Error; err != nil {
+		t.Fatal(err)
+	}
+	prefix, err := storage.LegacyMediaLayout{}.FilePrefix(file.UUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstKey := migrationTestKey(t, prefix.String()+"/720p/segment.ts")
+	lateKey := migrationTestKey(t, prefix.String()+"/720p/index.m3u8")
+	putMigrationTestObject(t, source, firstKey, "first-segment")
+	destination := &migrationHookStore{Store: destinationLocal, hook: func() {
+		putMigrationTestObject(t, source, lateKey, "late-manifest")
+	}}
+	storageService, err := storage.NewService("source", storage.LegacyMediaLayout{}, map[string]storage.Store{"source": source, "destination": destination})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = storageService.Close() })
+	worker := NewWorkerGroup(&app.Deps{DB: db, Storage: storageService}, nil)
+	migration := models.StorageMigration{UUID: "migration", Status: models.StorageMigrationRunning, FileCount: 1}
+	if err := db.Create(&migration).Error; err != nil {
+		t.Fatal(err)
+	}
+	item := models.StorageMigrationItem{
+		MigrationID: migration.ID, FileID: file.ID, FileUUID: file.UUID,
+		SourceMountID: "source", DestinationMountID: "destination",
+		Status: models.StorageMigrationItemPending, ReservationKey: "file:1", PlannedBytes: file.Size,
+	}
+	if err := db.Create(&item).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := worker.migrateStorageItem(context.Background(), migration, &item); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.First(&file, file.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if file.StorageID != "destination" {
+		t.Fatalf("storage id = %q, want destination", file.StorageID)
+	}
+	if err := db.First(&item, item.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if item.Status != models.StorageMigrationItemCleanupPending || item.CutoverAt == nil || item.ObjectsVerified != 2 {
+		t.Fatalf("unexpected migrated item: %#v", item)
+	}
+	assertMigrationTestObject(t, destination, firstKey, "first-segment")
+	assertMigrationTestObject(t, destination, lateKey, "late-manifest")
+	assertMigrationTestObject(t, source, firstKey, "first-segment")
+
+	if err := worker.cleanupStorageMigrationItem(context.Background(), &item); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := source.Stat(context.Background(), firstKey); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("source remained after cleanup: %v", err)
+	}
+	if err := db.First(&item, item.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if item.Status != models.StorageMigrationItemCleaned || item.ReservationKey != "" {
+		t.Fatalf("unexpected cleaned item: %#v", item)
+	}
+}
+
+func TestStorageMigrationRefusesUnownedDestinationPrefix(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
+		t.Fatal(err)
+	}
+	source, _ := storage.NewLocalStore(t.TempDir())
+	destination, _ := storage.NewLocalStore(t.TempDir())
+	service, err := storage.NewService("source", storage.LegacyMediaLayout{}, map[string]storage.Store{"source": source, "destination": destination})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = service.Close() })
+	file := models.File{UUID: "550e8400-e29b-41d4-a716-446655440202", StorageID: "source", StorageState: models.FileStorageAvailable}
+	if err := db.Create(&file).Error; err != nil {
+		t.Fatal(err)
+	}
+	key := migrationTestKey(t, file.UUID+"/source/original.mp4")
+	putMigrationTestObject(t, source, key, "source")
+	putMigrationTestObject(t, destination, key, "unrelated")
+	migration := models.StorageMigration{UUID: "migration-conflict", Status: models.StorageMigrationRunning, FileCount: 1}
+	db.Create(&migration)
+	item := models.StorageMigrationItem{MigrationID: migration.ID, FileID: file.ID, FileUUID: file.UUID, SourceMountID: "source", DestinationMountID: "destination", Status: models.StorageMigrationItemPending, ReservationKey: "file:conflict"}
+	db.Create(&item)
+	worker := NewWorkerGroup(&app.Deps{DB: db, Storage: service}, nil)
+	if err := worker.migrateStorageItem(context.Background(), migration, &item); !errors.Is(err, errStorageMigrationStateConflict) {
+		t.Fatalf("expected destination conflict, got %v", err)
+	}
+	if err := db.First(&file, file.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if file.StorageID != "source" {
+		t.Fatalf("conflicted migration cut over to %q", file.StorageID)
+	}
+}
+
+func TestCanceledStorageMigrationRemovesOnlyUnreferencedDestinationData(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
+		t.Fatal(err)
+	}
+	source, _ := storage.NewLocalStore(t.TempDir())
+	destination, _ := storage.NewLocalStore(t.TempDir())
+	service, _ := storage.NewService("source", storage.LegacyMediaLayout{}, map[string]storage.Store{"source": source, "destination": destination})
+	t.Cleanup(func() { _ = service.Close() })
+	worker := NewWorkerGroup(&app.Deps{DB: db, Storage: service}, nil)
+	migration := models.StorageMigration{UUID: "canceled", Status: models.StorageMigrationCanceled, FileCount: 2}
+	db.Create(&migration)
+
+	pendingFile := models.File{UUID: "550e8400-e29b-41d4-a716-446655440401", StorageID: "source", StorageState: models.FileStorageAvailable}
+	db.Create(&pendingFile)
+	pendingKey := migrationTestKey(t, pendingFile.UUID+"/source/original.mp4")
+	putMigrationTestObject(t, source, pendingKey, "source")
+	putMigrationTestObject(t, destination, pendingKey, "partial")
+	pending := models.StorageMigrationItem{MigrationID: migration.ID, FileID: pendingFile.ID, FileUUID: pendingFile.UUID, SourceMountID: "source", DestinationMountID: "destination", Status: models.StorageMigrationItemCopying, ReservationKey: fmt.Sprintf("file:%d", pendingFile.ID), DestinationOwned: true}
+	db.Create(&pending)
+	if err := worker.cleanupCanceledStorageMigrationItem(context.Background(), &pending); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := destination.Stat(context.Background(), pendingKey); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("partial destination remained: %v", err)
+	}
+	assertMigrationTestObject(t, source, pendingKey, "source")
+
+	cutoverFile := models.File{UUID: "550e8400-e29b-41d4-a716-446655440402", StorageID: "destination", StorageState: models.FileStorageAvailable}
+	db.Create(&cutoverFile)
+	cutoverKey := migrationTestKey(t, cutoverFile.UUID+"/source/original.mp4")
+	putMigrationTestObject(t, source, cutoverKey, "original")
+	putMigrationTestObject(t, destination, cutoverKey, "active")
+	now := time.Now().UTC()
+	cutover := models.StorageMigrationItem{MigrationID: migration.ID, FileID: cutoverFile.ID, FileUUID: cutoverFile.UUID, SourceMountID: "source", DestinationMountID: "destination", Status: models.StorageMigrationItemCleanupPending, ReservationKey: fmt.Sprintf("file:%d", cutoverFile.ID), DestinationOwned: true, CutoverAt: &now}
+	db.Create(&cutover)
+	if err := worker.cleanupCanceledStorageMigrationItem(context.Background(), &cutover); err != nil {
+		t.Fatal(err)
+	}
+	assertMigrationTestObject(t, destination, cutoverKey, "active")
+	assertMigrationTestObject(t, source, cutoverKey, "original")
+	if err := db.First(&cutover, cutover.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if cutover.Status != models.StorageMigrationItemOriginalKept || cutover.ReservationKey != "" {
+		t.Fatalf("unexpected cutover cancellation state: %#v", cutover)
+	}
+}
+
+func TestStorageMigrationReconciliationRepairsCanceledJobCrashWindow(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := background.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	runtime := background.New(db, background.Options{})
+	deps := &app.Deps{DB: db, Background: runtime}
+	worker := NewWorkerGroup(deps, nil)
+	migration := models.StorageMigration{UUID: "reconcile-canceled", SourcePoolName: "Source", DestinationPoolName: "Destination", Status: models.StorageMigrationQueued, FileCount: 1}
+	if err := db.Create(&migration).Error; err != nil {
+		t.Fatal(err)
+	}
+	item := models.StorageMigrationItem{MigrationID: migration.ID, FileID: 1, FileUUID: "file", SourceMountID: "source", DestinationMountID: "destination", Status: models.StorageMigrationItemPending, ReservationKey: "file:1"}
+	if err := db.Create(&item).Error; err != nil {
+		t.Fatal(err)
+	}
+	mainJob, _, err := runtime.Enqueue(context.Background(), background.JobSpec{
+		Kind: "storage.migration", Visibility: background.VisibilityAdmin,
+		SubjectType: "storage_migration", SubjectID: migration.UUID,
+		Tasks: []background.TaskSpec{{Kind: taskStorageMigration, Queue: background.QueueStorage, Required: true}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := runtime.CancelJob(context.Background(), mainJob.ID, 1, "admin"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := worker.storageMigrationReconcileHandler(runtime)(context.Background(), background.Task{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.First(&migration, migration.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if migration.Status != models.StorageMigrationCanceled || migration.BackgroundJobID != mainJob.ID || migration.CleanupJobID == "" {
+		t.Fatalf("canceled migration was not reconciled: %#v", migration)
+	}
+	abortJob, err := runtime.Job(context.Background(), migration.CleanupJobID, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if abortJob.Kind != "storage.migration.abort_cleanup" || abortJob.Status != background.JobQueued {
+		t.Fatalf("unexpected reconciled cleanup job: %#v", abortJob)
+	}
+
+	retaining := models.StorageMigration{UUID: "reconcile-retention", Status: models.StorageMigrationRetainingOriginals, FileCount: 1}
+	if err := db.Create(&retaining).Error; err != nil {
+		t.Fatal(err)
+	}
+	retainedItem := models.StorageMigrationItem{MigrationID: retaining.ID, FileID: 2, FileUUID: "retained", SourceMountID: "source", DestinationMountID: "destination", Status: models.StorageMigrationItemCleanupPending, ReservationKey: "file:2"}
+	if err := db.Create(&retainedItem).Error; err != nil {
+		t.Fatal(err)
+	}
+	cleanupJob, _, err := runtime.Enqueue(context.Background(), background.JobSpec{
+		Kind: "storage.migration.cleanup", Visibility: background.VisibilityAdmin,
+		SubjectType: "storage_migration", SubjectID: retaining.UUID,
+		Tasks: []background.TaskSpec{{Kind: taskStorageCleanup, Queue: background.QueueStorage, Required: true}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Model(&retaining).Update("cleanup_job_id", cleanupJob.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := runtime.CancelJob(context.Background(), cleanupJob.ID, 1, "admin"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := worker.storageMigrationReconcileHandler(runtime)(context.Background(), background.Task{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.First(&retaining, retaining.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.First(&retainedItem, retainedItem.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if retaining.Status != models.StorageMigrationOriginalsRetained || retainedItem.Status != models.StorageMigrationItemOriginalKept || retainedItem.ReservationKey != "" {
+		t.Fatalf("canceled original cleanup was not reconciled: migration=%#v item=%#v", retaining, retainedItem)
+	}
+}
+
+type migrationHookStore struct {
+	storage.Store
+	once sync.Once
+	hook func()
+}
+
+func (s *migrationHookStore) Put(ctx context.Context, key storage.Key, source io.Reader, options storage.PutOptions) (storage.ObjectInfo, error) {
+	info, err := s.Store.Put(ctx, key, source, options)
+	if err == nil && s.hook != nil {
+		s.once.Do(s.hook)
+	}
+	return info, err
+}
+
+func migrationTestKey(t *testing.T, value string) storage.Key {
+	t.Helper()
+	key, err := storage.ParseKey(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return key
+}
+
+func putMigrationTestObject(t *testing.T, store storage.Store, key storage.Key, value string) {
+	t.Helper()
+	size := int64(len(value))
+	if _, err := store.Put(context.Background(), key, strings.NewReader(value), storage.PutOptions{ExpectedSize: &size}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertMigrationTestObject(t *testing.T, store storage.Store, key storage.Key, expected string) {
+	t.Helper()
+	object, err := store.Open(context.Background(), key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer object.Body.Close()
+	data, err := io.ReadAll(object.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != expected {
+		t.Fatalf("object %s = %q, want %q", key.String(), data, expected)
+	}
+}
+
+func waitStorageMigrationJob(t *testing.T, runtime *background.Runtime, jobID string, status string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		detail, err := runtime.Job(context.Background(), jobID, nil, true)
+		if err == nil && detail.Status == status {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	detail, err := runtime.Job(context.Background(), jobID, nil, true)
+	t.Fatalf("job did not reach %s: detail=%#v err=%v", status, detail, err)
+}

--- a/storage/copy.go
+++ b/storage/copy.go
@@ -1,0 +1,121 @@
+package storage
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"sort"
+	"strings"
+)
+
+type VerifiedCopyResult struct {
+	Info     ObjectInfo
+	Checksum string
+	Copied   bool
+}
+
+func PrefixInventory(ctx context.Context, store Store, prefix Key) ([]ObjectInfo, error) {
+	if store == nil {
+		return nil, ErrStoreNotConfigured
+	}
+	objects := make([]ObjectInfo, 0)
+	if err := store.Walk(ctx, prefix, func(info ObjectInfo) error {
+		objects = append(objects, info)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	sort.Slice(objects, func(i, j int) bool {
+		iManifest := strings.EqualFold(objectExtension(objects[i].Key.String()), ".m3u8")
+		jManifest := strings.EqualFold(objectExtension(objects[j].Key.String()), ".m3u8")
+		if iManifest != jManifest {
+			return !iManifest
+		}
+		return objects[i].Key.String() < objects[j].Key.String()
+	})
+	return objects, nil
+}
+
+func CopyObjectVerified(ctx context.Context, source, destination Store, sourceInfo ObjectInfo) (VerifiedCopyResult, error) {
+	if source == nil || destination == nil {
+		return VerifiedCopyResult{}, ErrStoreNotConfigured
+	}
+	if err := ctx.Err(); err != nil {
+		return VerifiedCopyResult{}, err
+	}
+	if destinationInfo, err := destination.Stat(ctx, sourceInfo.Key); err == nil && destinationInfo.Size == sourceInfo.Size {
+		sourceChecksum, sourceSize, sourceErr := hashStoredObject(ctx, source, sourceInfo.Key)
+		if sourceErr != nil {
+			return VerifiedCopyResult{}, sourceErr
+		}
+		destinationChecksum, destinationSize, destinationErr := hashStoredObject(ctx, destination, sourceInfo.Key)
+		if destinationErr != nil {
+			return VerifiedCopyResult{}, destinationErr
+		}
+		if sourceSize == destinationSize && sourceChecksum == destinationChecksum {
+			return VerifiedCopyResult{Info: destinationInfo, Checksum: sourceChecksum, Copied: false}, nil
+		}
+	} else if err != nil && !errors.Is(err, ErrNotFound) {
+		return VerifiedCopyResult{}, err
+	}
+
+	object, err := source.Open(ctx, sourceInfo.Key)
+	if err != nil {
+		return VerifiedCopyResult{}, err
+	}
+	defer object.Body.Close()
+	expectedSize := object.Info.Size
+	digest := sha256.New()
+	reader := io.TeeReader(&contextReader{ctx: ctx, reader: object.Body}, digest)
+	written, err := destination.Put(ctx, sourceInfo.Key, reader, PutOptions{
+		ContentType: object.Info.ContentType, CacheControl: object.Info.CacheControl, ExpectedSize: &expectedSize,
+	})
+	if err != nil {
+		return VerifiedCopyResult{}, err
+	}
+	if written.Size != expectedSize {
+		return VerifiedCopyResult{}, fmt.Errorf("copied object %s size mismatch: wrote %d, expected %d", sourceInfo.Key.String(), written.Size, expectedSize)
+	}
+	sourceChecksum := fmt.Sprintf("%x", digest.Sum(nil))
+	destinationChecksum, destinationSize, err := hashStoredObject(ctx, destination, sourceInfo.Key)
+	if err != nil {
+		return VerifiedCopyResult{}, err
+	}
+	if destinationSize != expectedSize || destinationChecksum != sourceChecksum {
+		return VerifiedCopyResult{}, fmt.Errorf("copied object %s failed checksum verification", sourceInfo.Key.String())
+	}
+	return VerifiedCopyResult{Info: written, Checksum: sourceChecksum, Copied: true}, nil
+}
+
+func hashStoredObject(ctx context.Context, store Store, key Key) (string, int64, error) {
+	object, err := store.Open(ctx, key)
+	if err != nil {
+		return "", 0, err
+	}
+	defer object.Body.Close()
+	digest := sha256.New()
+	written, err := copyHashWithContext(ctx, digest, object.Body)
+	if err != nil {
+		return "", written, err
+	}
+	if written != object.Info.Size {
+		return "", written, fmt.Errorf("object %s size mismatch while hashing: read %d, expected %d", key.String(), written, object.Info.Size)
+	}
+	return fmt.Sprintf("%x", digest.Sum(nil)), written, nil
+}
+
+func copyHashWithContext(ctx context.Context, destination hash.Hash, source io.Reader) (int64, error) {
+	return copyWithContext(ctx, destination, source)
+}
+
+func objectExtension(value string) string {
+	index := strings.LastIndexByte(value, '.')
+	separator := strings.LastIndexByte(value, '/')
+	if index < 0 || index < separator {
+		return ""
+	}
+	return value[index:]
+}

--- a/storage/copy_test.go
+++ b/storage/copy_test.go
@@ -1,0 +1,76 @@
+package storage
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCopyObjectVerifiedCopiesMetadataAndSkipsVerifiedDestination(t *testing.T) {
+	source, err := NewLocalStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	destination, err := NewLocalStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := copyTestKey(t, "video/source/original.mp4")
+	size := int64(len("verified media"))
+	if _, err := source.Put(context.Background(), key, strings.NewReader("verified media"), PutOptions{ContentType: "video/mp4", CacheControl: "private", ExpectedSize: &size}); err != nil {
+		t.Fatal(err)
+	}
+	info, err := source.Stat(context.Background(), key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := CopyObjectVerified(context.Background(), source, destination, info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !first.Copied || first.Checksum == "" || first.Info.Size != size {
+		t.Fatalf("unexpected first copy: %#v", first)
+	}
+	second, err := CopyObjectVerified(context.Background(), source, destination, info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Copied || second.Checksum != first.Checksum {
+		t.Fatalf("verified destination was not reused: %#v", second)
+	}
+}
+
+func TestPrefixInventoryOrdersManifestsLast(t *testing.T) {
+	root := t.TempDir()
+	store, err := NewLocalStore(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"video/stream/index.m3u8", "video/stream/segment.ts", "video/stream/audio.m3u8"} {
+		path := filepath.Join(root, filepath.FromSlash(name))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(name), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	objects, err := PrefixInventory(context.Background(), store, copyTestKey(t, "video"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(objects) != 3 || strings.HasSuffix(objects[0].Key.String(), ".m3u8") || !strings.HasSuffix(objects[2].Key.String(), ".m3u8") {
+		t.Fatalf("unexpected inventory order: %#v", objects)
+	}
+}
+
+func copyTestKey(t *testing.T, value string) Key {
+	t.Helper()
+	key, err := ParseKey(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return key
+}


### PR DESCRIPTION
## Summary

- add durable pause and resume support to the standardized background-job system
- add admin-managed storage migrations with preflight validation, bounded concurrent copying, verification, per-video atomic cutover, and delayed cleanup
- add pause, resume, cancel, retry, keep-originals, and recovery behavior across restarts
- add the storage migration admin workflow and self-hosting operations guidance through pinned frontend and documentation commits

## Safety and reliability

- playback stays on the source pool until each video has copied and verified successfully
- destination reservations and lifecycle guards prevent conflicting pool changes and media mutations
- cancellation preserves source media and removes only safe, incomplete destination data
- source cleanup runs as a separate delayed background job after a 24-hour grace period
- startup and periodic reconciliation close crash windows around cancellation and cleanup scheduling

## Companion commits

- Frontend: https://github.com/Kirari04/videocms-frontend/commit/7e5d319b4ea3118d06e0940b4a06f103f87a2e7b
- Self-hosting docs: https://github.com/Kirari04/videocms-docs/commit/b97f5ac9cb829abde1fcdab749b3e1d541d891cb

## Verification

- go test ./...
- go test -race ./app ./background ./logic ./services ./storage
- go vet ./...
- frontend npm run build
- docs bun run docs:build
- git diff --check
- frontend Impeccable audit: no findings