### PR TITLE
fix(storage): make migrations deletion-safe

### DIFF
--- a/logic/StorageMigration.go
+++ b/logic/StorageMigration.go
@@ -667,7 +667,7 @@ func (s *Service) KeepStorageMigrationOriginals(ctx context.Context, migrationUU
 			if err := tx.Select("id", "status").First(item, item.ID).Error; err != nil {
 				return err
 			}
-			if item.Status == models.StorageMigrationItemCleaned {
+			if item.Status == models.StorageMigrationItemCleaned || item.Status == models.StorageMigrationItemDeleted {
 				return nil
 			}
 			status := models.StorageMigrationItemOriginalKept
@@ -676,16 +676,18 @@ func (s *Service) KeepStorageMigrationOriginals(ctx context.Context, migrationUU
 				status = models.StorageMigrationItemOriginalPartial
 				message = "Original cleanup was incomplete; remaining data retained"
 			}
-			return tx.Model(item).Updates(map[string]any{
-				"status": status, "reservation_key": "", "progress_message": message,
-			}).Error
+			return tx.Model(item).
+				Where("status NOT IN ?", []string{models.StorageMigrationItemCleaned, models.StorageMigrationItemDeleted}).
+				Updates(map[string]any{
+					"status": status, "reservation_key": "", "progress_message": message,
+				}).Error
 		})
 		releaseFile()
 		if err != nil {
 			return models.StorageMigration{}, err
 		}
 	}
