### PR TITLE
Storage migrations: account scopes, resilience, and faster transfers

### DIFF
--- a/background/errors.go
+++ b/background/errors.go
@@ -19,6 +19,7 @@ const (
 	ErrorCanceled    ErrorClass = "canceled"
 	ErrorInterrupted ErrorClass = "interrupted"
 	ErrorPaused      ErrorClass = "paused"
+	ErrorDeferred    ErrorClass = "deferred"
 )
 
 type TaskError struct {
@@ -60,6 +61,12 @@ func Interrupted(cause error) error {
 
 func Paused(cause error) error {
 	return &TaskError{Code: "paused", Public: "Paused", Diagnostic: diagnostic(cause), Class: ErrorPaused, Cause: cause}
+}
+
+// Deferred requeues work that is waiting on an expected prerequisite. Unlike
+// a transient failure, a deferral does not consume the task's retry budget.
+func Deferred(code, public string, retryAfter time.Duration) error {
+	return &TaskError{Code: code, Public: public, Class: ErrorDeferred, RetryAfter: retryAfter}
 }
 
 func PauseRequested(ctx context.Context) bool {

--- a/background/runtime.go
+++ b/background/runtime.go
@@ -778,6 +778,17 @@ func (r *Runtime) finish(task Task, attempt Attempt, result Result, taskErr *Tas
 				updates["max_attempts"] = gorm.Expr("max_attempts + 1")
 				eventType = "task_interrupted"
 				eventMessage = "Task interrupted and queued again"
+			case ErrorDeferred:
+				attemptStatus = AttemptInterrupted
+				taskStatus = TaskRetryWait
+				delay := retryDelay(current.AttemptCount, taskErr.RetryAfter)
+				runAfter := now.Add(delay)
+				updates["status"] = taskStatus
+				updates["run_after"] = &runAfter
+				updates["finished_at"] = nil
+				updates["max_attempts"] = gorm.Expr("max_attempts + 1")
+				eventType = "task_deferred"
+				eventMessage = fmt.Sprintf("Task deferred for %s", delay.Round(time.Second))
 			case ErrorCanceled:
 				attemptStatus = AttemptCanceled
 				taskStatus = TaskCanceled

--- a/background/runtime_test.go
+++ b/background/runtime_test.go
@@ -285,6 +285,42 @@ func TestTransientFailureRetriesThenSucceeds(t *testing.T) {
 	}
 }
 
+func TestDeferredTaskRetriesWithoutExhaustingRetryBudget(t *testing.T) {
+	runtime, _ := testRuntime(t)
+	var calls atomic.Int32
+	if err := runtime.Register("test.deferred", func(context.Context, Task) (Result, error) {
+		if calls.Add(1) == 1 {
+			return Result{}, Deferred("prerequisite_pending", "Waiting for a prerequisite", time.Millisecond)
+		}
+		return Result{}, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	startTestRuntime(t, runtime)
+	job := enqueueTestJob(t, runtime, "deferred", "test.deferred", QueueStorage, 1)
+	detail := waitForJob(t, runtime, job.ID, JobSucceeded)
+	if calls.Load() != 2 || len(detail.Tasks) != 1 {
+		t.Fatalf("expected a deferred attempt followed by success, calls=%d tasks=%#v", calls.Load(), detail.Tasks)
+	}
+	task := detail.Tasks[0]
+	if task.AttemptCount != 2 || task.MaxAttempts != 2 {
+		t.Fatalf("deferral consumed the retry budget: %#v", task)
+	}
+	if len(task.Attempts) != 2 || task.Attempts[0].Status != AttemptInterrupted || task.Attempts[1].Status != AttemptSucceeded {
+		t.Fatalf("unexpected deferred attempt history: %#v", task.Attempts)
+	}
+	foundDeferredEvent := false
+	for _, event := range detail.Events {
+		if event.Type == "task_deferred" {
+			foundDeferredEvent = true
+			break
+		}
+	}
+	if !foundDeferredEvent {
+		t.Fatalf("deferred task event was not recorded: %#v", detail.Events)
+	}
+}
+
 func TestPermanentFailureDoesNotRetryAndRedactsDiagnostics(t *testing.T) {
 	runtime, _ := testRuntime(t)
 	if err := runtime.Register("test.fail", func(context.Context, Task) (Result, error) {

--- a/controllers/StorageMigrationController.go
+++ b/controllers/StorageMigrationController.go
@@ -69,6 +69,14 @@ func (h *Handlers) ListStorageMigrations(c echo.Context) error {
 	return c.JSON(http.StatusOK, response)
 }
 
+func (h *Handlers) ListStorageMigrationAccounts(c echo.Context) error {
+	accounts, err := h.Logic.ListStorageMigrationAccounts(c.Request().Context(), c.QueryParam("search"), 20)
+	if err != nil {
+		return storageMigrationError(c, err)
+	}
+	return c.JSON(http.StatusOK, echo.Map{"accounts": accounts})
+}
+
 func (h *Handlers) GetStorageMigration(c echo.Context) error {
 	migration, err := h.Logic.GetStorageMigration(c.Request().Context(), c.Param("id"))
 	if err != nil {
@@ -136,6 +144,8 @@ func storageMigrationError(c echo.Context, err error) error {
 		return c.JSON(http.StatusUnprocessableEntity, echo.Map{"error": "storage_migration_empty", "message": err.Error()})
 	case errors.Is(err, logic.ErrStorageMigrationUnavailable):
 		return c.JSON(http.StatusUnprocessableEntity, echo.Map{"error": "storage_migration_unavailable", "message": err.Error()})
+	case errors.Is(err, logic.ErrStorageMigrationAccounts):
+		return c.JSON(http.StatusUnprocessableEntity, echo.Map{"error": "storage_migration_accounts_invalid", "message": err.Error()})
 	default:
 		return c.JSON(http.StatusInternalServerError, echo.Map{"error": "storage_migration_failed"})
 	}

--- a/inits/Models.go
+++ b/inits/Models.go
@@ -59,6 +59,7 @@ func MigrateModels(gormDB *gorm.DB) error {
 		&models.StoragePool{},
 		&models.StoragePoolMount{},
 		&models.StorageMigration{},
+		&models.StorageMigrationAccount{},
 		&models.StorageMigrationItem{},
 		&models.User{},
 		&models.Folder{},

--- a/inits/Models.go
+++ b/inits/Models.go
@@ -61,6 +61,7 @@ func MigrateModels(gormDB *gorm.DB) error {
 		&models.StorageMigration{},
 		&models.StorageMigrationAccount{},
 		&models.StorageMigrationItem{},
+		&models.StorageMigrationObject{},
 		&models.User{},
 		&models.Folder{},
 		&models.File{},

--- a/logic/StorageMigration.go
+++ b/logic/StorageMigration.go
@@ -21,11 +21,15 @@ var (
 	ErrStorageMigrationConflict    = errors.New("storage migration conflicts with existing work")
 	ErrStorageMigrationEmpty       = errors.New("source pool contains no available videos")
 	ErrStorageMigrationUnavailable = errors.New("storage migration requires available mounts and media")
+	ErrStorageMigrationAccounts    = errors.New("storage migration account selection is invalid")
 )
+
+const maxStorageMigrationAccounts = 500
 
 type StorageMigrationInput struct {
 	SourcePoolID      uint   `json:"sourcePoolId" validate:"required"`
 	DestinationPoolID uint   `json:"destinationPoolId" validate:"required"`
+	AccountIDs        []uint `json:"accountIds,omitempty"`
 	PlanFingerprint   string `json:"planFingerprint,omitempty"`
 	IdempotencyKey    string `json:"-"`
 }
@@ -45,11 +49,19 @@ type StorageMigrationPlacementPreview struct {
 	PlannedBytes int64  `json:"plannedBytes"`
 }
 
+type StorageMigrationAccountPreview struct {
+	ID       uint   `json:"id"`
+	Username string `json:"username"`
+}
+
 type StorageMigrationPreview struct {
 	SourcePoolID          uint                               `json:"sourcePoolId"`
 	SourcePoolName        string                             `json:"sourcePoolName"`
 	DestinationPoolID     uint                               `json:"destinationPoolId"`
 	DestinationPoolName   string                             `json:"destinationPoolName"`
+	Scope                 string                             `json:"scope"`
+	Accounts              []StorageMigrationAccountPreview   `json:"accounts"`
+	SharedFileCount       int64                              `json:"sharedFileCount"`
 	FileCount             int64                              `json:"fileCount"`
 	PlannedBytes          int64                              `json:"plannedBytes"`
 	SourceMounts          []StorageMigrationMountPreview     `json:"sourceMounts"`
@@ -67,10 +79,30 @@ type StorageMigrationSummary struct {
 	VideosMoved        int64 `json:"videosMoved"`
 }
 
+func (s *Service) ListStorageMigrationAccounts(ctx context.Context, search string, limit int) ([]StorageMigrationAccountPreview, error) {
+	if s == nil || s.Deps == nil || s.Deps.DB == nil {
+		return nil, errors.New("storage migration account lookup is not configured")
+	}
+	if limit < 1 || limit > 50 {
+		limit = 20
+	}
+	query := s.Deps.DB.WithContext(ctx).Model(&models.User{}).Select("id", "username")
+	if search = strings.TrimSpace(search); search != "" {
+		query = query.Where("username LIKE ?", "%"+search+"%")
+	}
+	var accounts []StorageMigrationAccountPreview
+	err := query.Order("username ASC, id ASC").Limit(limit).Scan(&accounts).Error
+	if accounts == nil {
+		accounts = []StorageMigrationAccountPreview{}
+	}
+	return accounts, err
+}
+
 type storageMigrationPlan struct {
 	preview     StorageMigrationPreview
 	files       []models.File
 	destination map[uint]string
+	accounts    []StorageMigrationAccountPreview
 }
 
 type storageMountUsageRow struct {
@@ -139,6 +171,9 @@ func (s *Service) StartStorageMigration(ctx context.Context, input StorageMigrat
 		DestinationPoolID:   input.DestinationPoolID,
 		SourcePoolName:      plan.preview.SourcePoolName,
 		DestinationPoolName: plan.preview.DestinationPoolName,
+		Scope:               plan.preview.Scope,
+		AccountCount:        len(plan.accounts),
+		SharedFileCount:     plan.preview.SharedFileCount,
 		Status:              models.StorageMigrationQueued,
 		Phase:               "Waiting to start",
 		FileCount:           plan.preview.FileCount,
@@ -149,6 +184,17 @@ func (s *Service) StartStorageMigration(ctx context.Context, input StorageMigrat
 	err = s.Deps.DB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Create(migration).Error; err != nil {
 			return err
+		}
+		if len(plan.accounts) > 0 {
+			accounts := make([]models.StorageMigrationAccount, 0, len(plan.accounts))
+			for _, account := range plan.accounts {
+				accounts = append(accounts, models.StorageMigrationAccount{
+					MigrationID: migration.ID, UserID: account.ID, Username: account.Username,
+				})
+			}
+			if err := tx.CreateInBatches(&accounts, 100).Error; err != nil {
+				return err
+			}
 		}
 		items := make([]models.StorageMigrationItem, 0, len(plan.files))
 		for _, file := range plan.files {
@@ -243,11 +289,15 @@ func (s *Service) storageMigrationByRequest(ctx context.Context, requestKey stri
 }
 
 func storageMigrationJobSpec(migration models.StorageMigration) background.JobSpec {
+	label := fmt.Sprintf("Migrate %s to %s", migration.SourcePoolName, migration.DestinationPoolName)
+	if migration.Scope == models.StorageMigrationScopeAccounts {
+		label = fmt.Sprintf("Migrate videos for %d accounts from %s to %s", migration.AccountCount, migration.SourcePoolName, migration.DestinationPoolName)
+	}
 	return background.JobSpec{
 		Kind: "storage.migration", Visibility: background.VisibilityAdmin,
 		SubjectType: "storage_migration", SubjectID: migration.UUID,
 		IdempotencyKey: "storage-migration:" + migration.UUID,
-		Label:          fmt.Sprintf("Migrate %s to %s", migration.SourcePoolName, migration.DestinationPoolName),
+		Label:          label,
 		Pausable:       true,
 		Tasks: []background.TaskSpec{{
 			Kind: "storage.migration.run", Queue: background.QueueStorage, Phase: "Migrating videos",
@@ -318,12 +368,66 @@ func sameStorageMigrationFiles(first, second []models.File) bool {
 	return true
 }
 
+func (s *Service) storageMigrationAccountScope(ctx context.Context, requested []uint) ([]uint, []StorageMigrationAccountPreview, error) {
+	if len(requested) == 0 {
+		return nil, []StorageMigrationAccountPreview{}, nil
+	}
+	if len(requested) > maxStorageMigrationAccounts {
+		return nil, nil, fmt.Errorf("%w: select at most %d accounts", ErrStorageMigrationAccounts, maxStorageMigrationAccounts)
+	}
+	seen := make(map[uint]struct{}, len(requested))
+	accountIDs := make([]uint, 0, len(requested))
+	for _, accountID := range requested {
+		if accountID == 0 {
+			return nil, nil, fmt.Errorf("%w: account IDs must be positive", ErrStorageMigrationAccounts)
+		}
+		if _, exists := seen[accountID]; exists {
+			continue
+		}
+		seen[accountID] = struct{}{}
+		accountIDs = append(accountIDs, accountID)
+	}
+	sort.Slice(accountIDs, func(i, j int) bool { return accountIDs[i] < accountIDs[j] })
+	var users []models.User
+	if err := s.Deps.DB.WithContext(ctx).Select("id", "username").Where("id IN ?", accountIDs).Order("id ASC").Find(&users).Error; err != nil {
+		return nil, nil, err
+	}
+	if len(users) != len(accountIDs) {
+		return nil, nil, fmt.Errorf("%w: one or more selected accounts no longer exist", ErrStorageMigrationAccounts)
+	}
+	accounts := make([]StorageMigrationAccountPreview, 0, len(users))
+	for _, user := range users {
+		accounts = append(accounts, StorageMigrationAccountPreview{ID: user.ID, Username: user.Username})
+	}
+	return accountIDs, accounts, nil
+}
+
+func applyStorageMigrationAccountScope(query *gorm.DB, accountIDs []uint) *gorm.DB {
+	if len(accountIDs) == 0 {
+		return query
+	}
+	return query.Where(`EXISTS (
+		SELECT 1 FROM links
+		WHERE links.file_id = files.id
+			AND links.deleted_at IS NULL
+			AND links.user_id IN ?
+	)`, accountIDs)
+}
+
 func (s *Service) buildStorageMigrationPlan(ctx context.Context, input StorageMigrationInput) (storageMigrationPlan, error) {
 	if s == nil || s.Deps == nil || s.Deps.DB == nil || s.Deps.Storage == nil {
 		return storageMigrationPlan{}, storage.ErrStoreNotConfigured
 	}
 	if input.SourcePoolID == 0 || input.DestinationPoolID == 0 || input.SourcePoolID == input.DestinationPoolID {
 		return storageMigrationPlan{}, fmt.Errorf("%w: source and destination pools must be different", ErrStorageMigrationConflict)
+	}
+	accountIDs, accounts, err := s.storageMigrationAccountScope(ctx, input.AccountIDs)
+	if err != nil {
+		return storageMigrationPlan{}, err
+	}
+	scope := models.StorageMigrationScopeAll
+	if len(accountIDs) > 0 {
+		scope = models.StorageMigrationScopeAccounts
 	}
 	var sourcePool, destinationPool models.StoragePool
 	preload := func(db *gorm.DB) *gorm.DB { return db.Preload("Members.StorageMount") }
@@ -352,18 +456,18 @@ func (s *Service) buildStorageMigrationPlan(ctx context.Context, input StorageMi
 	}
 
 	var unavailable int64
-	if err := s.Deps.DB.WithContext(ctx).Model(&models.File{}).
-		Where("storage_id IN ? AND storage_state = ?", sourceIDs, models.FileStorageUnavailable).
-		Count(&unavailable).Error; err != nil {
+	unavailableQuery := s.Deps.DB.WithContext(ctx).Model(&models.File{}).
+		Where("storage_id IN ? AND storage_state = ?", sourceIDs, models.FileStorageUnavailable)
+	if err := applyStorageMigrationAccountScope(unavailableQuery, accountIDs).Count(&unavailable).Error; err != nil {
 		return storageMigrationPlan{}, err
 	}
 	if unavailable > 0 {
 		return storageMigrationPlan{}, fmt.Errorf("%w: source pool contains %d unavailable videos", ErrStorageMigrationUnavailable, unavailable)
 	}
 	var files []models.File
-	if err := s.Deps.DB.WithContext(ctx).
-		Where("storage_id IN ? AND storage_state = ?", sourceIDs, models.FileStorageAvailable).
-		Order("size DESC, id ASC").Find(&files).Error; err != nil {
+	filesQuery := s.Deps.DB.WithContext(ctx).Model(&models.File{}).
+		Where("storage_id IN ? AND storage_state = ?", sourceIDs, models.FileStorageAvailable)
+	if err := applyStorageMigrationAccountScope(filesQuery, accountIDs).Order("size DESC, id ASC").Find(&files).Error; err != nil {
 		return storageMigrationPlan{}, err
 	}
 	if len(files) == 0 {
@@ -373,19 +477,32 @@ func (s *Service) buildStorageMigrationPlan(ctx context.Context, input StorageMi
 	for _, file := range files {
 		plannedBytes += file.Size
 	}
+	fileIDs := make([]uint, 0, len(files))
+	for _, file := range files {
+		fileIDs = append(fileIDs, file.ID)
+	}
 	var reserved int64
 	if err := s.Deps.DB.WithContext(ctx).Model(&models.StorageMigrationItem{}).
-		Where(`reservation_key <> '' AND EXISTS (
-			SELECT 1 FROM files
-			WHERE files.id = storage_migration_items.file_id
-			AND files.deleted_at IS NULL
-			AND files.storage_id IN ?
-			AND files.storage_state = ?
-		)`, sourceIDs, models.FileStorageAvailable).Count(&reserved).Error; err != nil {
+		Where("reservation_key <> '' AND file_id IN ?", fileIDs).Count(&reserved).Error; err != nil {
 		return storageMigrationPlan{}, err
 	}
 	if reserved > 0 {
 		return storageMigrationPlan{}, fmt.Errorf("%w: %d videos are already reserved by another migration", ErrStorageMigrationConflict, reserved)
+	}
+	var sharedFileCount int64
+	if len(accountIDs) > 0 {
+		if err := s.Deps.DB.WithContext(ctx).Model(&models.File{}).
+			Where("id IN ?", fileIDs).
+			Where(`EXISTS (
+				SELECT 1 FROM links
+				JOIN users ON users.id = links.user_id AND users.deleted_at IS NULL
+				WHERE links.file_id = files.id
+					AND links.deleted_at IS NULL
+					AND links.user_id NOT IN ?
+			)`, accountIDs).
+			Count(&sharedFileCount).Error; err != nil {
+			return storageMigrationPlan{}, err
+		}
 	}
 
 	usage := make(map[string]int64, len(destinationIDs))
@@ -429,25 +546,41 @@ func (s *Service) buildStorageMigrationPlan(ctx context.Context, input StorageMi
 	}
 
 	warnings := []string{"Videos uploaded after this snapshot will not be included.", "Upload routing is not changed automatically."}
+	if sharedFileCount > 0 {
+		videoLabel, verb := "videos", "are"
+		if sharedFileCount == 1 {
+			videoLabel, verb = "video", "is"
+		}
+		warnings = append(warnings, fmt.Sprintf("%d selected %s %s also used by other accounts; shared physical files move once for everyone.", sharedFileCount, videoLabel, verb))
+	}
 	if sourcePool.IsDefault {
 		warnings = append(warnings, "The source is still the default upload pool.")
 	}
 	var overrideCount int64
-	if err := s.Deps.DB.WithContext(ctx).Model(&models.User{}).Where("storage_pool_id = ?", sourcePool.ID).Count(&overrideCount).Error; err != nil {
+	overrideQuery := s.Deps.DB.WithContext(ctx).Model(&models.User{}).Where("storage_pool_id = ?", sourcePool.ID)
+	if len(accountIDs) > 0 {
+		overrideQuery = overrideQuery.Where("id IN ?", accountIDs)
+	}
+	if err := overrideQuery.Count(&overrideCount).Error; err != nil {
 		return storageMigrationPlan{}, err
 	}
 	if overrideCount > 0 {
-		warnings = append(warnings, fmt.Sprintf("%d users still upload to the source pool.", overrideCount))
+		label := "accounts"
+		if len(accountIDs) > 0 {
+			label = "selected accounts"
+		}
+		warnings = append(warnings, fmt.Sprintf("%d %s still upload to the source pool.", overrideCount, label))
 	}
 	plan := storageMigrationPlan{
 		preview: StorageMigrationPreview{
 			SourcePoolID: sourcePool.ID, SourcePoolName: sourcePool.Name,
 			DestinationPoolID: destinationPool.ID, DestinationPoolName: destinationPool.Name,
+			Scope: scope, Accounts: accounts, SharedFileCount: sharedFileCount,
 			FileCount: int64(len(files)), PlannedBytes: plannedBytes,
 			SourceMounts: sourceMounts, DestinationMounts: destinationMounts,
 			DestinationPlacements: placements, Warnings: warnings, CleanupGraceHours: 24,
 		},
-		files: files, destination: destination,
+		files: files, destination: destination, accounts: accounts,
 	}
 	plan.preview.PlanFingerprint = storageMigrationPlanFingerprint(plan)
 	return plan, nil
@@ -455,7 +588,10 @@ func (s *Service) buildStorageMigrationPlan(ctx context.Context, input StorageMi
 
 func storageMigrationPlanFingerprint(plan storageMigrationPlan) string {
 	digest := sha256.New()
-	_, _ = fmt.Fprintf(digest, "source-pool:%d\ndestination-pool:%d\n", plan.preview.SourcePoolID, plan.preview.DestinationPoolID)
+	_, _ = fmt.Fprintf(digest, "source-pool:%d\ndestination-pool:%d\nscope:%s\nshared-files:%d\n", plan.preview.SourcePoolID, plan.preview.DestinationPoolID, plan.preview.Scope, plan.preview.SharedFileCount)
+	for _, account := range plan.accounts {
+		_, _ = fmt.Fprintf(digest, "account:%d:%q\n", account.ID, account.Username)
+	}
 	for _, mount := range plan.preview.SourceMounts {
 		_, _ = fmt.Fprintf(digest, "source-mount:%s\n", mount.UUID)
 	}
@@ -561,7 +697,9 @@ func (s *Service) GetStorageMigration(ctx context.Context, migrationUUID string)
 	if err != nil {
 		return models.StorageMigration{}, err
 	}
-	err = s.Deps.DB.WithContext(context.WithoutCancel(ctx)).First(&migration, migration.ID).Error
+	err = s.Deps.DB.WithContext(context.WithoutCancel(ctx)).Preload("Accounts", func(db *gorm.DB) *gorm.DB {
+		return db.Order("user_id ASC")
+	}).First(&migration, migration.ID).Error
 	return migration, err
 }
 

--- a/logic/StorageMigration_test.go
+++ b/logic/StorageMigration_test.go
@@ -3,6 +3,7 @@ package logic
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -22,7 +23,7 @@ func TestStorageMigrationPreviewAndStartSnapshotDeterministically(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.AutoMigrate(&models.StorageMount{}, &models.StoragePool{}, &models.StoragePoolMount{}, &models.User{}, &models.File{}, &models.Link{}, &models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
+	if err := db.AutoMigrate(&models.StorageMount{}, &models.StoragePool{}, &models.StoragePoolMount{}, &models.User{}, &models.File{}, &models.Link{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}); err != nil {
 		t.Fatal(err)
 	}
 	if err := background.Migrate(db); err != nil {
@@ -79,7 +80,7 @@ func TestStorageMigrationPreviewAndStartSnapshotDeterministically(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	if preview.FileCount != 2 || preview.PlannedBytes != 150 || preview.CleanupGraceHours != 24 || len(preview.DestinationPlacements) != 2 {
+	if preview.Scope != models.StorageMigrationScopeAll || preview.Accounts == nil || preview.FileCount != 2 || preview.PlannedBytes != 150 || preview.CleanupGraceHours != 24 || len(preview.DestinationPlacements) != 2 {
 		t.Fatalf("unexpected preview: %#v", preview)
 	}
 	input.PlanFingerprint = preview.PlanFingerprint
@@ -140,6 +141,241 @@ func TestStorageMigrationPreviewAndStartSnapshotDeterministically(t *testing.T) 
 	}
 }
 
+func TestStorageMigrationAccountScopeUsesActiveLinksAndPersistsSnapshot(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.StorageMount{}, &models.StoragePool{}, &models.StoragePoolMount{}, &models.User{}, &models.File{}, &models.Link{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}); err != nil {
+		t.Fatal(err)
+	}
+	if err := background.Migrate(db); err != nil {
+		t.Fatal(err)
+	}
+	stores := make(map[string]storage.Store)
+	var mounts []models.StorageMount
+	for _, id := range []string{"account-source", "account-destination"} {
+		store, storeErr := storage.NewLocalStore(t.TempDir())
+		if storeErr != nil {
+			t.Fatal(storeErr)
+		}
+		stores[id] = store
+		mount := models.StorageMount{UUID: id, Name: id, Provider: models.StorageProviderLocal, Mounted: true}
+		if err := db.Create(&mount).Error; err != nil {
+			t.Fatal(err)
+		}
+		mounts = append(mounts, mount)
+	}
+	storageService, err := storage.NewService("account-source", storage.LegacyMediaLayout{}, stores)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = storageService.Close() })
+	sourcePool := models.StoragePool{UUID: "account-source-pool", Name: "Account source"}
+	destinationPool := models.StoragePool{UUID: "account-destination-pool", Name: "Account destination"}
+	if err := db.Create(&sourcePool).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&destinationPool).Error; err != nil {
+		t.Fatal(err)
+	}
+	for _, membership := range []models.StoragePoolMount{
+		{StoragePoolID: sourcePool.ID, StorageMountID: mounts[0].ID},
+		{StoragePoolID: destinationPool.ID, StorageMountID: mounts[1].ID},
+	} {
+		if err := db.Create(&membership).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	users := []models.User{{Username: "alice"}, {Username: "bob"}, {Username: "carol"}, {Username: "deleted"}}
+	if err := db.Create(&users).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Delete(&users[3]).Error; err != nil {
+		t.Fatal(err)
+	}
+	files := []models.File{
+		{UUID: "account-alice", StorageID: mounts[0].UUID, StorageState: models.FileStorageAvailable, Size: 100},
+		{UUID: "account-bob", StorageID: mounts[0].UUID, StorageState: models.FileStorageAvailable, Size: 80},
+		{UUID: "account-alice-carol", StorageID: mounts[0].UUID, StorageState: models.FileStorageAvailable, Size: 60},
+		{UUID: "account-alice-bob", StorageID: mounts[0].UUID, StorageState: models.FileStorageAvailable, Size: 40},
+		{UUID: "account-carol", StorageID: mounts[0].UUID, StorageState: models.FileStorageAvailable, Size: 20},
+		{UUID: "account-carol-unavailable", StorageID: mounts[0].UUID, StorageState: models.FileStorageUnavailable, Size: 10},
+	}
+	if err := db.Create(&files).Error; err != nil {
+		t.Fatal(err)
+	}
+	links := []models.Link{
+		{UUID: "link-alice", Name: "Alice", FileID: files[0].ID, UserID: users[0].ID},
+		{UUID: "link-bob", Name: "Bob", FileID: files[1].ID, UserID: users[1].ID},
+		{UUID: "link-alice-shared", Name: "Alice shared", FileID: files[2].ID, UserID: users[0].ID},
+		{UUID: "link-carol-shared", Name: "Carol shared", FileID: files[2].ID, UserID: users[2].ID},
+		{UUID: "link-alice-selected", Name: "Alice selected", FileID: files[3].ID, UserID: users[0].ID},
+		{UUID: "link-bob-selected", Name: "Bob selected", FileID: files[3].ID, UserID: users[1].ID},
+		{UUID: "link-carol", Name: "Carol", FileID: files[4].ID, UserID: users[2].ID},
+		{UUID: "link-carol-unavailable", Name: "Carol unavailable", FileID: files[5].ID, UserID: users[2].ID},
+		{UUID: "link-deleted-shared", Name: "Deleted shared", FileID: files[0].ID, UserID: users[3].ID},
+	}
+	if err := db.Create(&links).Error; err != nil {
+		t.Fatal(err)
+	}
+	runtime := background.New(db, background.Options{})
+	service := NewService(&app.Deps{DB: db, Storage: storageService, Background: runtime})
+	accountResults, err := service.ListStorageMigrationAccounts(context.Background(), "ali", 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(accountResults) != 1 || accountResults[0].ID != users[0].ID || accountResults[0].Username != "alice" {
+		t.Fatalf("unexpected account search results: %#v", accountResults)
+	}
+	accountResults, err = service.ListStorageMigrationAccounts(context.Background(), "", 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(accountResults) != 3 {
+		t.Fatalf("deleted accounts were returned by account search: %#v", accountResults)
+	}
+	input := StorageMigrationInput{
+		SourcePoolID: sourcePool.ID, DestinationPoolID: destinationPool.ID,
+		AccountIDs: []uint{users[1].ID, users[0].ID, users[0].ID},
+	}
+	preview, err := service.PreviewStorageMigration(context.Background(), input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if preview.Scope != models.StorageMigrationScopeAccounts || preview.FileCount != 4 || preview.PlannedBytes != 280 || preview.SharedFileCount != 1 {
+		t.Fatalf("unexpected account-scoped preview: %#v", preview)
+	}
+	if len(preview.Accounts) != 2 || preview.Accounts[0].ID != users[0].ID || preview.Accounts[1].ID != users[1].ID {
+		t.Fatalf("account selection was not normalized: %#v", preview.Accounts)
+	}
+	if !strings.Contains(strings.Join(preview.Warnings, " "), "shared physical files move once for everyone") {
+		t.Fatalf("shared-file consequence was not disclosed: %#v", preview.Warnings)
+	}
+
+	// A source file unavailable only to an unselected account does not block
+	// this scoped migration, but the same full-pool migration remains blocked.
+	if _, err := service.PreviewStorageMigration(context.Background(), StorageMigrationInput{
+		SourcePoolID: sourcePool.ID, DestinationPoolID: destinationPool.ID,
+	}); !errors.Is(err, ErrStorageMigrationUnavailable) {
+		t.Fatalf("expected full migration to see unrelated unavailable video, got %v", err)
+	}
+	selectedUnavailable := models.File{UUID: "account-alice-unavailable", StorageID: mounts[0].UUID, StorageState: models.FileStorageUnavailable, Size: 5}
+	if err := db.Create(&selectedUnavailable).Error; err != nil {
+		t.Fatal(err)
+	}
+	selectedUnavailableLink := models.Link{UUID: "link-alice-unavailable", Name: "Alice unavailable", FileID: selectedUnavailable.ID, UserID: users[0].ID}
+	if err := db.Create(&selectedUnavailableLink).Error; err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.PreviewStorageMigration(context.Background(), input); !errors.Is(err, ErrStorageMigrationUnavailable) {
+		t.Fatalf("expected selected unavailable video to block migration, got %v", err)
+	}
+	if err := db.Unscoped().Delete(&selectedUnavailableLink).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Unscoped().Delete(&selectedUnavailable).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	// Reservations are checked only for selected physical files, so unrelated
+	// account migrations can run concurrently without weakening overlap safety.
+	reservation := models.StorageMigrationItem{MigrationID: 999, FileID: files[4].ID, FileUUID: files[4].UUID, ReservationKey: fmt.Sprintf("file:%d", files[4].ID)}
+	if err := db.Create(&reservation).Error; err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.PreviewStorageMigration(context.Background(), input); err != nil {
+		t.Fatalf("unrelated reservation blocked selected accounts: %v", err)
+	}
+	if _, err := service.PreviewStorageMigration(context.Background(), StorageMigrationInput{
+		SourcePoolID: sourcePool.ID, DestinationPoolID: destinationPool.ID, AccountIDs: []uint{users[2].ID},
+	}); !errors.Is(err, ErrStorageMigrationUnavailable) {
+		// Carol still has an unavailable source video, which is checked before
+		// reservations and remains the correct safety failure.
+		t.Fatalf("expected selected unavailable video to take precedence, got %v", err)
+	}
+	if err := db.Unscoped().Delete(&reservation).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Unscoped().Delete(&links[7]).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Unscoped().Delete(&files[5]).Error; err != nil {
+		t.Fatal(err)
+	}
+	reservation = models.StorageMigrationItem{MigrationID: 999, FileID: files[4].ID, FileUUID: files[4].UUID, ReservationKey: fmt.Sprintf("file:%d", files[4].ID)}
+	if err := db.Create(&reservation).Error; err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.PreviewStorageMigration(context.Background(), StorageMigrationInput{
+		SourcePoolID: sourcePool.ID, DestinationPoolID: destinationPool.ID, AccountIDs: []uint{users[2].ID},
+	}); !errors.Is(err, ErrStorageMigrationConflict) {
+		t.Fatalf("expected overlapping selected reservation conflict, got %v", err)
+	}
+	if err := db.Unscoped().Delete(&reservation).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	alicePreview, err := service.PreviewStorageMigration(context.Background(), StorageMigrationInput{
+		SourcePoolID: sourcePool.ID, DestinationPoolID: destinationPool.ID, AccountIDs: []uint{users[0].ID},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if alicePreview.PlanFingerprint == preview.PlanFingerprint {
+		t.Fatal("different account scopes produced the same plan fingerprint")
+	}
+	input.PlanFingerprint = preview.PlanFingerprint
+	input.IdempotencyKey = "account-migration-request"
+	if err := db.Model(&users[0]).Update("username", "alice-renamed").Error; err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := service.StartStorageMigration(context.Background(), input, 9, "admin"); !errors.Is(err, ErrStorageMigrationConflict) {
+		t.Fatalf("expected renamed account snapshot to require another review, got %v", err)
+	}
+	if err := db.Model(&users[0]).Update("username", "alice").Error; err != nil {
+		t.Fatal(err)
+	}
+	migration, _, err := service.StartStorageMigration(context.Background(), input, 9, "admin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if migration.Scope != models.StorageMigrationScopeAccounts || migration.AccountCount != 2 || migration.SharedFileCount != 1 {
+		t.Fatalf("migration scope summary was not persisted: %#v", migration)
+	}
+	detail, err := service.GetStorageMigration(context.Background(), migration.UUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(detail.Accounts) != 2 || detail.Accounts[0].Username != "alice" || detail.Accounts[1].Username != "bob" {
+		t.Fatalf("account snapshot was not returned: %#v", detail.Accounts)
+	}
+	if err := db.Model(&users[0]).Update("username", "alice-renamed").Error; err != nil {
+		t.Fatal(err)
+	}
+	detail, err = service.GetStorageMigration(context.Background(), migration.UUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detail.Accounts[0].Username != "alice" {
+		t.Fatalf("migration audit snapshot changed after account rename: %#v", detail.Accounts)
+	}
+	if _, err := service.PreviewStorageMigration(context.Background(), StorageMigrationInput{
+		SourcePoolID: sourcePool.ID, DestinationPoolID: destinationPool.ID, AccountIDs: []uint{users[3].ID},
+	}); !errors.Is(err, ErrStorageMigrationAccounts) {
+		t.Fatalf("expected deleted account selection to fail, got %v", err)
+	}
+	tooMany := make([]uint, maxStorageMigrationAccounts+1)
+	for index := range tooMany {
+		tooMany[index] = uint(index + 1)
+	}
+	if _, err := service.PreviewStorageMigration(context.Background(), StorageMigrationInput{
+		SourcePoolID: sourcePool.ID, DestinationPoolID: destinationPool.ID, AccountIDs: tooMany,
+	}); !errors.Is(err, ErrStorageMigrationAccounts) {
+		t.Fatalf("expected oversized account selection to fail, got %v", err)
+	}
+}
+
 func TestStorageMigrationRejectsOverlappingPools(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
 	if err != nil {
@@ -171,7 +407,7 @@ func TestKeepStorageMigrationOriginalsWaitsForInFlightCleanup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.AutoMigrate(&models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
+	if err := db.AutoMigrate(&models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}); err != nil {
 		t.Fatal(err)
 	}
 	migration := models.StorageMigration{UUID: "keep-originals", Status: models.StorageMigrationCleaningOriginals, FileCount: 3}
@@ -250,7 +486,7 @@ func TestCanceledStorageMigrationProtectsMountsDuringSafetyWindow(t *testing.T) 
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.AutoMigrate(&models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
+	if err := db.AutoMigrate(&models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}); err != nil {
 		t.Fatal(err)
 	}
 	protectUntil := time.Now().UTC().Add(time.Hour)
@@ -283,7 +519,7 @@ func TestFailedStorageMigrationCanBeCanceledForReconciliation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.AutoMigrate(&models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
+	if err := db.AutoMigrate(&models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}); err != nil {
 		t.Fatal(err)
 	}
 	if err := background.Migrate(db); err != nil {

--- a/models/Link.go
+++ b/models/Link.go
@@ -7,9 +7,9 @@ type Link struct {
 	Name           string  `gorm:"size:128;"`
 	Thumbnail      string  `gorm:"size:128;" json:"-"`
 	File           File    `json:"-"`
-	FileID         uint    `json:"-"`
+	FileID         uint    `gorm:"index" json:"-"`
 	User           User    `json:"-"`
-	UserID         uint    `json:"-"`
+	UserID         uint    `gorm:"index" json:"-"`
 	ParentFolder   *Folder `json:"-"`
 	ParentFolderID uint
 	Tags           []*Tag `gorm:"many2many:tag_links;"`

--- a/models/StorageMigration.go
+++ b/models/StorageMigration.go
@@ -101,3 +101,17 @@ type StorageMigrationItem struct {
 	CutoverAt          *time.Time
 	CleanedAt          *time.Time
 }
+
+// StorageMigrationObject is a short-lived durable checkpoint. It allows a
+// retry to trust an object that this migration already uploaded and validated
+// without downloading the destination again. Checkpoints are removed at
+// cutover or when an incomplete destination is discarded.
+type StorageMigrationObject struct {
+	ItemID          uint   `gorm:"primaryKey;autoIncrement:false"`
+	ObjectKey       string `gorm:"primaryKey;size:1024"`
+	SourceRevision  string `gorm:"size:64"`
+	SourceSize      int64
+	DestinationETag string    `gorm:"size:255"`
+	Checksum        string    `gorm:"size:64"`
+	UpdatedAt       time.Time `gorm:"index"`
+}

--- a/models/StorageMigration.go
+++ b/models/StorageMigration.go
@@ -3,6 +3,9 @@ package models
 import "time"
 
 const (
+	StorageMigrationScopeAll      = "all"
+	StorageMigrationScopeAccounts = "accounts"
+
 	StorageMigrationQueued             = "queued"
 	StorageMigrationRunning            = "running"
 	StorageMigrationPaused             = "paused"
@@ -36,6 +39,9 @@ type StorageMigration struct {
 	DestinationPoolID   uint   `gorm:"index"`
 	SourcePoolName      string `gorm:"size:120"`
 	DestinationPoolName string `gorm:"size:120"`
+	Scope               string `gorm:"size:24;index;default:all"`
+	AccountCount        int
+	SharedFileCount     int64
 	BackgroundJobID     string `gorm:"size:36;index"`
 	CleanupJobID        string `gorm:"size:36;index"`
 	Status              string `gorm:"size:32;index"`
@@ -59,7 +65,17 @@ type StorageMigration struct {
 	ErrorCode           string `gorm:"size:80"`
 	ErrorMessage        string `gorm:"size:512"`
 
-	Items []StorageMigrationItem `gorm:"foreignKey:MigrationID" json:"-"`
+	Items    []StorageMigrationItem    `gorm:"foreignKey:MigrationID" json:"-"`
+	Accounts []StorageMigrationAccount `gorm:"foreignKey:MigrationID" json:"Accounts,omitempty"`
+}
+
+// StorageMigrationAccount preserves the selected account identity as it was
+// shown to the administrator. It intentionally does not reference users with a
+// foreign key so migration history survives account deletion.
+type StorageMigrationAccount struct {
+	MigrationID uint   `gorm:"primaryKey" json:"MigrationID"`
+	UserID      uint   `gorm:"primaryKey;index" json:"UserID"`
+	Username    string `gorm:"size:32" json:"Username"`
 }
 
 type StorageMigrationItem struct {

--- a/routes/api.go
+++ b/routes/api.go
@@ -78,6 +78,7 @@ func Api(apiGroup *echo.Group, handlers *controllers.Handlers, middlewareFactory
 	adminV2.POST("/storage/migrations/preview", handlers.PreviewStorageMigration)
 	adminV2.POST("/storage/migrations", handlers.CreateStorageMigration)
 	adminV2.GET("/storage/migrations", handlers.ListStorageMigrations)
+	adminV2.GET("/storage/migrations/accounts", handlers.ListStorageMigrationAccounts)
 	adminV2.GET("/storage/migrations/:id", handlers.GetStorageMigration)
 	adminV2.GET("/storage/migrations/:id/items", handlers.ListStorageMigrationItems)
 	adminV2.POST("/storage/migrations/:id/cancel", handlers.CancelFailedStorageMigration)

--- a/routes/api_test.go
+++ b/routes/api_test.go
@@ -94,6 +94,7 @@ func TestAPIRoutesExposePauseResumeAndStorageMigrationAdminEndpoints(t *testing.
 		http.MethodPost + " /api/v2/admin/storage/migrations/preview",
 		http.MethodPost + " /api/v2/admin/storage/migrations",
 		http.MethodGet + " /api/v2/admin/storage/migrations",
+		http.MethodGet + " /api/v2/admin/storage/migrations/accounts",
 		http.MethodGet + " /api/v2/admin/storage/migrations/:id",
 		http.MethodGet + " /api/v2/admin/storage/migrations/:id/items",
 		http.MethodPost + " /api/v2/admin/storage/migrations/:id/cancel",

--- a/services/Deleter.go
+++ b/services/Deleter.go
@@ -151,6 +151,15 @@ func (w *WorkerGroup) runDeleter() error {
 			}).Error; err != nil {
 				return err
 			}
+			if len(migrationItems) > 0 {
+				itemIDs := make([]uint, 0, len(migrationItems))
+				for _, item := range migrationItems {
+					itemIDs = append(itemIDs, item.ID)
+				}
+				if err := tx.Where("item_id IN ?", itemIDs).Delete(&models.StorageMigrationObject{}).Error; err != nil {
+					return err
+				}
+			}
 			if err := tx.Unscoped().Where("file_id = ?", todo.ID).Delete(&models.Subtitle{}).Error; err != nil {
 				return err
 			}

--- a/services/Deleter_test.go
+++ b/services/Deleter_test.go
@@ -76,7 +76,7 @@ func TestDeleterRemovesAllMigrationCopiesAndReleasesReservations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.AutoMigrate(&models.File{}, &models.Link{}, &models.Quality{}, &models.Audio{}, &models.Subtitle{}, &models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
+	if err := db.AutoMigrate(&models.File{}, &models.Link{}, &models.Quality{}, &models.Audio{}, &models.Subtitle{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}); err != nil {
 		t.Fatal(err)
 	}
 	source, _ := storage.NewLocalStore(t.TempDir())

--- a/services/Deleter_test.go
+++ b/services/Deleter_test.go
@@ -76,7 +76,7 @@ func TestDeleterRemovesAllMigrationCopiesAndReleasesReservations(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.AutoMigrate(&models.File{}, &models.Link{}, &models.Quality{}, &models.Audio{}, &models.Subtitle{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}); err != nil {
+	if err := db.AutoMigrate(&models.File{}, &models.Link{}, &models.Quality{}, &models.Audio{}, &models.Subtitle{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}, &models.StorageMigrationObject{}); err != nil {
 		t.Fatal(err)
 	}
 	source, _ := storage.NewLocalStore(t.TempDir())
@@ -119,6 +119,11 @@ func TestDeleterRemovesAllMigrationCopiesAndReleasesReservations(t *testing.T) {
 	if err := db.Create(&items).Error; err != nil {
 		t.Fatal(err)
 	}
+	for _, item := range items {
+		if err := db.Create(&models.StorageMigrationObject{ItemID: item.ID, ObjectKey: fmt.Sprintf("checkpoint/%d", item.ID), SourceRevision: "delete"}).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
 	worker := NewWorkerGroup(&app.Deps{DB: db, Storage: storageService}, nil)
 	if err := worker.runDeleter(); err != nil {
 		t.Fatal(err)
@@ -150,6 +155,13 @@ func TestDeleterRemovesAllMigrationCopiesAndReleasesReservations(t *testing.T) {
 	}
 	if migration.DeletedCount != 2 || migration.ActualBytes != 0 || migration.CopiedBytes != 0 {
 		t.Fatalf("migration progress was not reconciled: %#v", migration)
+	}
+	var checkpointCount int64
+	if err := db.Model(&models.StorageMigrationObject{}).Count(&checkpointCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if checkpointCount != 0 {
+		t.Fatalf("%d deleted-file checkpoint(s) remained", checkpointCount)
 	}
 }
 

--- a/services/StorageMigration.go
+++ b/services/StorageMigration.go
@@ -2,8 +2,10 @@ package services
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"sync"
 	"time"
@@ -13,15 +15,39 @@ import (
 	"ch/kirari04/videocms/storage"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
-const storageMigrationCleanupGrace = 24 * time.Hour
+const (
+	storageMigrationCleanupGrace        = 24 * time.Hour
+	storageMigrationEncodingRetry       = 5 * time.Minute
+	storageMigrationObjectConcurrency   = 6
+	storageMigrationObjectMaxAttempts   = 5
+	storageMigrationCheckpointBatchSize = 64
+)
 
 var errStorageMigrationStateConflict = errors.New("storage migration state changed")
 var errStorageMigrationItemDeleted = errors.New("storage migration video was deleted")
+var errStorageMigrationEncodingActive = errors.New("video encoding is still active")
 
 type storageMigrationTaskPayload struct {
 	MigrationID uint `json:"migrationId"`
+}
+
+type storageMigrationObjectResult struct {
+	source      storage.ObjectInfo
+	destination storage.ObjectInfo
+	checkpoint  *models.StorageMigrationObject
+	err         error
+}
+
+type storageMigrationCopyProgress struct {
+	totalObjects    int
+	verifiedObjects int
+	verifiedBytes   int64
+	verifiedKeys    map[string]storage.ObjectInfo
+	pending         []models.StorageMigrationObject
+	lastPersistedAt time.Time
 }
 
 func (w *WorkerGroup) storageMigrationHandler(runtime *background.Runtime) background.Handler {
@@ -346,6 +372,9 @@ func (w *WorkerGroup) migrateStorageItem(ctx context.Context, migration models.S
 		if updated.RowsAffected != 1 {
 			return errStorageMigrationItemDeleted
 		}
+		if err := tx.Where("item_id = ?", item.ID).Delete(&models.StorageMigrationObject{}).Error; err != nil {
+			return err
+		}
 		return nil
 	})
 	if errors.Is(err, errStorageMigrationItemDeleted) {
@@ -433,9 +462,12 @@ func (w *WorkerGroup) cleanupDeletedStorageMigrationDestination(ctx context.Cont
 	if err := storage.DeletePrefix(ctx, store, prefix); err != nil {
 		return err
 	}
-	return w.deps.DB.WithContext(ctx).Model(item).
-		Where("status = ?", models.StorageMigrationItemDeleted).
-		Update("destination_owned", false).Error
+	return w.deps.DB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("item_id = ?", item.ID).Delete(&models.StorageMigrationObject{}).Error; err != nil {
+			return err
+		}
+		return tx.Model(item).Where("status = ?", models.StorageMigrationItemDeleted).Update("destination_owned", false).Error
+	})
 }
 
 func (w *WorkerGroup) copyStorageMigrationPrefix(ctx context.Context, item *models.StorageMigrationItem, file models.File, finalSync bool) error {
@@ -451,13 +483,16 @@ func (w *WorkerGroup) copyStorageMigrationPrefix(ctx context.Context, item *mode
 	if err != nil {
 		return err
 	}
+	destinationInventory, err := storage.PrefixInventory(ctx, destination, prefix)
+	if err != nil {
+		return err
+	}
 	if !item.DestinationOwned {
-		existing, err := storage.PrefixInventory(ctx, destination, prefix)
-		if err != nil {
-			return err
-		}
-		if len(existing) > 0 {
+		if len(destinationInventory) > 0 {
 			return fmt.Errorf("%w: destination prefix %s already contains data", errStorageMigrationStateConflict, prefix.String())
+		}
+		if err := w.clearStorageMigrationObjectCheckpoints(ctx, item.ID); err != nil {
+			return err
 		}
 		if err := updateActiveStorageMigrationItem(w.deps.DB.WithContext(ctx), item, map[string]any{"destination_owned": true}); err != nil {
 			return err
@@ -484,27 +519,30 @@ func (w *WorkerGroup) copyStorageMigrationPrefix(ctx context.Context, item *mode
 	}); err != nil {
 		return err
 	}
-	verifiedKeys := make(map[string]bool, len(objects))
-	var verifiedBytes int64
-	lastProgressUpdate := time.Time{}
-	for index, object := range objects {
-		if _, err := storage.CopyObjectVerified(ctx, source, destination, object); err != nil {
-			return fmt.Errorf("copy %s: %w", object.Key.String(), err)
+	checkpoints, err := w.loadStorageMigrationObjectCheckpoints(ctx, item.ID)
+	if err != nil {
+		return err
+	}
+	destinationByKey := make(map[string]storage.ObjectInfo, len(destinationInventory))
+	for _, object := range destinationInventory {
+		destinationByKey[object.Key.String()] = object
+	}
+	regular := make([]storage.ObjectInfo, 0, len(objects))
+	manifests := make([]storage.ObjectInfo, 0)
+	for _, object := range objects {
+		if strings.HasSuffix(strings.ToLower(object.Key.String()), ".m3u8") {
+			manifests = append(manifests, object)
+		} else {
+			regular = append(regular, object)
 		}
-		verifiedKeys[object.Key.String()] = true
-		verifiedBytes += object.Size
-		now := time.Now()
-		if index+1 == len(objects) || lastProgressUpdate.IsZero() || now.Sub(lastProgressUpdate) >= 500*time.Millisecond {
-			if err := updateActiveStorageMigrationItem(w.deps.DB.WithContext(ctx), item, map[string]any{
-				"bytes_copied": verifiedBytes, "objects_verified": index + 1,
-				"progress_message": fmt.Sprintf("Verified %d of %d objects", index+1, len(objects)),
-			}); err != nil {
-				return err
-			}
-			if err := w.refreshStorageMigrationProgress(ctx, item.MigrationID); err != nil {
-				return err
-			}
-			lastProgressUpdate = now
+	}
+	progress := &storageMigrationCopyProgress{
+		totalObjects: len(objects), verifiedKeys: make(map[string]storage.ObjectInfo, len(objects)),
+		pending: make([]models.StorageMigrationObject, 0, storageMigrationCheckpointBatchSize),
+	}
+	for _, batch := range [][]storage.ObjectInfo{regular, manifests} {
+		if err := w.copyStorageMigrationObjectBatch(ctx, item, source, destination, batch, destinationByKey, checkpoints, progress); err != nil {
+			return err
 		}
 	}
 	if finalSync {
@@ -512,15 +550,242 @@ func (w *WorkerGroup) copyStorageMigrationPrefix(ctx context.Context, item *mode
 		if err != nil {
 			return err
 		}
+		finalDestination := make(map[string]storage.ObjectInfo, len(destinationObjects))
 		for _, object := range destinationObjects {
-			if !verifiedKeys[object.Key.String()] {
+			if _, verified := progress.verifiedKeys[object.Key.String()]; !verified {
 				if err := destination.Delete(ctx, object.Key); err != nil {
 					return fmt.Errorf("remove stale destination object %s: %w", object.Key.String(), err)
 				}
+				continue
+			}
+			finalDestination[object.Key.String()] = object
+		}
+		for key, expected := range progress.verifiedKeys {
+			object, exists := finalDestination[key]
+			if !exists || object.Size != expected.Size || (expected.ETag != "" && object.ETag != "" && expected.ETag != object.ETag) {
+				return fmt.Errorf("final destination inventory mismatch for %s: stored size/etag %d/%q, expected %d/%q", key, object.Size, object.ETag, expected.Size, expected.ETag)
 			}
 		}
 	}
 	return nil
+}
+
+func (w *WorkerGroup) copyStorageMigrationObjectBatch(
+	ctx context.Context,
+	item *models.StorageMigrationItem,
+	source storage.Store,
+	destination storage.Store,
+	objects []storage.ObjectInfo,
+	destinationInventory map[string]storage.ObjectInfo,
+	checkpoints map[string]models.StorageMigrationObject,
+	progress *storageMigrationCopyProgress,
+) error {
+	if len(objects) == 0 {
+		return nil
+	}
+	workCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	jobs := make(chan storage.ObjectInfo, len(objects))
+	results := make(chan storageMigrationObjectResult, len(objects))
+	for _, object := range objects {
+		jobs <- object
+	}
+	close(jobs)
+	workerCount := min(storageMigrationObjectConcurrency, len(objects))
+	var workers sync.WaitGroup
+	for index := 0; index < workerCount; index++ {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			for object := range jobs {
+				if workCtx.Err() != nil {
+					return
+				}
+				checkpoint := checkpoints[object.Key.String()]
+				destinationInfo, destinationExists := destinationInventory[object.Key.String()]
+				result := copyStorageMigrationObject(workCtx, source, destination, object, destinationInfo, destinationExists, checkpoint)
+				results <- result
+				if result.err != nil {
+					return
+				}
+			}
+		}()
+	}
+	go func() {
+		workers.Wait()
+		close(results)
+	}()
+
+	var firstErr error
+	for result := range results {
+		if result.err != nil {
+			if firstErr == nil && !errors.Is(result.err, context.Canceled) {
+				firstErr = result.err
+			}
+			cancel()
+			continue
+		}
+		progress.verifiedObjects++
+		progress.verifiedBytes += result.source.Size
+		verifiedDestination := result.destination
+		verifiedDestination.Size = result.source.Size
+		progress.verifiedKeys[result.source.Key.String()] = verifiedDestination
+		if result.checkpoint != nil {
+			progress.pending = append(progress.pending, *result.checkpoint)
+		}
+		now := time.Now()
+		if len(progress.pending) >= storageMigrationCheckpointBatchSize || progress.lastPersistedAt.IsZero() || now.Sub(progress.lastPersistedAt) >= 500*time.Millisecond || progress.verifiedObjects == progress.totalObjects {
+			if err := w.persistStorageMigrationCopyProgress(ctx, item, progress); err != nil {
+				if firstErr == nil {
+					firstErr = err
+				}
+				cancel()
+			}
+		}
+	}
+	if len(progress.pending) > 0 {
+		if err := w.persistStorageMigrationCopyProgress(context.WithoutCancel(ctx), item, progress); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	if firstErr == nil && ctx.Err() != nil {
+		firstErr = ctx.Err()
+	}
+	return firstErr
+}
+
+func copyStorageMigrationObject(
+	ctx context.Context,
+	source storage.Store,
+	destination storage.Store,
+	object storage.ObjectInfo,
+	destinationInfo storage.ObjectInfo,
+	destinationExists bool,
+	checkpoint models.StorageMigrationObject,
+) storageMigrationObjectResult {
+	revision := storageMigrationObjectRevision(object)
+	if storageMigrationCheckpointMatches(ctx, destination, object, destinationInfo, destinationExists, checkpoint, revision) {
+		return storageMigrationObjectResult{source: object, destination: destinationInfo}
+	}
+	var lastErr error
+	for attempt := 1; attempt <= storageMigrationObjectMaxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return storageMigrationObjectResult{err: err}
+		}
+		current, err := source.Stat(ctx, object.Key)
+		if err == nil {
+			copied, copyErr := storage.CopyObjectValidated(ctx, source, destination, current)
+			if copyErr == nil {
+				after, statErr := source.Stat(ctx, object.Key)
+				if statErr == nil && storageMigrationObjectRevision(after) == storageMigrationObjectRevision(copied.SourceInfo) {
+					checkpoint := &models.StorageMigrationObject{
+						ObjectKey: object.Key.String(), SourceRevision: storageMigrationObjectRevision(after),
+						SourceSize: after.Size, DestinationETag: copied.Info.ETag,
+						Checksum: copied.Checksum, UpdatedAt: time.Now().UTC(),
+					}
+					return storageMigrationObjectResult{source: after, destination: copied.Info, checkpoint: checkpoint}
+				}
+				if statErr != nil {
+					copyErr = statErr
+				} else {
+					copyErr = errors.New("source object changed while it was being copied")
+				}
+			}
+			err = copyErr
+		}
+		lastErr = err
+		if attempt < storageMigrationObjectMaxAttempts {
+			delay := time.Duration(1<<(attempt-1)) * 200 * time.Millisecond
+			timer := time.NewTimer(delay)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return storageMigrationObjectResult{err: ctx.Err()}
+			case <-timer.C:
+			}
+		}
+	}
+	return storageMigrationObjectResult{err: fmt.Errorf("copy %s failed after %d attempts: %w", object.Key.String(), storageMigrationObjectMaxAttempts, lastErr)}
+}
+
+func storageMigrationCheckpointMatches(
+	ctx context.Context,
+	destination storage.Store,
+	object storage.ObjectInfo,
+	destinationInfo storage.ObjectInfo,
+	destinationExists bool,
+	checkpoint models.StorageMigrationObject,
+	revision string,
+) bool {
+	if !destinationExists || destinationInfo.Size != object.Size || checkpoint.ObjectKey != object.Key.String() || checkpoint.SourceSize != object.Size || checkpoint.SourceRevision != revision {
+		return false
+	}
+	if checkpoint.DestinationETag != "" && destinationInfo.ETag != "" {
+		return checkpoint.DestinationETag == destinationInfo.ETag
+	}
+	if checkpoint.Checksum == "" {
+		return false
+	}
+
+	// Local and SFTP stores have no stable ETag. On a resumed migration, hash
+	// their existing destination once before trusting the durable checkpoint.
+	// S3 stays on the cheap ETag path and does not download the object again.
+	stored, err := destination.Open(ctx, object.Key)
+	if err != nil {
+		return false
+	}
+	digest := sha256.New()
+	written, readErr := io.Copy(digest, stored.Body)
+	closeErr := stored.Body.Close()
+	return readErr == nil && closeErr == nil && written == object.Size && fmt.Sprintf("%x", digest.Sum(nil)) == checkpoint.Checksum
+}
+
+func storageMigrationObjectRevision(object storage.ObjectInfo) string {
+	value := fmt.Sprintf("%s\x00%d\x00%d\x00%s", object.Key.String(), object.Size, object.ModTime.UTC().UnixNano(), object.ETag)
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(value)))
+}
+
+func (w *WorkerGroup) loadStorageMigrationObjectCheckpoints(ctx context.Context, itemID uint) (map[string]models.StorageMigrationObject, error) {
+	var rows []models.StorageMigrationObject
+	if err := w.deps.DB.WithContext(ctx).Where("item_id = ?", itemID).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	result := make(map[string]models.StorageMigrationObject, len(rows))
+	for _, row := range rows {
+		result[row.ObjectKey] = row
+	}
+	return result, nil
+}
+
+func (w *WorkerGroup) persistStorageMigrationCopyProgress(ctx context.Context, item *models.StorageMigrationItem, progress *storageMigrationCopyProgress) error {
+	pending := append([]models.StorageMigrationObject(nil), progress.pending...)
+	for index := range pending {
+		pending[index].ItemID = item.ID
+	}
+	err := w.deps.DB.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if len(pending) > 0 {
+			if err := tx.Clauses(clause.OnConflict{
+				Columns:   []clause.Column{{Name: "item_id"}, {Name: "object_key"}},
+				DoUpdates: clause.AssignmentColumns([]string{"source_revision", "source_size", "destination_e_tag", "checksum", "updated_at"}),
+			}).Create(&pending).Error; err != nil {
+				return err
+			}
+		}
+		return updateActiveStorageMigrationItem(tx, item, map[string]any{
+			"bytes_copied": progress.verifiedBytes, "objects_verified": progress.verifiedObjects,
+			"progress_message": fmt.Sprintf("Verified %d of %d objects", progress.verifiedObjects, progress.totalObjects),
+		})
+	})
+	if err != nil {
+		return err
+	}
+	progress.pending = progress.pending[:0]
+	progress.lastPersistedAt = time.Now()
+	return w.refreshStorageMigrationProgress(ctx, item.MigrationID)
+}
+
+func (w *WorkerGroup) clearStorageMigrationObjectCheckpoints(ctx context.Context, itemID uint) error {
+	return w.deps.DB.WithContext(ctx).Where("item_id = ?", itemID).Delete(&models.StorageMigrationObject{}).Error
 }
 
 func (w *WorkerGroup) refreshStorageMigrationProgress(ctx context.Context, migrationID uint) error {
@@ -634,6 +899,18 @@ func (w *WorkerGroup) storageMigrationCleanupHandler(ctx context.Context, task b
 	}
 	for index := range items {
 		if err := w.cleanupStorageMigrationItem(ctx, &items[index]); err != nil {
+			if errors.Is(err, errStorageMigrationEncodingActive) {
+				_ = w.deps.DB.WithContext(context.WithoutCancel(ctx)).Model(&migration).Updates(map[string]any{
+					"status": models.StorageMigrationCleaningOriginals,
+					"phase":  "Waiting for video encoding to finish",
+				}).Error
+				background.ReportProgress(ctx, float64(index)/float64(len(items)), "Waiting for video encoding to finish")
+				return background.Result{}, background.Deferred(
+					"encoding_active",
+					"Original cleanup is waiting for video encoding to finish",
+					storageMigrationEncodingRetry,
+				)
+			}
 			if ctx.Err() != nil {
 				if reloadErr := w.deps.DB.WithContext(context.WithoutCancel(ctx)).First(&migration, migration.ID).Error; reloadErr == nil && migration.KeepOriginals {
 					return background.Result{}, ctx.Err()
@@ -704,6 +981,21 @@ func (w *WorkerGroup) cleanupStorageMigrationItem(ctx context.Context, item *mod
 	if err == nil && file.StorageID != item.DestinationMountID {
 		return fmt.Errorf("%w: file %d is no longer on expected destination", errStorageMigrationStateConflict, item.FileID)
 	}
+	if err == nil {
+		encoding, encodingErr := storageMigrationFileEncodingActive(w.deps.DB.WithContext(ctx), item.FileID)
+		if encodingErr != nil {
+			return encodingErr
+		}
+		if encoding {
+			if updateErr := updateActiveStorageMigrationItem(w.deps.DB.WithContext(ctx), item, map[string]any{
+				"status":           models.StorageMigrationItemCleanupPending,
+				"progress_message": "Waiting for video encoding to finish",
+			}); updateErr != nil && !errors.Is(updateErr, errStorageMigrationItemDeleted) {
+				return updateErr
+			}
+			return errStorageMigrationEncodingActive
+		}
+	}
 	store, err := w.deps.Storage.Store(item.SourceMountID)
 	if err != nil {
 		return err
@@ -736,6 +1028,19 @@ func (w *WorkerGroup) cleanupStorageMigrationItem(ctx context.Context, item *mod
 		return nil
 	}
 	return err
+}
+
+func storageMigrationFileEncodingActive(db *gorm.DB, fileID uint) (bool, error) {
+	for _, model := range []any{&models.Quality{}, &models.Audio{}, &models.Subtitle{}} {
+		var count int64
+		if err := db.Model(model).Where("file_id = ? AND encoding = ?", fileID, true).Count(&count).Error; err != nil {
+			return false, err
+		}
+		if count > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (w *WorkerGroup) storageMigrationAbortHandler(runtime *background.Runtime) background.Handler {
@@ -802,7 +1107,7 @@ func (w *WorkerGroup) cleanupCanceledStorageMigrationItem(ctx context.Context, i
 		return err
 	}
 	if item.Status == models.StorageMigrationItemDeleted {
-		return nil
+		return w.clearStorageMigrationObjectCheckpoints(context.WithoutCancel(ctx), item.ID)
 	}
 	var file models.File
 	err := w.deps.DB.WithContext(ctx).First(&file, item.FileID).Error
@@ -835,9 +1140,14 @@ func (w *WorkerGroup) cleanupCanceledStorageMigrationItem(ctx context.Context, i
 			return err
 		}
 	}
-	err = updateActiveStorageMigrationItem(w.deps.DB.WithContext(context.WithoutCancel(ctx)), item, map[string]any{
-		"status": models.StorageMigrationItemCanceled, "reservation_key": "", "destination_owned": false,
-		"bytes_copied": 0, "objects_verified": 0, "progress_message": "Canceled before cutover",
+	err = w.deps.DB.WithContext(context.WithoutCancel(ctx)).Transaction(func(tx *gorm.DB) error {
+		if err := updateActiveStorageMigrationItem(tx, item, map[string]any{
+			"status": models.StorageMigrationItemCanceled, "reservation_key": "", "destination_owned": false,
+			"bytes_copied": 0, "objects_verified": 0, "progress_message": "Canceled before cutover",
+		}); err != nil {
+			return err
+		}
+		return tx.Where("item_id = ?", item.ID).Delete(&models.StorageMigrationObject{}).Error
 	})
 	if errors.Is(err, errStorageMigrationItemDeleted) {
 		return nil

--- a/services/StorageMigration_integration_test.go
+++ b/services/StorageMigration_integration_test.go
@@ -85,7 +85,7 @@ func TestStorageMigrationS3ToSFTPIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}); err != nil {
+	if err := db.AutoMigrate(&models.File{}, &models.Quality{}, &models.Audio{}, &models.Subtitle{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}, &models.StorageMigrationObject{}); err != nil {
 		t.Fatal(err)
 	}
 	file := models.File{UUID: fileUUID, StorageID: "s3", StorageState: models.FileStorageAvailable, Size: int64(len("garage-to-sftp-media"))}

--- a/services/StorageMigration_integration_test.go
+++ b/services/StorageMigration_integration_test.go
@@ -85,7 +85,7 @@ func TestStorageMigrationS3ToSFTPIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
+	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}); err != nil {
 		t.Fatal(err)
 	}
 	file := models.File{UUID: fileUUID, StorageID: "s3", StorageState: models.FileStorageAvailable, Size: int64(len("garage-to-sftp-media"))}

--- a/services/StorageMigration_test.go
+++ b/services/StorageMigration_test.go
@@ -25,7 +25,7 @@ func TestStorageMigrationBackgroundJobCutsOverAndSchedulesDeferredCleanup(t *tes
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
+	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}); err != nil {
 		t.Fatal(err)
 	}
 	if err := background.Migrate(db); err != nil {
@@ -100,7 +100,7 @@ func TestStorageMigrationCopiesFinalChangesBeforeAtomicCutover(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
+	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}); err != nil {
 		t.Fatal(err)
 	}
 	source, err := storage.NewLocalStore(t.TempDir())
@@ -181,7 +181,7 @@ func TestStorageMigrationDeletionBetweenCopyAndCutoverIsTerminal(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
+	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}); err != nil {
 		t.Fatal(err)
 	}
 	source, err := storage.NewLocalStore(t.TempDir())
@@ -304,7 +304,7 @@ func TestStorageMigrationCleanupStopsOnlyBetweenVideos(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
+	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}); err != nil {
 		t.Fatal(err)
 	}
 	sourceLocal, err := storage.NewLocalStore(t.TempDir())
@@ -382,7 +382,7 @@ func TestStorageMigrationRefusesUnownedDestinationPrefix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
+	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}); err != nil {
 		t.Fatal(err)
 	}
 	source, _ := storage.NewLocalStore(t.TempDir())
@@ -420,7 +420,7 @@ func TestCanceledStorageMigrationRemovesOnlyUnreferencedDestinationData(t *testi
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
+	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}); err != nil {
 		t.Fatal(err)
 	}
 	source, _ := storage.NewLocalStore(t.TempDir())
@@ -472,7 +472,7 @@ func TestStorageMigrationReconciliationRepairsCanceledJobCrashWindow(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.AutoMigrate(&models.StorageMigration{}, &models.StorageMigrationItem{}); err != nil {
+	if err := db.AutoMigrate(&models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}); err != nil {
 		t.Fatal(err)
 	}
 	if err := background.Migrate(db); err != nil {

--- a/services/StorageMigration_test.go
+++ b/services/StorageMigration_test.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -25,7 +26,7 @@ func TestStorageMigrationBackgroundJobCutsOverAndSchedulesDeferredCleanup(t *tes
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}); err != nil {
+	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}, &models.StorageMigrationObject{}); err != nil {
 		t.Fatal(err)
 	}
 	if err := background.Migrate(db); err != nil {
@@ -100,7 +101,7 @@ func TestStorageMigrationCopiesFinalChangesBeforeAtomicCutover(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}); err != nil {
+	if err := db.AutoMigrate(&models.File{}, &models.Quality{}, &models.Audio{}, &models.Subtitle{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}, &models.StorageMigrationObject{}); err != nil {
 		t.Fatal(err)
 	}
 	source, err := storage.NewLocalStore(t.TempDir())
@@ -176,12 +177,270 @@ func TestStorageMigrationCopiesFinalChangesBeforeAtomicCutover(t *testing.T) {
 	}
 }
 
+func TestStorageMigrationRetriesObjectsInPlaceAndCopiesSegmentsConcurrently(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}, &models.StorageMigrationObject{}); err != nil {
+		t.Fatal(err)
+	}
+	source, _ := storage.NewLocalStore(t.TempDir())
+	destinationLocal, _ := storage.NewLocalStore(t.TempDir())
+	file := models.File{UUID: "550e8400-e29b-41d4-a716-446655440207", StorageID: "source", StorageState: models.FileStorageAvailable}
+	if err := db.Create(&file).Error; err != nil {
+		t.Fatal(err)
+	}
+	prefix, err := storage.LegacyMediaLayout{}.FilePrefix(file.UUID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	keys := make([]storage.Key, 0, 13)
+	for index := 0; index < 12; index++ {
+		key := migrationTestKey(t, fmt.Sprintf("%s/1080p/out%03d.ts", prefix.String(), index))
+		putMigrationTestObject(t, source, key, fmt.Sprintf("segment-%03d", index))
+		keys = append(keys, key)
+	}
+	manifest := migrationTestKey(t, prefix.String()+"/1080p/index.m3u8")
+	putMigrationTestObject(t, source, manifest, "manifest")
+	keys = append(keys, manifest)
+	flakyKey := keys[5].String()
+	destination := &migrationObservedPutStore{
+		Store: destinationLocal, delay: 20 * time.Millisecond,
+		failures: map[string]int{flakyKey: 2}, attempts: make(map[string]int),
+	}
+	service, err := storage.NewService("source", storage.LegacyMediaLayout{}, map[string]storage.Store{"source": source, "destination": destination})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = service.Close() })
+	migration := models.StorageMigration{UUID: "parallel-object-copy", Status: models.StorageMigrationRunning, FileCount: 1}
+	if err := db.Create(&migration).Error; err != nil {
+		t.Fatal(err)
+	}
+	item := models.StorageMigrationItem{
+		MigrationID: migration.ID, FileID: file.ID, FileUUID: file.UUID,
+		SourceMountID: "source", DestinationMountID: "destination",
+		Status: models.StorageMigrationItemPending, ReservationKey: fmt.Sprintf("file:%d", file.ID),
+	}
+	if err := db.Create(&item).Error; err != nil {
+		t.Fatal(err)
+	}
+	worker := NewWorkerGroup(&app.Deps{DB: db, Storage: service}, nil)
+	if err := worker.migrateStorageItem(context.Background(), migration, &item); err != nil {
+		t.Fatal(err)
+	}
+	if attempts := destination.attemptCount(flakyKey); attempts != 3 {
+		t.Fatalf("flaky object attempts = %d, want 3", attempts)
+	}
+	if maximum := destination.maximumConcurrency(); maximum < 2 || maximum > storageMigrationObjectConcurrency {
+		t.Fatalf("object copy concurrency = %d, want 2..%d", maximum, storageMigrationObjectConcurrency)
+	}
+	if destination.manifestOverlappedSegments() {
+		t.Fatal("manifest upload started before all segment uploads completed")
+	}
+	if err := db.First(&file, file.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if file.StorageID != "destination" {
+		t.Fatalf("file remained on %q", file.StorageID)
+	}
+	var checkpointCount int64
+	if err := db.Model(&models.StorageMigrationObject{}).Where("item_id = ?", item.ID).Count(&checkpointCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if checkpointCount != 0 {
+		t.Fatalf("%d checkpoint(s) remained after cutover", checkpointCount)
+	}
+}
+
+func TestStorageMigrationReusesDurableObjectCheckpoints(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}, &models.StorageMigrationObject{}); err != nil {
+		t.Fatal(err)
+	}
+	source, _ := storage.NewLocalStore(t.TempDir())
+	destinationLocal, _ := storage.NewLocalStore(t.TempDir())
+	file := models.File{UUID: "550e8400-e29b-41d4-a716-446655440208", StorageID: "source", StorageState: models.FileStorageAvailable}
+	if err := db.Create(&file).Error; err != nil {
+		t.Fatal(err)
+	}
+	first := migrationTestKey(t, file.UUID+"/720p/out000.ts")
+	second := migrationTestKey(t, file.UUID+"/720p/out001.ts")
+	putMigrationTestObject(t, source, first, "first")
+	putMigrationTestObject(t, source, second, "second")
+	putMigrationTestObject(t, destinationLocal, first, "first")
+	firstInfo, err := source.Stat(context.Background(), first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	destination := &migrationObservedPutStore{Store: destinationLocal, attempts: make(map[string]int), failures: make(map[string]int)}
+	service, err := storage.NewService("source", storage.LegacyMediaLayout{}, map[string]storage.Store{"source": source, "destination": destination})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = service.Close() })
+	migration := models.StorageMigration{UUID: "checkpoint-resume", Status: models.StorageMigrationRunning, FileCount: 1}
+	if err := db.Create(&migration).Error; err != nil {
+		t.Fatal(err)
+	}
+	item := models.StorageMigrationItem{
+		MigrationID: migration.ID, FileID: file.ID, FileUUID: file.UUID,
+		SourceMountID: "source", DestinationMountID: "destination", DestinationOwned: true,
+		Status: models.StorageMigrationItemCopying, ReservationKey: fmt.Sprintf("file:%d", file.ID),
+	}
+	if err := db.Create(&item).Error; err != nil {
+		t.Fatal(err)
+	}
+	checkpoint := models.StorageMigrationObject{
+		ItemID: item.ID, ObjectKey: first.String(), SourceRevision: storageMigrationObjectRevision(firstInfo),
+		SourceSize: firstInfo.Size, Checksum: fmt.Sprintf("%x", sha256.Sum256([]byte("first"))), UpdatedAt: time.Now().UTC(),
+	}
+	if err := db.Create(&checkpoint).Error; err != nil {
+		t.Fatal(err)
+	}
+	worker := NewWorkerGroup(&app.Deps{DB: db, Storage: service}, nil)
+	if err := worker.copyStorageMigrationPrefix(context.Background(), &item, file, false); err != nil {
+		t.Fatal(err)
+	}
+	if attempts := destination.attemptCount(first.String()); attempts != 0 {
+		t.Fatalf("checkpointed object was uploaded %d time(s)", attempts)
+	}
+	if attempts := destination.attemptCount(second.String()); attempts != 1 {
+		t.Fatalf("new object uploads = %d, want 1", attempts)
+	}
+	if err := db.First(&item, item.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if item.ObjectsVerified != 2 || item.BytesCopied != int64(len("first")+len("second")) {
+		t.Fatalf("unexpected resumed progress: %#v", item)
+	}
+	var checkpointCount int64
+	if err := db.Model(&models.StorageMigrationObject{}).Where("item_id = ?", item.ID).Count(&checkpointCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if checkpointCount != 2 {
+		t.Fatalf("checkpoint count = %d, want 2", checkpointCount)
+	}
+
+	// A same-size destination corruption must not be trusted when the store has
+	// no ETag. The saved checksum makes the final pass repair it.
+	putMigrationTestObject(t, destinationLocal, first, "wrong")
+	if err := worker.copyStorageMigrationPrefix(context.Background(), &item, file, true); err != nil {
+		t.Fatal(err)
+	}
+	if attempts := destination.attemptCount(first.String()); attempts != 1 {
+		t.Fatalf("corrupted checkpointed object uploads = %d, want 1", attempts)
+	}
+	assertMigrationTestObject(t, destination, first, "first")
+
+	// A same-size source replacement must not be mistaken for the already
+	// copied object either. The final pass compares its source revision.
+	time.Sleep(time.Millisecond)
+	putMigrationTestObject(t, source, first, "fresh")
+	if err := worker.copyStorageMigrationPrefix(context.Background(), &item, file, true); err != nil {
+		t.Fatal(err)
+	}
+	if attempts := destination.attemptCount(first.String()); attempts != 2 {
+		t.Fatalf("changed checkpointed object uploads = %d, want 2 total", attempts)
+	}
+	if attempts := destination.attemptCount(second.String()); attempts != 1 {
+		t.Fatalf("unchanged checkpointed object uploads = %d, want 1 total", attempts)
+	}
+	assertMigrationTestObject(t, destination, first, "fresh")
+}
+
+func TestStorageMigrationCleanupWaitsForActiveEncoding(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(
+		&models.File{}, &models.Quality{}, &models.Audio{}, &models.Subtitle{},
+		&models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	source, _ := storage.NewLocalStore(t.TempDir())
+	destination, _ := storage.NewLocalStore(t.TempDir())
+	service, err := storage.NewService("source", storage.LegacyMediaLayout{}, map[string]storage.Store{"source": source, "destination": destination})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = service.Close() })
+	file := models.File{UUID: "550e8400-e29b-41d4-a716-446655440206", StorageID: "destination", StorageState: models.FileStorageAvailable}
+	if err := db.Create(&file).Error; err != nil {
+		t.Fatal(err)
+	}
+	quality := models.Quality{FileID: file.ID, Name: "720p", Encoding: true}
+	if err := db.Create(&quality).Error; err != nil {
+		t.Fatal(err)
+	}
+	key := migrationTestKey(t, file.UUID+"/source/original.mp4")
+	putMigrationTestObject(t, source, key, "media")
+	migration := models.StorageMigration{UUID: "encoding-cleanup-wait", Status: models.StorageMigrationRetainingOriginals, FileCount: 1}
+	if err := db.Create(&migration).Error; err != nil {
+		t.Fatal(err)
+	}
+	item := models.StorageMigrationItem{
+		MigrationID: migration.ID, FileID: file.ID, FileUUID: file.UUID,
+		SourceMountID: "source", DestinationMountID: "destination",
+		Status: models.StorageMigrationItemCleanupPending, ReservationKey: fmt.Sprintf("file:%d", file.ID),
+	}
+	if err := db.Create(&item).Error; err != nil {
+		t.Fatal(err)
+	}
+	worker := NewWorkerGroup(&app.Deps{DB: db, Storage: service}, nil)
+	handler := worker.storageMigrationCleanupHandler
+	task := background.Task{PayloadVersion: 1, Payload: fmt.Sprintf(`{"migrationId":%d}`, migration.ID)}
+	if _, err := handler(context.Background(), task); err == nil {
+		t.Fatal("cleanup proceeded while encoding was active")
+	} else {
+		var taskErr *background.TaskError
+		if !errors.As(err, &taskErr) || taskErr.Class != background.ErrorDeferred || taskErr.Code != "encoding_active" {
+			t.Fatalf("cleanup returned %T %v, want an encoding deferral", err, err)
+		}
+	}
+	assertMigrationTestObject(t, source, key, "media")
+	if err := db.First(&item, item.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if item.Status != models.StorageMigrationItemCleanupPending || item.ProgressMessage != "Waiting for video encoding to finish" {
+		t.Fatalf("unexpected waiting item state: %#v", item)
+	}
+	if err := db.First(&migration, migration.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if migration.Status != models.StorageMigrationCleaningOriginals || migration.Phase != "Waiting for video encoding to finish" {
+		t.Fatalf("unexpected waiting migration state: %#v", migration)
+	}
+
+	if err := db.Model(&quality).Update("encoding", false).Error; err != nil {
+		t.Fatal(err)
+	}
+	if _, err := handler(context.Background(), task); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := source.Stat(context.Background(), key); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("source remained after encoding completed: %v", err)
+	}
+	if err := db.First(&item, item.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if item.Status != models.StorageMigrationItemCleaned || item.ReservationKey != "" {
+		t.Fatalf("unexpected cleaned item: %#v", item)
+	}
+}
+
 func TestStorageMigrationDeletionBetweenCopyAndCutoverIsTerminal(t *testing.T) {
 	db, err := gorm.Open(sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}); err != nil {
+	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}, &models.StorageMigrationObject{}); err != nil {
 		t.Fatal(err)
 	}
 	source, err := storage.NewLocalStore(t.TempDir())
@@ -260,7 +519,7 @@ func TestStorageMigrationCleanupSkipsDeletedVideo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.AutoMigrate(&models.StorageMigrationItem{}); err != nil {
+	if err := db.AutoMigrate(&models.StorageMigrationItem{}, &models.StorageMigrationObject{}); err != nil {
 		t.Fatal(err)
 	}
 	source, _ := storage.NewLocalStore(t.TempDir())
@@ -304,7 +563,7 @@ func TestStorageMigrationCleanupStopsOnlyBetweenVideos(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}); err != nil {
+	if err := db.AutoMigrate(&models.File{}, &models.Quality{}, &models.Audio{}, &models.Subtitle{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}, &models.StorageMigrationObject{}); err != nil {
 		t.Fatal(err)
 	}
 	sourceLocal, err := storage.NewLocalStore(t.TempDir())
@@ -382,7 +641,7 @@ func TestStorageMigrationRefusesUnownedDestinationPrefix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}); err != nil {
+	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}, &models.StorageMigrationObject{}); err != nil {
 		t.Fatal(err)
 	}
 	source, _ := storage.NewLocalStore(t.TempDir())
@@ -420,7 +679,7 @@ func TestCanceledStorageMigrationRemovesOnlyUnreferencedDestinationData(t *testi
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}); err != nil {
+	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}, &models.StorageMigrationObject{}); err != nil {
 		t.Fatal(err)
 	}
 	source, _ := storage.NewLocalStore(t.TempDir())
@@ -438,6 +697,9 @@ func TestCanceledStorageMigrationRemovesOnlyUnreferencedDestinationData(t *testi
 	putMigrationTestObject(t, destination, pendingKey, "partial")
 	pending := models.StorageMigrationItem{MigrationID: migration.ID, FileID: pendingFile.ID, FileUUID: pendingFile.UUID, SourceMountID: "source", DestinationMountID: "destination", Status: models.StorageMigrationItemCopying, ReservationKey: fmt.Sprintf("file:%d", pendingFile.ID), DestinationOwned: true}
 	db.Create(&pending)
+	if err := db.Create(&models.StorageMigrationObject{ItemID: pending.ID, ObjectKey: pendingKey.String(), SourceRevision: "pending"}).Error; err != nil {
+		t.Fatal(err)
+	}
 	if err := worker.cleanupCanceledStorageMigrationItem(context.Background(), &pending); err != nil {
 		t.Fatal(err)
 	}
@@ -445,6 +707,13 @@ func TestCanceledStorageMigrationRemovesOnlyUnreferencedDestinationData(t *testi
 		t.Fatalf("partial destination remained: %v", err)
 	}
 	assertMigrationTestObject(t, source, pendingKey, "source")
+	var pendingCheckpointCount int64
+	if err := db.Model(&models.StorageMigrationObject{}).Where("item_id = ?", pending.ID).Count(&pendingCheckpointCount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if pendingCheckpointCount != 0 {
+		t.Fatalf("%d canceled-item checkpoint(s) remained", pendingCheckpointCount)
+	}
 
 	cutoverFile := models.File{UUID: "550e8400-e29b-41d4-a716-446655440402", StorageID: "destination", StorageState: models.FileStorageAvailable}
 	db.Create(&cutoverFile)
@@ -472,7 +741,7 @@ func TestStorageMigrationReconciliationRepairsCanceledJobCrashWindow(t *testing.
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.AutoMigrate(&models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}); err != nil {
+	if err := db.AutoMigrate(&models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}, &models.StorageMigrationObject{}); err != nil {
 		t.Fatal(err)
 	}
 	if err := background.Migrate(db); err != nil {
@@ -609,6 +878,80 @@ type migrationHookStore struct {
 	storage.Store
 	once sync.Once
 	hook func()
+}
+
+type migrationObservedPutStore struct {
+	storage.Store
+	delay time.Duration
+
+	mu                     sync.Mutex
+	attempts               map[string]int
+	failures               map[string]int
+	active                 int
+	maxActive              int
+	activeSegments         int
+	manifestSegmentOverlap bool
+}
+
+func (s *migrationObservedPutStore) Put(ctx context.Context, key storage.Key, source io.Reader, options storage.PutOptions) (storage.ObjectInfo, error) {
+	isManifest := strings.HasSuffix(strings.ToLower(key.String()), ".m3u8")
+	s.mu.Lock()
+	s.attempts[key.String()]++
+	s.active++
+	if s.active > s.maxActive {
+		s.maxActive = s.active
+	}
+	if isManifest {
+		if s.activeSegments > 0 {
+			s.manifestSegmentOverlap = true
+		}
+	} else {
+		s.activeSegments++
+	}
+	shouldFail := s.failures[key.String()] > 0
+	if shouldFail {
+		s.failures[key.String()]--
+	}
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		s.active--
+		if !isManifest {
+			s.activeSegments--
+		}
+		s.mu.Unlock()
+	}()
+	if s.delay > 0 {
+		timer := time.NewTimer(s.delay)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return storage.ObjectInfo{}, ctx.Err()
+		case <-timer.C:
+		}
+	}
+	if shouldFail {
+		return storage.ObjectInfo{}, io.ErrUnexpectedEOF
+	}
+	return s.Store.Put(ctx, key, source, options)
+}
+
+func (s *migrationObservedPutStore) attemptCount(key string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.attempts[key]
+}
+
+func (s *migrationObservedPutStore) maximumConcurrency() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.maxActive
+}
+
+func (s *migrationObservedPutStore) manifestOverlappedSegments() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.manifestSegmentOverlap
 }
 
 type migrationBlockingDeleteStore struct {

--- a/storage/copy.go
+++ b/storage/copy.go
@@ -12,9 +12,10 @@ import (
 )
 
 type VerifiedCopyResult struct {
-	Info     ObjectInfo
-	Checksum string
-	Copied   bool
+	Info       ObjectInfo
+	SourceInfo ObjectInfo
+	Checksum   string
+	Copied     bool
 }
 
 func PrefixInventory(ctx context.Context, store Store, prefix Key) ([]ObjectInfo, error) {
@@ -56,7 +57,7 @@ func CopyObjectVerified(ctx context.Context, source, destination Store, sourceIn
 			return VerifiedCopyResult{}, destinationErr
 		}
 		if sourceSize == destinationSize && sourceChecksum == destinationChecksum {
-			return VerifiedCopyResult{Info: destinationInfo, Checksum: sourceChecksum, Copied: false}, nil
+			return VerifiedCopyResult{Info: destinationInfo, SourceInfo: sourceInfo, Checksum: sourceChecksum, Copied: false}, nil
 		}
 	} else if err != nil && !errors.Is(err, ErrNotFound) {
 		return VerifiedCopyResult{}, err
@@ -87,7 +88,45 @@ func CopyObjectVerified(ctx context.Context, source, destination Store, sourceIn
 	if destinationSize != expectedSize || destinationChecksum != sourceChecksum {
 		return VerifiedCopyResult{}, fmt.Errorf("copied object %s failed checksum verification", sourceInfo.Key.String())
 	}
-	return VerifiedCopyResult{Info: written, Checksum: sourceChecksum, Copied: true}, nil
+	return VerifiedCopyResult{Info: written, SourceInfo: object.Info, Checksum: sourceChecksum, Copied: true}, nil
+}
+
+// CopyObjectValidated copies an object once and relies on Store.Put's atomic,
+// size-checked, transport-validated contract. S3 uploads are protected by the
+// SDK's request checksums, SFTP by SSH integrity and atomic rename, and local
+// writes by a temporary file and atomic rename. The source SHA-256 is retained
+// for the caller's durable checkpoint, avoiding an expensive destination
+// download after every successful upload.
+func CopyObjectValidated(ctx context.Context, source, destination Store, sourceInfo ObjectInfo) (VerifiedCopyResult, error) {
+	if source == nil || destination == nil {
+		return VerifiedCopyResult{}, ErrStoreNotConfigured
+	}
+	if err := ctx.Err(); err != nil {
+		return VerifiedCopyResult{}, err
+	}
+	object, err := source.Open(ctx, sourceInfo.Key)
+	if err != nil {
+		return VerifiedCopyResult{}, err
+	}
+	defer object.Body.Close()
+	if object.Info.Size != sourceInfo.Size {
+		return VerifiedCopyResult{}, fmt.Errorf("source object %s changed size from %d to %d", sourceInfo.Key.String(), sourceInfo.Size, object.Info.Size)
+	}
+	expectedSize := object.Info.Size
+	digest := sha256.New()
+	reader := io.TeeReader(&contextReader{ctx: ctx, reader: object.Body}, digest)
+	written, err := destination.Put(ctx, sourceInfo.Key, reader, PutOptions{
+		ContentType: object.Info.ContentType, CacheControl: object.Info.CacheControl, ExpectedSize: &expectedSize,
+	})
+	if err != nil {
+		return VerifiedCopyResult{}, err
+	}
+	if written.Size != expectedSize {
+		return VerifiedCopyResult{}, fmt.Errorf("copied object %s size mismatch: wrote %d, expected %d", sourceInfo.Key.String(), written.Size, expectedSize)
+	}
+	return VerifiedCopyResult{
+		Info: written, SourceInfo: object.Info, Checksum: fmt.Sprintf("%x", digest.Sum(nil)), Copied: true,
+	}, nil
 }
 
 func hashStoredObject(ctx context.Context, store Store, key Key) (string, int64, error) {

--- a/storage/copy_test.go
+++ b/storage/copy_test.go
@@ -2,11 +2,22 @@ package storage
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+type openCountingStore struct {
+	Store
+	opens int
+}
+
+func (s *openCountingStore) Open(ctx context.Context, key Key) (*Object, error) {
+	s.opens++
+	return s.Store.Open(ctx, key)
+}
 
 func TestCopyObjectVerifiedCopiesMetadataAndSkipsVerifiedDestination(t *testing.T) {
 	source, err := NewLocalStore(t.TempDir())
@@ -39,6 +50,46 @@ func TestCopyObjectVerifiedCopiesMetadataAndSkipsVerifiedDestination(t *testing.
 	}
 	if second.Copied || second.Checksum != first.Checksum {
 		t.Fatalf("verified destination was not reused: %#v", second)
+	}
+}
+
+func TestCopyObjectValidatedUsesTransportValidationWithoutDestinationReadback(t *testing.T) {
+	source, err := NewLocalStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	destinationLocal, err := NewLocalStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	destination := &openCountingStore{Store: destinationLocal}
+	key := copyTestKey(t, "video/1080p/out288.ts")
+	size := int64(len("segment-data"))
+	if _, err := source.Put(context.Background(), key, strings.NewReader("segment-data"), PutOptions{ExpectedSize: &size}); err != nil {
+		t.Fatal(err)
+	}
+	info, err := source.Stat(context.Background(), key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := CopyObjectValidated(context.Background(), source, destination, info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.Copied || result.Checksum == "" || result.Info.Size != size {
+		t.Fatalf("unexpected validated copy: %#v", result)
+	}
+	if destination.opens != 0 {
+		t.Fatalf("destination was downloaded %d time(s) after upload", destination.opens)
+	}
+	object, err := destinationLocal.Open(context.Background(), key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer object.Body.Close()
+	data, err := io.ReadAll(object.Body)
+	if err != nil || string(data) != "segment-data" {
+		t.Fatalf("stored data = %q, %v", data, err)
 	}
 }
 

--- a/storage/s3.go
+++ b/storage/s3.go
@@ -26,6 +26,7 @@ const (
 	defaultS3UploadPartSize    = int64(16 * 1024 * 1024)
 	defaultS3UploadConcurrency = 4
 	minimumS3UploadPartSize    = int64(5 * 1024 * 1024)
+	maxS3ReadResumeAttempts    = 4
 )
 
 type S3Options struct {
@@ -210,18 +211,22 @@ func (s *S3Store) Put(ctx context.Context, key Key, src io.Reader, options PutOp
 	if options.CacheControl != "" {
 		input.CacheControl = aws.String(options.CacheControl)
 	}
-	if _, err := s.uploader.UploadObject(ctx, input); err != nil {
+	output, err := s.uploader.UploadObject(ctx, input)
+	if err != nil {
 		return ObjectInfo{}, fmt.Errorf("upload S3 object %s: %w", key.String(), err)
 	}
-	info, err := s.Stat(ctx, key)
-	if err != nil {
-		return ObjectInfo{}, err
+	if output == nil {
+		return ObjectInfo{}, fmt.Errorf("upload S3 object %s returned no result", key.String())
 	}
-	if options.ExpectedSize != nil && info.Size != *options.ExpectedSize {
-		sizeErr := fmt.Errorf("object %s size mismatch: stored %d, expected %d", key.String(), info.Size, *options.ExpectedSize)
+	storedSize := aws.ToInt64(output.ContentLength)
+	if options.ExpectedSize != nil && storedSize != *options.ExpectedSize {
+		sizeErr := fmt.Errorf("object %s size mismatch: stored %d, expected %d", key.String(), storedSize, *options.ExpectedSize)
 		return ObjectInfo{}, errors.Join(sizeErr, s.Delete(context.WithoutCancel(ctx), key))
 	}
-	return info, nil
+	return ObjectInfo{
+		Key: key, Size: storedSize, ContentType: options.ContentType,
+		CacheControl: options.CacheControl, ETag: aws.ToString(output.ETag),
+	}, nil
 }
 
 func validateSeekableSize(src io.Reader, expected int64) error {
@@ -425,6 +430,7 @@ type s3ReadSeekCloser struct {
 	position int64
 	body     io.ReadCloser
 	closed   bool
+	resumes  int
 }
 
 func (r *s3ReadSeekCloser) Read(buffer []byte) (int, error) {
@@ -442,24 +448,59 @@ func (r *s3ReadSeekCloser) Read(buffer []byte) (int, error) {
 	if r.position >= r.size {
 		return 0, io.EOF
 	}
-	if r.body == nil {
-		if err := r.openBody(); err != nil {
-			return 0, err
+	for {
+		if r.body == nil {
+			if err := r.openBody(); err != nil {
+				if retryErr := r.prepareResume(err); retryErr != nil {
+					return 0, retryErr
+				}
+				continue
+			}
 		}
-	}
-	n, err := r.body.Read(buffer)
-	r.position += int64(n)
-	if errors.Is(err, io.EOF) {
+		n, err := r.body.Read(buffer)
+		r.position += int64(n)
+		if err == nil {
+			return n, nil
+		}
 		closeErr := r.body.Close()
 		r.body = nil
-		if r.position < r.size {
-			err = io.ErrUnexpectedEOF
+		if r.position >= r.size {
+			if closeErr != nil {
+				return n, fmt.Errorf("close S3 object %s after reading: %w", r.key, closeErr)
+			}
+			// Keep io.EOF as the exact sentinel. io.ReadAll and io.Copy compare it
+			// directly rather than using errors.Is, so wrapping it would turn a
+			// complete short-object read into a false failure.
+			return n, io.EOF
 		}
-		if closeErr != nil {
-			err = errors.Join(err, closeErr)
+		if retryErr := r.prepareResume(errors.Join(err, closeErr)); retryErr != nil {
+			return n, retryErr
+		}
+		if n > 0 {
+			// Preserve the bytes already read. The next call resumes from the exact
+			// offset with If-Match protection against an object replacement.
+			return n, nil
 		}
 	}
-	return n, err
+}
+
+func (r *s3ReadSeekCloser) prepareResume(cause error) error {
+	if err := r.ctx.Err(); err != nil {
+		return err
+	}
+	if r.resumes >= maxS3ReadResumeAttempts {
+		return fmt.Errorf("read S3 object %s stopped at byte %d after %d resume attempts: %w", r.key, r.position, r.resumes, cause)
+	}
+	r.resumes++
+	delay := time.Duration(1<<(r.resumes-1)) * 50 * time.Millisecond
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-r.ctx.Done():
+		return r.ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func (r *s3ReadSeekCloser) Seek(offset int64, whence int) (int64, error) {
@@ -496,6 +537,7 @@ func (r *s3ReadSeekCloser) Seek(offset int64, whence int) (int64, error) {
 		r.body = nil
 	}
 	r.position = target
+	r.resumes = 0
 	return target, nil
 }
 

--- a/storage/s3_test.go
+++ b/storage/s3_test.go
@@ -160,6 +160,55 @@ func TestS3StoreRejectsRangeResponseForWrongOffset(t *testing.T) {
 	}
 }
 
+func TestS3StoreResumesInterruptedReadWithPinnedRange(t *testing.T) {
+	backend := newMemoryS3(1000)
+	backend.interruptReads = 2
+	backend.interruptAfter = 4
+	store := newS3Store(S3Options{Bucket: "media"}, backend, backend)
+	key := mustParseKey(t, "file/source/original.mp4")
+	content := "resumable-media-data"
+	if _, err := store.Put(context.Background(), key, strings.NewReader(content), PutOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	object, err := store.Open(context.Background(), key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer object.Body.Close()
+	data, err := io.ReadAll(object.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != content {
+		t.Fatalf("resumed data = %q, want %q", data, content)
+	}
+	ranges := backend.getRanges()
+	if len(ranges) != 3 || ranges[0] != "" || ranges[1] != "bytes=4-" || ranges[2] != "bytes=8-" {
+		t.Fatalf("resume ranges = %v, want [<full> bytes=4- bytes=8-]", ranges)
+	}
+	for _, match := range backend.getIfMatches() {
+		if match == "" {
+			t.Fatalf("resume request did not pin the object version: %v", backend.getIfMatches())
+		}
+	}
+}
+
+func TestS3StorePreservesExactEOFWhenFinalReadReturnsData(t *testing.T) {
+	reader := &s3ReadSeekCloser{
+		ctx:  context.Background(),
+		key:  "file/source/original.mp4",
+		size: 5,
+		body: &dataAndEOFReadCloser{data: []byte("media")},
+	}
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if string(data) != "media" {
+		t.Fatalf("ReadAll() = %q, want media", data)
+	}
+}
+
 func TestNormalizeS3Options(t *testing.T) {
 	valid, err := normalizeS3Options(S3Options{
 		Bucket:          " media ",
@@ -214,6 +263,8 @@ type memoryS3 struct {
 	lastContentLength int64
 	lastMultipartSize int64
 	wrongContentRange bool
+	interruptReads    int
+	interruptAfter    int
 }
 
 func newMemoryS3(pageSize int) *memoryS3 {
@@ -282,6 +333,11 @@ func (m *memoryS3) GetObject(ctx context.Context, input *s3.GetObjectInput, _ ..
 	m.ranges = append(m.ranges, rangeValue)
 	m.ifMatches = append(m.ifMatches, ifMatch)
 	wrongContentRange := m.wrongContentRange
+	interrupt := m.interruptReads > 0
+	if interrupt {
+		m.interruptReads--
+	}
+	interruptAfter := m.interruptAfter
 	m.mu.Unlock()
 	if !ok {
 		return nil, &smithy.GenericAPIError{Code: "NoSuchKey", Message: "missing"}
@@ -304,8 +360,12 @@ func (m *memoryS3) GetObject(ctx context.Context, input *s3.GetObjectInput, _ ..
 		contentRange = fmt.Sprintf("bytes %d-%d/%d", contentStart, len(object.data)-1, len(object.data))
 	}
 	data := append([]byte(nil), object.data[start:]...)
+	body := io.ReadCloser(io.NopCloser(bytes.NewReader(data)))
+	if interrupt {
+		body = &interruptingReadCloser{reader: bytes.NewReader(data), remaining: interruptAfter}
+	}
 	return &s3.GetObjectOutput{
-		Body:          io.NopCloser(bytes.NewReader(data)),
+		Body:          body,
 		ContentLength: aws.Int64(int64(len(data))),
 		ContentRange:  optionalString(contentRange),
 		ContentType:   aws.String(object.contentType),
@@ -314,6 +374,46 @@ func (m *memoryS3) GetObject(ctx context.Context, input *s3.GetObjectInput, _ ..
 		ETag:          aws.String(object.etag),
 	}, nil
 }
+
+type interruptingReadCloser struct {
+	reader    *bytes.Reader
+	remaining int
+}
+
+func (r *interruptingReadCloser) Read(buffer []byte) (int, error) {
+	if r.remaining <= 0 {
+		return 0, io.ErrUnexpectedEOF
+	}
+	if len(buffer) > r.remaining {
+		buffer = buffer[:r.remaining]
+	}
+	n, err := r.reader.Read(buffer)
+	r.remaining -= n
+	if r.remaining == 0 && err == nil {
+		err = io.ErrUnexpectedEOF
+	}
+	return n, err
+}
+
+func (r *interruptingReadCloser) Close() error { return nil }
+
+type dataAndEOFReadCloser struct {
+	data []byte
+}
+
+func (r *dataAndEOFReadCloser) Read(buffer []byte) (int, error) {
+	if len(r.data) == 0 {
+		return 0, io.EOF
+	}
+	n := copy(buffer, r.data)
+	r.data = r.data[n:]
+	if len(r.data) == 0 {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func (r *dataAndEOFReadCloser) Close() error { return nil }
 
 func (m *memoryS3) DeleteObject(ctx context.Context, input *s3.DeleteObjectInput, _ ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
 	if err := ctx.Err(); err != nil {


### PR DESCRIPTION
Adds account-scoped storage migrations and completes the migration reliability/performance pass: bounded parallel object copying, per-object retries, durable checkpoints, resumable S3 reads, transport-validated uploads, safe manifest ordering, encoding-aware deferred cleanup, and deletion-safe checkpoint cleanup. Verified with the full Go suite, vet, race detector, and real Garage S3/OpenSSH SFTP migration smoke tests.