-	var cleaned, partial int64
+	var cleaned, partial, deleted int64
 	now := time.Now().UTC()
 	err = s.Deps.DB.WithContext(durableCtx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Model(&models.StorageMigrationItem{}).
@@ -696,6 +698,11 @@ func (s *Service) KeepStorageMigrationOriginals(ctx context.Context, migrationUU
 		if err := tx.Model(&models.StorageMigrationItem{}).
 			Where("migration_id = ? AND status = ?", migration.ID, models.StorageMigrationItemOriginalPartial).
 			Count(&partial).Error; err != nil {
+			return err
+		}
+		if err := tx.Model(&models.StorageMigrationItem{}).
+			Where("migration_id = ? AND status = ?", migration.ID, models.StorageMigrationItemDeleted).
+			Count(&deleted).Error; err != nil {
 			return err
 		}
 		phase := "Original copies retained"
@@ -710,7 +717,7 @@ func (s *Service) KeepStorageMigrationOriginals(ctx context.Context, migrationUU
 		}
 		return tx.Model(&migration).Updates(map[string]any{
 			"status": models.StorageMigrationOriginalsRetained, "phase": phase, "keep_originals": true,
-			"cleaned_count": cleaned, "completed_at": &now, "error_code": "", "error_message": "",
+			"cleaned_count": cleaned, "deleted_count": deleted, "completed_at": &now, "error_code": "", "error_message": "",
 		}).Error
 	})
 	if err != nil {

--- a/logic/StorageMigration_test.go
+++ b/logic/StorageMigration_test.go
@@ -174,7 +174,7 @@ func TestKeepStorageMigrationOriginalsWaitsForInFlightCleanup(t *testing.T) {
 	if err := db.AutoMigrate(&models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
 		t.Fatal(err)
 	}
-	migration := models.StorageMigration{UUID: "keep-originals", Status: models.StorageMigrationCleaningOriginals, FileCount: 2}
+	migration := models.StorageMigration{UUID: "keep-originals", Status: models.StorageMigrationCleaningOriginals, FileCount: 3}
 	if err := db.Create(&migration).Error; err != nil {
 		t.Fatal(err)
 	}
@@ -184,6 +184,10 @@ func TestKeepStorageMigrationOriginalsWaitsForInFlightCleanup(t *testing.T) {
 	}
 	partial := models.StorageMigrationItem{MigrationID: migration.ID, FileID: 43, FileUUID: "partial", Status: models.StorageMigrationItemCleaning, ReservationKey: "file:43"}
 	if err := db.Create(&partial).Error; err != nil {
+		t.Fatal(err)
+	}
+	deleted := models.StorageMigrationItem{MigrationID: migration.ID, FileID: 44, FileUUID: "deleted", Status: models.StorageMigrationItemDeleted, ReservationKey: "file:44"}
+	if err := db.Create(&deleted).Error; err != nil {
 		t.Fatal(err)
 	}
 	deps := &app.Deps{DB: db}
@@ -213,7 +217,7 @@ func TestKeepStorageMigrationOriginalsWaitsForInFlightCleanup(t *testing.T) {
 	releaseCleanup()
 	select {
 	case kept := <-result:
-		if kept.Status != models.StorageMigrationOriginalsRetained || kept.CleanedCount != 1 {
+		if kept.Status != models.StorageMigrationOriginalsRetained || kept.CleanedCount != 1 || kept.DeletedCount != 1 {
 			t.Fatalf("unexpected retained state: %#v", kept)
 		}
 	case err := <-failures:
@@ -232,6 +236,12 @@ func TestKeepStorageMigrationOriginalsWaitsForInFlightCleanup(t *testing.T) {
 	}
 	if partial.Status != models.StorageMigrationItemOriginalPartial || partial.ReservationKey != "" {
 		t.Fatalf("incomplete cleanup was mislabeled as a complete original: %#v", partial)
+	}
+	if err := db.First(&deleted, deleted.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if deleted.Status != models.StorageMigrationItemDeleted || deleted.ReservationKey == "" {
+		t.Fatalf("deleted video cleanup ownership was released: %#v", deleted)
 	}
 }
 

--- a/models/StorageMigration.go
+++ b/models/StorageMigration.go
@@ -22,6 +22,7 @@ const (
 	StorageMigrationItemCleaned         = "cleaned"
 	StorageMigrationItemOriginalKept    = "original_kept"
 	StorageMigrationItemOriginalPartial = "original_partial"
+	StorageMigrationItemDeleted         = "deleted"
 	StorageMigrationItemFailed          = "failed"
 	StorageMigrationItemCanceled        = "canceled"
 )
@@ -45,6 +46,7 @@ type StorageMigration struct {
 	CopiedBytes         int64
 	CutoverCount        int64
 	CleanedCount        int64
+	DeletedCount        int64
 	CreatedByID         uint   `gorm:"index"`
 	CreatedByName       string `gorm:"size:120"`
 	CancelGeneration    int

--- a/services/Deleter.go
+++ b/services/Deleter.go
@@ -26,58 +26,82 @@ func (w *WorkerGroup) Deleter(ctx context.Context) {
 
 func (w *WorkerGroup) runDeleter() error {
 	var deletionErrors []error
-	var notReferencedFiles []uint
+	var candidateFileIDs []uint
 	if res := w.deps.DB.
 		Raw(`
-		SELECT files.id FROM files
-		JOIN links ON links.file_id = files.id
-		GROUP BY files.id
-		HAVING COUNT(links.id) = SUM(CASE WHEN links.deleted_at IS NULL THEN 0 ELSE 1 END);
-		`).Scan(&notReferencedFiles); res.Error != nil {
+		SELECT files.id
+		FROM files
+		WHERE files.deleted_at IS NOT NULL
+			OR NOT EXISTS (
+				SELECT 1 FROM links
+				WHERE links.file_id = files.id AND links.deleted_at IS NULL
+			)
+		ORDER BY files.id ASC;
+		`).Scan(&candidateFileIDs); res.Error != nil {
 		log.Printf("Failed to query unreferenced files: %v", res.Error)
 		return res.Error
 	}
 
-	if len(notReferencedFiles) > 0 {
-		if res := w.deps.DB.Delete(&models.File{}, notReferencedFiles); res.Error != nil {
-			log.Printf("Failed to delete unreferenced files: %v", res.Error)
-			return res.Error
-		}
-	}
-
-	var todos []models.File
-	if res := w.deps.DB.
-		Model(&models.File{}).
-		Preload("Qualitys").
-		Preload("Subtitles").
-		Preload("Audios").
-		Preload("Links").
-		Unscoped().
-		Where("deleted_at IS NOT NULL").
-		Find(&todos, todos); res.Error != nil {
-		log.Printf("Failed to query deleted files: %v", res.Error)
-		return res.Error
-	}
-
-	if len(todos) > 0 {
-		log.Printf("Queued %d file to delete", len(todos))
+	if len(candidateFileIDs) > 0 {
+		log.Printf("Queued %d file to delete", len(candidateFileIDs))
 	}
 	var skippingDeletion int
 	var successDeletion int
-	for _, todo := range todos {
-		w.CancelDownloadPreparationsForFile(todo.ID)
-		w.cancelActiveEncodingsForFile(todo.ID, "file queued for deletion")
-		releaseFile := w.deps.StorageLifecycle.FileWriteLock(todo.ID)
-		if err := w.deps.DB.Unscoped().Preload("Qualitys").Preload("Subtitles").Preload("Audios").Preload("Links").First(&todo, todo.ID).Error; err != nil {
+	for _, fileID := range candidateFileIDs {
+		w.CancelDownloadPreparationsForFile(fileID)
+		w.cancelActiveEncodingsForFile(fileID, "file queued for deletion")
+		releaseFile := w.deps.StorageLifecycle.FileWriteLock(fileID)
+		var todo models.File
+		if err := w.deps.DB.Unscoped().Preload("Qualitys").Preload("Subtitles").Preload("Audios").Preload("Links").First(&todo, fileID).Error; err != nil {
 			releaseFile()
 			if !errors.Is(err, gorm.ErrRecordNotFound) {
 				deletionErrors = append(deletionErrors, err)
 			}
 			continue
 		}
+		if todo.DeletedAt == nil || !todo.DeletedAt.Valid {
+			var references int64
+			if err := w.deps.DB.Model(&models.Link{}).Where("file_id = ?", todo.ID).Count(&references).Error; err != nil {
+				deletionErrors = append(deletionErrors, err)
+				releaseFile()
+				continue
+			}
+			if references > 0 {
+				releaseFile()
+				continue
+			}
+			if err := w.deps.DB.Delete(&todo).Error; err != nil {
+				deletionErrors = append(deletionErrors, err)
+				releaseFile()
+				continue
+			}
+		}
+
+		var migrationItems []models.StorageMigrationItem
+		if err := w.deps.DB.Where("file_id = ?", todo.ID).Order("id ASC").Find(&migrationItems).Error; err != nil {
+			deletionErrors = append(deletionErrors, err)
+			releaseFile()
+			continue
+		}
+		migrationIDs := make(map[uint]struct{}, len(migrationItems))
+		if len(migrationItems) > 0 {
+			if err := w.deps.DB.Model(&models.StorageMigrationItem{}).Where("file_id = ?", todo.ID).Updates(map[string]any{
+				"status": models.StorageMigrationItemDeleted, "progress_message": "Deleted during migration",
+				"error_code": "", "error_message": "", "bytes_total": 0, "bytes_copied": 0,
+				"objects_verified": 0,
+			}).Error; err != nil {
+				deletionErrors = append(deletionErrors, err)
+				releaseFile()
+				continue
+			}
+			for index := range migrationItems {
+				migrationIDs[migrationItems[index].MigrationID] = struct{}{}
+			}
+		}
 		if w.HasActiveDownloadPreparationForFile(todo.ID) {
 			skippingDeletion++
 			releaseFile()
+			w.refreshDeletedFileMigrationProgress(migrationIDs, &deletionErrors)
 			continue
 		}
 
@@ -106,18 +130,27 @@ func (w *WorkerGroup) runDeleter() error {
 			// we will try again in the next loop (the encoding process may be finished until then)
 			skippingDeletion++
 			releaseFile()
+			w.refreshDeletedFileMigrationProgress(migrationIDs, &deletionErrors)
 			continue
 		}
 
-		if err := w.deleteStoredFile(todo); err != nil {
+		if err := w.deleteStoredFileCopies(todo, migrationItems); err != nil {
 			log.Printf("Failed to delete stored data for file %d: %v", todo.ID, err)
 			deletionErrors = append(deletionErrors, err)
 			skippingDeletion++
 			releaseFile()
+			w.refreshDeletedFileMigrationProgress(migrationIDs, &deletionErrors)
 			continue
 		}
 
 		if err := w.deps.DB.Transaction(func(tx *gorm.DB) error {
+			if err := tx.Model(&models.StorageMigrationItem{}).Where("file_id = ?", todo.ID).Updates(map[string]any{
+				"status": models.StorageMigrationItemDeleted, "reservation_key": "", "destination_owned": false,
+				"progress_message": "Deleted during migration", "error_code": "", "error_message": "",
+				"bytes_total": 0, "bytes_copied": 0, "objects_verified": 0,
+			}).Error; err != nil {
+				return err
+			}
 			if err := tx.Unscoped().Where("file_id = ?", todo.ID).Delete(&models.Subtitle{}).Error; err != nil {
 				return err
 			}
@@ -132,10 +165,12 @@ func (w *WorkerGroup) runDeleter() error {
 			log.Printf("Failed to delete file %d from database: %v", todo.ID, err)
 			deletionErrors = append(deletionErrors, err)
 			releaseFile()
+			w.refreshDeletedFileMigrationProgress(migrationIDs, &deletionErrors)
 			continue
 		}
 		successDeletion++
 		releaseFile()
+		w.refreshDeletedFileMigrationProgress(migrationIDs, &deletionErrors)
 	}
 	if skippingDeletion > 0 {
 		log.Printf("Skipped %d files from deletion", skippingDeletion)
@@ -147,8 +182,23 @@ func (w *WorkerGroup) runDeleter() error {
 }
 
 func (w *WorkerGroup) deleteStoredFile(file models.File) error {
-	releaseMount := w.deps.StorageLifecycle.ReadLock(file.StorageID)
-	defer releaseMount()
+	return w.deleteStoredFileCopies(file, nil)
+}
+
+func (w *WorkerGroup) deleteStoredFileCopies(file models.File, migrationItems []models.StorageMigrationItem) error {
+	mountIDs := []string{file.StorageID}
+	if w.deps.Storage != nil && w.deps.Storage.Layout() != nil {
+		for _, item := range migrationItems {
+			if item.CleanedAt == nil {
+				mountIDs = append(mountIDs, item.SourceMountID)
+			}
+			if item.DestinationOwned {
+				mountIDs = append(mountIDs, item.DestinationMountID)
+			}
+		}
+	}
+	releaseMounts := w.deps.StorageLifecycle.ReadLocks(mountIDs...)
+	defer releaseMounts()
 	if file.Path != "" {
 		info, err := os.Stat(file.Path)
 		switch {
@@ -162,15 +212,25 @@ func (w *WorkerGroup) deleteStoredFile(file models.File) error {
 	}
 
 	if w.deps.Storage != nil && w.deps.Storage.Layout() != nil {
-		store, err := w.deps.Storage.StoreOrDefault(file.StorageID)
-		if err != nil {
-			return err
-		}
 		prefix, err := w.deps.Storage.Layout().FilePrefix(file.UUID)
 		if err != nil {
 			return err
 		}
-		return storage.DeletePrefix(context.Background(), store, prefix)
+		seen := make(map[string]bool, len(mountIDs))
+		for _, mountID := range mountIDs {
+			if seen[mountID] {
+				continue
+			}
+			seen[mountID] = true
+			store, err := w.deps.Storage.StoreOrDefault(mountID)
+			if err != nil {
+				return err
+			}
+			if err := storage.DeletePrefix(context.Background(), store, prefix); err != nil {
+				return err
+			}
+		}
+		return nil
 	}
 
 	if file.Folder == "" {
@@ -186,5 +246,13 @@ func (w *WorkerGroup) deleteStoredFile(file models.File) error {
 		return nil
 	default:
 		return os.RemoveAll(file.Folder)
+	}
+}
+
+func (w *WorkerGroup) refreshDeletedFileMigrationProgress(migrationIDs map[uint]struct{}, deletionErrors *[]error) {
+	for migrationID := range migrationIDs {
+		if err := w.refreshStorageMigrationProgress(context.Background(), migrationID); err != nil {
+			*deletionErrors = append(*deletionErrors, err)
+		}
 	}
 }

--- a/services/Deleter_test.go
+++ b/services/Deleter_test.go
@@ -6,10 +6,16 @@ import (
 	"ch/kirari04/videocms/storage"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 func TestDeleteStoredFileUsesMediaStoreAndRemovesSource(t *testing.T) {
@@ -62,5 +68,114 @@ func TestDeleteStoredFileUsesMediaStoreAndRemovesSource(t *testing.T) {
 	}
 	if _, err := defaultStore.Stat(context.Background(), mediaKey); err != nil {
 		t.Fatalf("default-store object was removed: %v", err)
+	}
+}
+
+func TestDeleterRemovesAllMigrationCopiesAndReleasesReservations(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.File{}, &models.Link{}, &models.Quality{}, &models.Audio{}, &models.Subtitle{}, &models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
+		t.Fatal(err)
+	}
+	source, _ := storage.NewLocalStore(t.TempDir())
+	destination, _ := storage.NewLocalStore(t.TempDir())
+	storageService, err := storage.NewService("source", storage.LegacyMediaLayout{}, map[string]storage.Store{"source": source, "destination": destination})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = storageService.Close() })
+	migration := models.StorageMigration{UUID: "delete-migrating-files", Status: models.StorageMigrationRunning, FileCount: 2, PlannedBytes: 11}
+	if err := db.Create(&migration).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	preCutover := models.File{UUID: "550e8400-e29b-41d4-a716-446655440310", StorageID: "source", StorageState: models.FileStorageAvailable}
+	postCutover := models.File{UUID: "550e8400-e29b-41d4-a716-446655440311", StorageID: "destination", StorageState: models.FileStorageAvailable}
+	for _, file := range []*models.File{&preCutover, &postCutover} {
+		if err := db.Create(file).Error; err != nil {
+			t.Fatal(err)
+		}
+		link := models.Link{UUID: file.UUID + "-link", Name: "deleted", FileID: file.ID}
+		if err := db.Create(&link).Error; err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Delete(&link).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	preKey := migrationTestKey(t, preCutover.UUID+"/source/original.mp4")
+	postKey := migrationTestKey(t, postCutover.UUID+"/source/original.mp4")
+	putMigrationTestObject(t, source, preKey, "source")
+	putMigrationTestObject(t, destination, preKey, "partial")
+	putMigrationTestObject(t, source, postKey, "retained")
+	putMigrationTestObject(t, destination, postKey, "active")
+	now := time.Now().UTC()
+	items := []models.StorageMigrationItem{
+		{MigrationID: migration.ID, FileID: preCutover.ID, FileUUID: preCutover.UUID, SourceMountID: "source", DestinationMountID: "destination", Status: models.StorageMigrationItemCopying, ReservationKey: fmt.Sprintf("file:%d", preCutover.ID), DestinationOwned: true, PlannedBytes: 5, BytesTotal: 5, BytesCopied: 5},
+		{MigrationID: migration.ID, FileID: postCutover.ID, FileUUID: postCutover.UUID, SourceMountID: "source", DestinationMountID: "destination", Status: models.StorageMigrationItemCleanupPending, ReservationKey: fmt.Sprintf("file:%d", postCutover.ID), DestinationOwned: true, PlannedBytes: 6, BytesTotal: 6, BytesCopied: 6, CutoverAt: &now},
+	}
+	if err := db.Create(&items).Error; err != nil {
+		t.Fatal(err)
+	}
+	worker := NewWorkerGroup(&app.Deps{DB: db, Storage: storageService}, nil)
+	if err := worker.runDeleter(); err != nil {
+		t.Fatal(err)
+	}
+	for _, file := range []models.File{preCutover, postCutover} {
+		var current models.File
+		if err := db.Unscoped().First(&current, file.ID).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
+			t.Fatalf("file %d still exists: %v", file.ID, err)
+		}
+	}
+	for _, pair := range []struct {
+		store storage.Store
+		key   storage.Key
+	}{{source, preKey}, {destination, preKey}, {source, postKey}, {destination, postKey}} {
+		if _, err := pair.store.Stat(context.Background(), pair.key); !errors.Is(err, storage.ErrNotFound) {
+			t.Fatalf("migration copy %s remained: %v", pair.key.String(), err)
+		}
+	}
+	for index := range items {
+		if err := db.First(&items[index], items[index].ID).Error; err != nil {
+			t.Fatal(err)
+		}
+		if items[index].Status != models.StorageMigrationItemDeleted || items[index].ReservationKey != "" || items[index].DestinationOwned {
+			t.Fatalf("migration item was not finalized: %#v", items[index])
+		}
+	}
+	if err := db.First(&migration, migration.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if migration.DeletedCount != 2 || migration.ActualBytes != 0 || migration.CopiedBytes != 0 {
+		t.Fatalf("migration progress was not reconciled: %#v", migration)
+	}
+}
+
+func TestDeleterKeepsFileWithActiveLink(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.File{}, &models.Link{}, &models.Quality{}, &models.Audio{}, &models.Subtitle{}); err != nil {
+		t.Fatal(err)
+	}
+	store, _ := storage.NewLocalStore(t.TempDir())
+	storageService, _ := storage.NewService("source", storage.LegacyMediaLayout{}, map[string]storage.Store{"source": store})
+	t.Cleanup(func() { _ = storageService.Close() })
+	file := models.File{UUID: "550e8400-e29b-41d4-a716-446655440312", StorageID: "source", StorageState: models.FileStorageAvailable}
+	if err := db.Create(&file).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&models.Link{UUID: "active-link", Name: "active", FileID: file.ID}).Error; err != nil {
+		t.Fatal(err)
+	}
+	worker := NewWorkerGroup(&app.Deps{DB: db, Storage: storageService}, nil)
+	if err := worker.runDeleter(); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.First(&models.File{}, file.ID).Error; err != nil {
+		t.Fatalf("referenced file was deleted: %v", err)
 	}
 }

--- a/services/StorageMigration.go
+++ b/services/StorageMigration.go
@@ -18,6 +18,7 @@ import (
 const storageMigrationCleanupGrace = 24 * time.Hour
 
 var errStorageMigrationStateConflict = errors.New("storage migration state changed")
+var errStorageMigrationItemDeleted = errors.New("storage migration video was deleted")
 
 type storageMigrationTaskPayload struct {
 	MigrationID uint `json:"migrationId"`
@@ -62,7 +63,7 @@ func (w *WorkerGroup) storageMigrationHandler(runtime *background.Runtime) backg
 
 		var items []models.StorageMigrationItem
 		if err := w.deps.DB.WithContext(ctx).
-			Where("migration_id = ? AND status NOT IN ?", migration.ID, []string{models.StorageMigrationItemCleanupPending, models.StorageMigrationItemCleaned}).
+			Where("migration_id = ? AND status NOT IN ?", migration.ID, []string{models.StorageMigrationItemCleanupPending, models.StorageMigrationItemCleaned, models.StorageMigrationItemDeleted}).
 			Order("id ASC").Find(&items).Error; err != nil {
 			return background.Result{}, background.Transient("migration_items_failed", "Migration videos could not be loaded", err)
 		}
@@ -124,9 +125,24 @@ func (w *WorkerGroup) prepareStorageMigrationRetry(ctx context.Context, migratio
 		}
 		for index := range items {
 			item := &items[index]
+			if item.Status == models.StorageMigrationItemDeleted {
+				continue
+			}
 			var file models.File
-			if err := tx.First(&file, item.FileID).Error; err != nil {
+			if err := tx.Unscoped().First(&file, item.FileID).Error; err != nil {
+				if errors.Is(err, gorm.ErrRecordNotFound) {
+					if err := markStorageMigrationItemDeleted(tx, item); err != nil {
+						return err
+					}
+					continue
+				}
 				return err
+			}
+			if file.DeletedAt != nil && file.DeletedAt.Valid {
+				if err := markStorageMigrationItemDeleted(tx, item); err != nil {
+					return err
+				}
+				continue
 			}
 			status := models.StorageMigrationItemPending
 			if file.StorageID == item.DestinationMountID && item.CutoverAt != nil {
@@ -140,11 +156,15 @@ func (w *WorkerGroup) prepareStorageMigrationRetry(ctx context.Context, migratio
 				updates["bytes_copied"] = 0
 				updates["objects_verified"] = 0
 			}
-			if err := tx.Model(item).Updates(updates).Error; err != nil {
-				if strings.Contains(strings.ToLower(err.Error()), "unique") {
+			updated := tx.Model(item).Where("status <> ?", models.StorageMigrationItemDeleted).Updates(updates)
+			if updated.Error != nil {
+				if strings.Contains(strings.ToLower(updated.Error.Error()), "unique") {
 					return errStorageMigrationStateConflict
 				}
-				return err
+				return updated.Error
+			}
+			if updated.RowsAffected == 0 {
+				continue
 			}
 		}
 		return tx.Model(migration).Updates(map[string]any{"keep_originals": false, "cleanup_job_id": "", "cleanup_after": nil, "canceled_at": nil}).Error
@@ -198,15 +218,8 @@ func (w *WorkerGroup) runStorageMigrationItems(ctx context.Context, migration mo
 }
 
 func (w *WorkerGroup) migrateStorageItem(ctx context.Context, migration models.StorageMigration, item *models.StorageMigrationItem) (err error) {
-	if item.Status == models.StorageMigrationItemCleanupPending || item.Status == models.StorageMigrationItemCleaned {
+	if item.Status == models.StorageMigrationItemCleanupPending || item.Status == models.StorageMigrationItemCleaned || item.Status == models.StorageMigrationItemDeleted {
 		return nil
-	}
-	now := time.Now().UTC()
-	if err := w.deps.DB.WithContext(ctx).Model(item).Updates(map[string]any{
-		"status": models.StorageMigrationItemCopying, "copy_started_at": gorm.Expr("COALESCE(copy_started_at, ?)", now),
-		"error_code": "", "error_message": "", "progress_message": "Copying and verifying media",
-	}).Error; err != nil {
-		return err
 	}
 	defer func() {
 		if err == nil {
@@ -216,15 +229,43 @@ func (w *WorkerGroup) migrateStorageItem(ctx context.Context, migration models.S
 		if ctx.Err() != nil {
 			status, code, message = models.StorageMigrationItemPending, "", "Paused at a safe checkpoint"
 		}
-		_ = w.deps.DB.WithContext(context.WithoutCancel(ctx)).Model(item).Updates(map[string]any{
+		_ = w.deps.DB.WithContext(context.WithoutCancel(ctx)).Model(item).
+			Where("status <> ?", models.StorageMigrationItemDeleted).Updates(map[string]any{
 			"status": status, "error_code": code, "error_message": message, "progress_message": message,
 		}).Error
 	}()
 
 	releaseFile := w.deps.StorageLifecycle.FileReadLock(item.FileID)
+	if err = w.deps.DB.WithContext(ctx).First(item, item.ID).Error; err != nil {
+		releaseFile()
+		return err
+	}
+	if item.Status == models.StorageMigrationItemDeleted {
+		releaseFile()
+		return nil
+	}
 	var file models.File
 	if err = w.deps.DB.WithContext(ctx).First(&file, item.FileID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			err = markStorageMigrationItemDeleted(w.deps.DB.WithContext(context.WithoutCancel(ctx)), item)
+			if err == nil {
+				releaseMount := w.deps.StorageLifecycle.ReadLock(item.DestinationMountID)
+				err = w.cleanupDeletedStorageMigrationDestination(context.WithoutCancel(ctx), item, false)
+				releaseMount()
+			}
+		}
 		releaseFile()
+		return err
+	}
+	now := time.Now().UTC()
+	if err = updateActiveStorageMigrationItem(w.deps.DB.WithContext(ctx), item, map[string]any{
+		"status": models.StorageMigrationItemCopying, "copy_started_at": gorm.Expr("COALESCE(copy_started_at, ?)", now),
+		"error_code": "", "error_message": "", "progress_message": "Copying and verifying media",
+	}); err != nil {
+		releaseFile()
+		if errors.Is(err, errStorageMigrationItemDeleted) {
+			return nil
+		}
 		return err
 	}
 	if file.StorageID != item.SourceMountID || file.StorageState != models.FileStorageAvailable {
@@ -233,8 +274,14 @@ func (w *WorkerGroup) migrateStorageItem(ctx context.Context, migration models.S
 	}
 	releaseMounts := w.deps.StorageLifecycle.ReadLocks(item.SourceMountID, item.DestinationMountID)
 	if err = w.copyStorageMigrationPrefix(ctx, item, file, false); err != nil {
+		if errors.Is(err, errStorageMigrationItemDeleted) {
+			err = w.cleanupDeletedStorageMigrationDestination(context.WithoutCancel(ctx), item, true)
+		}
 		releaseMounts()
 		releaseFile()
+		if errors.Is(err, errStorageMigrationItemDeleted) {
+			return nil
+		}
 		return err
 	}
 	releaseMounts()
@@ -245,15 +292,34 @@ func (w *WorkerGroup) migrateStorageItem(ctx context.Context, migration models.S
 	}
 	releaseFile = w.deps.StorageLifecycle.FileWriteLock(item.FileID)
 	defer releaseFile()
+	if err = w.deps.DB.WithContext(ctx).First(item, item.ID).Error; err != nil {
+		return err
+	}
+	if item.Status == models.StorageMigrationItemDeleted {
+		releaseMount := w.deps.StorageLifecycle.ReadLock(item.DestinationMountID)
+		defer releaseMount()
+		return w.cleanupDeletedStorageMigrationDestination(context.WithoutCancel(ctx), item, true)
+	}
 	releaseMounts = w.deps.StorageLifecycle.ReadLocks(item.SourceMountID, item.DestinationMountID)
 	defer releaseMounts()
 	if err = w.deps.DB.WithContext(ctx).First(&file, item.FileID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			if err = markStorageMigrationItemDeleted(w.deps.DB.WithContext(context.WithoutCancel(ctx)), item); err == nil {
+				err = w.cleanupDeletedStorageMigrationDestination(context.WithoutCancel(ctx), item, true)
+			}
+		}
 		return err
 	}
 	if file.StorageID != item.SourceMountID || file.StorageState != models.FileStorageAvailable {
 		return fmt.Errorf("%w: file %d changed before cutover", errStorageMigrationStateConflict, file.ID)
 	}
 	if err = w.copyStorageMigrationPrefix(ctx, item, file, true); err != nil {
+		if errors.Is(err, errStorageMigrationItemDeleted) {
+			if cleanupErr := w.cleanupDeletedStorageMigrationDestination(context.WithoutCancel(ctx), item, true); cleanupErr != nil {
+				return cleanupErr
+			}
+			return nil
+		}
 		return err
 	}
 	if err = ctx.Err(); err != nil {
@@ -270,12 +336,106 @@ func (w *WorkerGroup) migrateStorageItem(ctx context.Context, migration models.S
 		if updated.RowsAffected != 1 {
 			return errStorageMigrationStateConflict
 		}
-		return tx.Model(item).Updates(map[string]any{
+		updated = tx.Model(item).Where("status <> ?", models.StorageMigrationItemDeleted).Updates(map[string]any{
 			"status": models.StorageMigrationItemCleanupPending, "verified_at": &cutoverAt, "cutover_at": &cutoverAt,
 			"progress_message": "Destination active; original retained", "error_code": "", "error_message": "",
-		}).Error
+		})
+		if updated.Error != nil {
+			return updated.Error
+		}
+		if updated.RowsAffected != 1 {
+			return errStorageMigrationItemDeleted
+		}
+		return nil
 	})
+	if errors.Is(err, errStorageMigrationItemDeleted) {
+		if cleanupErr := w.cleanupDeletedStorageMigrationDestination(context.WithoutCancel(ctx), item, true); cleanupErr != nil {
+			return cleanupErr
+		}
+		return nil
+	}
+	if errors.Is(err, errStorageMigrationStateConflict) {
+		var current models.File
+		loadErr := w.deps.DB.WithContext(context.WithoutCancel(ctx)).Unscoped().First(&current, file.ID).Error
+		if errors.Is(loadErr, gorm.ErrRecordNotFound) || (loadErr == nil && current.DeletedAt != nil && current.DeletedAt.Valid) {
+			if markErr := markStorageMigrationItemDeleted(w.deps.DB.WithContext(context.WithoutCancel(ctx)), item); markErr != nil {
+				return markErr
+			}
+			if cleanupErr := w.cleanupDeletedStorageMigrationDestination(context.WithoutCancel(ctx), item, true); cleanupErr != nil {
+				return cleanupErr
+			}
+			return nil
+		}
+		if loadErr != nil {
+			return loadErr
+		}
+	}
 	return err
+}
+
+func updateActiveStorageMigrationItem(db *gorm.DB, item *models.StorageMigrationItem, updates map[string]any) error {
+	result := db.Model(item).Where("status <> ?", models.StorageMigrationItemDeleted).Updates(updates)
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		var current models.StorageMigrationItem
+		if err := db.First(&current, item.ID).Error; err != nil {
+			return err
+		}
+		if current.Status == models.StorageMigrationItemDeleted {
+			*item = current
+			return errStorageMigrationItemDeleted
+		}
+	}
+	return nil
+}
+
+func markStorageMigrationItemDeleted(db *gorm.DB, item *models.StorageMigrationItem) error {
+	updates := map[string]any{
+		"status": models.StorageMigrationItemDeleted, "error_code": "", "error_message": "",
+		"progress_message": "Deleted during migration", "bytes_total": 0, "bytes_copied": 0,
+		"objects_verified": 0,
+	}
+	if err := db.Model(item).Updates(updates).Error; err != nil {
+		return err
+	}
+	item.Status = models.StorageMigrationItemDeleted
+	item.ErrorCode = ""
+	item.ErrorMessage = ""
+	item.ProgressMessage = "Deleted during migration"
+	item.BytesTotal = 0
+	item.BytesCopied = 0
+	item.ObjectsVerified = 0
+	return nil
+}
+
+// cleanupDeletedStorageMigrationDestination removes any partial copy written
+// by a migration worker that overlapped deletion in another process. The file
+// deleter remains responsible for the source and releases the reservation only
+// after every application-owned copy has been removed.
+func (w *WorkerGroup) cleanupDeletedStorageMigrationDestination(ctx context.Context, item *models.StorageMigrationItem, workerWroteDestination bool) error {
+	ownedDestination := item.DestinationOwned || workerWroteDestination
+	if err := w.deps.DB.WithContext(ctx).First(item, item.ID).Error; err != nil {
+		return err
+	}
+	if item.Status != models.StorageMigrationItemDeleted || (!item.DestinationOwned && !ownedDestination) {
+		return nil
+	}
+	store, err := w.deps.Storage.Store(item.DestinationMountID)
+	if err != nil {
+		return err
+	}
+	prefix, err := w.deps.Storage.Layout().FilePrefix(item.FileUUID)
+	if err != nil {
+		return err
+	}
+	if err := storage.DeletePrefix(ctx, store, prefix); err != nil {
+		return err
+	}
+	return w.deps.DB.WithContext(ctx).Model(item).
+		Where("status = ?", models.StorageMigrationItemDeleted).
+		Update("destination_owned", false).Error
 }
 
 func (w *WorkerGroup) copyStorageMigrationPrefix(ctx context.Context, item *models.StorageMigrationItem, file models.File, finalSync bool) error {
@@ -299,7 +459,7 @@ func (w *WorkerGroup) copyStorageMigrationPrefix(ctx context.Context, item *mode
 		if len(existing) > 0 {
 			return fmt.Errorf("%w: destination prefix %s already contains data", errStorageMigrationStateConflict, prefix.String())
 		}
-		if err := w.deps.DB.WithContext(ctx).Model(item).Update("destination_owned", true).Error; err != nil {
+		if err := updateActiveStorageMigrationItem(w.deps.DB.WithContext(ctx), item, map[string]any{"destination_owned": true}); err != nil {
 			return err
 		}
 		item.DestinationOwned = true
@@ -319,9 +479,9 @@ func (w *WorkerGroup) copyStorageMigrationPrefix(ctx context.Context, item *mode
 	if finalSync {
 		status, message = models.StorageMigrationItemVerifying, "Final synchronization and verification"
 	}
-	if err := w.deps.DB.WithContext(ctx).Model(item).Updates(map[string]any{
+	if err := updateActiveStorageMigrationItem(w.deps.DB.WithContext(ctx), item, map[string]any{
 		"status": status, "bytes_total": total, "object_count": len(objects), "progress_message": message,
-	}).Error; err != nil {
+	}); err != nil {
 		return err
 	}
 	verifiedKeys := make(map[string]bool, len(objects))
@@ -335,10 +495,10 @@ func (w *WorkerGroup) copyStorageMigrationPrefix(ctx context.Context, item *mode
 		verifiedBytes += object.Size
 		now := time.Now()
 		if index+1 == len(objects) || lastProgressUpdate.IsZero() || now.Sub(lastProgressUpdate) >= 500*time.Millisecond {
-			if err := w.deps.DB.WithContext(ctx).Model(item).Updates(map[string]any{
+			if err := updateActiveStorageMigrationItem(w.deps.DB.WithContext(ctx), item, map[string]any{
 				"bytes_copied": verifiedBytes, "objects_verified": index + 1,
 				"progress_message": fmt.Sprintf("Verified %d of %d objects", index+1, len(objects)),
-			}).Error; err != nil {
+			}); err != nil {
 				return err
 			}
 			if err := w.refreshStorageMigrationProgress(ctx, item.MigrationID); err != nil {
@@ -369,29 +529,37 @@ func (w *WorkerGroup) refreshStorageMigrationProgress(ctx context.Context, migra
 		CopiedBytes  int64
 		CutoverCount int64
 		CleanedCount int64
+		DeletedCount int64
 		FileCount    int64
 	}
 	err := w.deps.DB.WithContext(ctx).Model(&models.StorageMigrationItem{}).
-		Select(`COALESCE(SUM(CASE WHEN bytes_total > 0 THEN bytes_total ELSE planned_bytes END), 0) AS actual_bytes,
-			COALESCE(SUM(bytes_copied), 0) AS copied_bytes,
+		Select(`COALESCE(SUM(CASE WHEN status = ? THEN 0 WHEN bytes_total > 0 THEN bytes_total ELSE planned_bytes END), 0) AS actual_bytes,
+			COALESCE(SUM(CASE WHEN status = ? THEN 0 ELSE bytes_copied END), 0) AS copied_bytes,
 			SUM(CASE WHEN status IN ? THEN 1 ELSE 0 END) AS cutover_count,
 			SUM(CASE WHEN status = ? THEN 1 ELSE 0 END) AS cleaned_count,
-			COUNT(*) AS file_count`, []string{models.StorageMigrationItemCleanupPending, models.StorageMigrationItemCleaning, models.StorageMigrationItemCleaned, models.StorageMigrationItemOriginalKept, models.StorageMigrationItemOriginalPartial}, models.StorageMigrationItemCleaned).
+			SUM(CASE WHEN status = ? THEN 1 ELSE 0 END) AS deleted_count,
+			COUNT(*) AS file_count`, models.StorageMigrationItemDeleted, models.StorageMigrationItemDeleted, []string{models.StorageMigrationItemCleanupPending, models.StorageMigrationItemCleaning, models.StorageMigrationItemCleaned, models.StorageMigrationItemOriginalKept, models.StorageMigrationItemOriginalPartial}, models.StorageMigrationItemCleaned, models.StorageMigrationItemDeleted).
 		Where("migration_id = ?", migrationID).Scan(&aggregate).Error
 	if err != nil {
 		return err
 	}
 	if err := w.deps.DB.WithContext(ctx).Model(&models.StorageMigration{}).Where("id = ?", migrationID).Updates(map[string]any{
 		"actual_bytes": aggregate.ActualBytes, "copied_bytes": aggregate.CopiedBytes,
-		"cutover_count": aggregate.CutoverCount, "cleaned_count": aggregate.CleanedCount,
+		"cutover_count": aggregate.CutoverCount, "cleaned_count": aggregate.CleanedCount, "deleted_count": aggregate.DeletedCount,
 	}).Error; err != nil {
 		return err
 	}
 	progress := 0.0
 	if aggregate.ActualBytes > 0 {
 		progress = float64(aggregate.CopiedBytes) / float64(aggregate.ActualBytes)
+	} else if aggregate.FileCount > 0 {
+		progress = float64(aggregate.CutoverCount+aggregate.DeletedCount) / float64(aggregate.FileCount)
 	}
-	background.ReportProgress(ctx, progress, fmt.Sprintf("%d of %d videos active on destination", aggregate.CutoverCount, aggregate.FileCount))
+	message := fmt.Sprintf("%d of %d videos active on destination", aggregate.CutoverCount, aggregate.FileCount)
+	if aggregate.DeletedCount > 0 {
+		message = fmt.Sprintf("%d moved, %d deleted during migration", aggregate.CutoverCount, aggregate.DeletedCount)
+	}
+	background.ReportProgress(ctx, progress, message)
 	return nil
 }
 
@@ -401,6 +569,13 @@ func (w *WorkerGroup) scheduleStorageMigrationCleanup(ctx context.Context, runti
 	}
 	if err := w.deps.DB.WithContext(ctx).First(migration, migration.ID).Error; err != nil {
 		return err
+	}
+	if migration.FileCount > 0 && migration.DeletedCount >= migration.FileCount {
+		completedAt := time.Now().UTC()
+		return w.deps.DB.WithContext(ctx).Model(migration).Updates(map[string]any{
+			"status": models.StorageMigrationCompleted, "phase": "Migration complete; all videos were deleted",
+			"copy_completed_at": &completedAt, "completed_at": &completedAt, "cleanup_after": nil,
+		}).Error
 	}
 	if migration.CleanupJobID != "" {
 		return nil
@@ -454,7 +629,7 @@ func (w *WorkerGroup) storageMigrationCleanupHandler(ctx context.Context, task b
 		return background.Result{}, background.Transient("cleanup_state_failed", "Cleanup state could not be updated", err)
 	}
 	var items []models.StorageMigrationItem
-	if err := w.deps.DB.WithContext(ctx).Where("migration_id = ? AND status <> ?", migration.ID, models.StorageMigrationItemCleaned).Order("id ASC").Find(&items).Error; err != nil {
+	if err := w.deps.DB.WithContext(ctx).Where("migration_id = ? AND status NOT IN ?", migration.ID, []string{models.StorageMigrationItemCleaned, models.StorageMigrationItemDeleted}).Order("id ASC").Find(&items).Error; err != nil {
 		return background.Result{}, background.Transient("cleanup_items_failed", "Cleanup videos could not be loaded", err)
 	}
 	for index := range items {
@@ -489,8 +664,11 @@ func (w *WorkerGroup) storageMigrationCleanupHandler(ctx context.Context, task b
 		return background.Result{ResultType: "storage_migration", ResultID: migration.UUID, Phase: "Originals retained"}, nil
 	}
 	completedAt := time.Now().UTC()
+	if err := w.refreshStorageMigrationProgress(context.WithoutCancel(ctx), migration.ID); err != nil {
+		return background.Result{}, background.Transient("cleanup_progress_failed", "Original cleanup progress could not be finalized", err)
+	}
 	if err := w.deps.DB.WithContext(context.WithoutCancel(ctx)).Model(&migration).Updates(map[string]any{
-		"status": models.StorageMigrationCompleted, "phase": "Migration and cleanup complete", "cleaned_count": migration.FileCount,
+		"status": models.StorageMigrationCompleted, "phase": "Migration and cleanup complete",
 		"completed_at": &completedAt,
 	}).Error; err != nil {
 		return background.Result{}, background.Transient("cleanup_state_failed", "Cleanup completion could not be recorded", err)
@@ -502,7 +680,7 @@ func (w *WorkerGroup) cleanupStorageMigrationItem(ctx context.Context, item *mod
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	if item.Status == models.StorageMigrationItemCleaned || item.Status == models.StorageMigrationItemOriginalKept || item.Status == models.StorageMigrationItemOriginalPartial {
+	if item.Status == models.StorageMigrationItemCleaned || item.Status == models.StorageMigrationItemOriginalKept || item.Status == models.StorageMigrationItemOriginalPartial || item.Status == models.StorageMigrationItemDeleted {
 		return nil
 	}
 	releaseFile := w.deps.StorageLifecycle.FileWriteLock(item.FileID)
@@ -515,7 +693,7 @@ func (w *WorkerGroup) cleanupStorageMigrationItem(ctx context.Context, item *mod
 	if err := w.deps.DB.WithContext(ctx).First(item, item.ID).Error; err != nil {
 		return err
 	}
-	if item.Status == models.StorageMigrationItemCleaned || item.Status == models.StorageMigrationItemOriginalKept || item.Status == models.StorageMigrationItemOriginalPartial {
+	if item.Status == models.StorageMigrationItemCleaned || item.Status == models.StorageMigrationItemOriginalKept || item.Status == models.StorageMigrationItemOriginalPartial || item.Status == models.StorageMigrationItemDeleted {
 		return nil
 	}
 	var file models.File
@@ -534,9 +712,12 @@ func (w *WorkerGroup) cleanupStorageMigrationItem(ctx context.Context, item *mod
 	if err != nil {
 		return err
 	}
-	if err := w.deps.DB.WithContext(ctx).Model(item).Updates(map[string]any{
+	if err := updateActiveStorageMigrationItem(w.deps.DB.WithContext(ctx), item, map[string]any{
 		"status": models.StorageMigrationItemCleaning, "progress_message": "Removing original copy",
-	}).Error; err != nil {
+	}); err != nil {
+		if errors.Is(err, errStorageMigrationItemDeleted) {
+			return nil
+		}
 		return err
 	}
 	// Once cleanup begins for a video, finish that whole video before honoring a
@@ -547,10 +728,14 @@ func (w *WorkerGroup) cleanupStorageMigrationItem(ctx context.Context, item *mod
 		return err
 	}
 	now := time.Now().UTC()
-	return w.deps.DB.WithContext(commitCtx).Model(item).Updates(map[string]any{
+	err = updateActiveStorageMigrationItem(w.deps.DB.WithContext(commitCtx), item, map[string]any{
 		"status": models.StorageMigrationItemCleaned, "cleaned_at": &now, "reservation_key": "",
 		"progress_message": "Original removed", "error_code": "", "error_message": "",
-	}).Error
+	})
+	if errors.Is(err, errStorageMigrationItemDeleted) {
+		return nil
+	}
+	return err
 }
 
 func (w *WorkerGroup) storageMigrationAbortHandler(runtime *background.Runtime) background.Handler {
@@ -616,16 +801,23 @@ func (w *WorkerGroup) cleanupCanceledStorageMigrationItem(ctx context.Context, i
 	if err := w.deps.DB.WithContext(ctx).First(item, item.ID).Error; err != nil {
 		return err
 	}
+	if item.Status == models.StorageMigrationItemDeleted {
+		return nil
+	}
 	var file models.File
 	err := w.deps.DB.WithContext(ctx).First(&file, item.FileID).Error
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return err
 	}
 	if err == nil && file.StorageID == item.DestinationMountID && item.CutoverAt != nil {
-		return w.deps.DB.WithContext(context.WithoutCancel(ctx)).Model(item).Updates(map[string]any{
+		err := updateActiveStorageMigrationItem(w.deps.DB.WithContext(context.WithoutCancel(ctx)), item, map[string]any{
 			"status": models.StorageMigrationItemOriginalKept, "reservation_key": "",
 			"progress_message": "Destination remains active; original retained",
-		}).Error
+		})
+		if errors.Is(err, errStorageMigrationItemDeleted) {
+			return nil
+		}
+		return err
 	}
 	if err == nil && file.StorageID != item.SourceMountID {
 		return fmt.Errorf("%w: file %d moved to unexpected mount %s", errStorageMigrationStateConflict, file.ID, file.StorageID)
@@ -643,10 +835,14 @@ func (w *WorkerGroup) cleanupCanceledStorageMigrationItem(ctx context.Context, i
 			return err
 		}
 	}
-	return w.deps.DB.WithContext(context.WithoutCancel(ctx)).Model(item).Updates(map[string]any{
+	err = updateActiveStorageMigrationItem(w.deps.DB.WithContext(context.WithoutCancel(ctx)), item, map[string]any{
 		"status": models.StorageMigrationItemCanceled, "reservation_key": "", "destination_owned": false,
 		"bytes_copied": 0, "objects_verified": 0, "progress_message": "Canceled before cutover",
-	}).Error
+	})
+	if errors.Is(err, errStorageMigrationItemDeleted) {
+		return nil
+	}
+	return err
 }
 
 func storageMigrationJobTerminal(status string) bool {

--- a/services/StorageMigration_test.go
+++ b/services/StorageMigration_test.go
@@ -176,6 +176,129 @@ func TestStorageMigrationCopiesFinalChangesBeforeAtomicCutover(t *testing.T) {
 	}
 }
 
+func TestStorageMigrationDeletionBetweenCopyAndCutoverIsTerminal(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
+		t.Fatal(err)
+	}
+	source, err := storage.NewLocalStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	destinationLocal, err := storage.NewLocalStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	file := models.File{UUID: "550e8400-e29b-41d4-a716-446655440204", StorageID: "source", StorageState: models.FileStorageAvailable, Size: 5}
+	if err := db.Create(&file).Error; err != nil {
+		t.Fatal(err)
+	}
+	key := migrationTestKey(t, file.UUID+"/source/original.mp4")
+	putMigrationTestObject(t, source, key, "media")
+	destination := &migrationHookStore{Store: destinationLocal, hook: func() {
+		if err := db.Delete(&file).Error; err != nil {
+			t.Errorf("delete file during copy: %v", err)
+		}
+	}}
+	service, err := storage.NewService("source", storage.LegacyMediaLayout{}, map[string]storage.Store{"source": source, "destination": destination})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = service.Close() })
+	migration := models.StorageMigration{UUID: "deleted-during-copy", Status: models.StorageMigrationRunning, FileCount: 1, PlannedBytes: 5}
+	if err := db.Create(&migration).Error; err != nil {
+		t.Fatal(err)
+	}
+	item := models.StorageMigrationItem{
+		MigrationID: migration.ID, FileID: file.ID, FileUUID: file.UUID,
+		SourceMountID: "source", DestinationMountID: "destination", Status: models.StorageMigrationItemPending,
+		ReservationKey: fmt.Sprintf("file:%d", file.ID), PlannedBytes: 5,
+	}
+	if err := db.Create(&item).Error; err != nil {
+		t.Fatal(err)
+	}
+	worker := NewWorkerGroup(&app.Deps{DB: db, Storage: service}, nil)
+	if err := worker.migrateStorageItem(context.Background(), migration, &item); err != nil {
+		t.Fatalf("deleted video failed migration: %v", err)
+	}
+	if err := db.First(&item, item.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if item.Status != models.StorageMigrationItemDeleted || item.CutoverAt != nil || item.DestinationOwned {
+		t.Fatalf("unexpected deleted migration item: %#v", item)
+	}
+	if item.ReservationKey == "" {
+		t.Fatal("reservation was released before the file deleter removed the source")
+	}
+	var deletedFile models.File
+	if err := db.Unscoped().First(&deletedFile, file.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if deletedFile.StorageID != "source" {
+		t.Fatalf("deleted file cut over to %q", deletedFile.StorageID)
+	}
+	assertMigrationTestObject(t, source, key, "media")
+	if _, err := destination.Stat(context.Background(), key); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("partial destination remained: %v", err)
+	}
+	if err := worker.refreshStorageMigrationProgress(context.Background(), migration.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.First(&migration, migration.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if migration.DeletedCount != 1 || migration.CutoverCount != 0 || migration.ActualBytes != 0 || migration.CopiedBytes != 0 {
+		t.Fatalf("unexpected deletion-aware progress: %#v", migration)
+	}
+}
+
+func TestStorageMigrationCleanupSkipsDeletedVideo(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.StorageMigrationItem{}); err != nil {
+		t.Fatal(err)
+	}
+	source, _ := storage.NewLocalStore(t.TempDir())
+	destination, _ := storage.NewLocalStore(t.TempDir())
+	service, err := storage.NewService("source", storage.LegacyMediaLayout{}, map[string]storage.Store{"source": source, "destination": destination})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = service.Close() })
+	item := models.StorageMigrationItem{FileID: 42, FileUUID: "550e8400-e29b-41d4-a716-446655440205", SourceMountID: "source", DestinationMountID: "destination", Status: models.StorageMigrationItemDeleted, ReservationKey: "file:42"}
+	if err := db.Create(&item).Error; err != nil {
+		t.Fatal(err)
+	}
+	key := migrationTestKey(t, item.FileUUID+"/source/original.mp4")
+	putMigrationTestObject(t, source, key, "awaiting-deleter")
+	putMigrationTestObject(t, destination, key, "late-copy")
+	worker := NewWorkerGroup(&app.Deps{DB: db, Storage: service}, nil)
+	if err := worker.cleanupStorageMigrationItem(context.Background(), &item); err != nil {
+		t.Fatal(err)
+	}
+	if err := worker.cleanupCanceledStorageMigrationItem(context.Background(), &item); err != nil {
+		t.Fatal(err)
+	}
+	assertMigrationTestObject(t, source, key, "awaiting-deleter")
+	if err := db.First(&item, item.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if item.Status != models.StorageMigrationItemDeleted || item.ReservationKey == "" {
+		t.Fatalf("cleanup changed deletion ownership: %#v", item)
+	}
+	if err := worker.cleanupDeletedStorageMigrationDestination(context.Background(), &item, true); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := destination.Stat(context.Background(), key); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("late destination copy remained after deletion finalized: %v", err)
+	}
+}
+
 func TestStorageMigrationCleanupStopsOnlyBetweenVideos(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
 	if err != nil {


### PR DESCRIPTION
## Summary
- treat user deletion as a terminal per-video migration outcome without failing the migration
- serialize deletion with copy/cutover and remove source, retained, partial, and late destination copies
- retain mount reservations until physical cleanup succeeds and prevent cleanup/retention actions from overriding deletion
- expose deletion-aware counts and statuses in the admin migration UI

## Validation
- go test ./...
- go test -race ./services ./logic
- go vet ./...
- frontend: bun run generate