### PR TITLE
Improve storage migration visibility and cleanup controls

### DIFF
--- a/background/runtime.go
+++ b/background/runtime.go
@@ -744,6 +744,7 @@ func (r *Runtime) finish(task Task, attempt Attempt, result Result, taskErr *Tas
 		}
 		eventType := "task_succeeded"
 		eventMessage := "Task completed"
+		eventMetadata := ""
 
 		if taskErr != nil {
 			code := boundedMessage(taskErr.Code, 80)
@@ -805,25 +806,29 @@ func (r *Runtime) finish(task Task, attempt Attempt, result Result, taskErr *Tas
 					updates["run_after"] = &runAfter
 					updates["finished_at"] = nil
 					eventType = "task_retry_scheduled"
-					eventMessage = fmt.Sprintf("Retry scheduled in %s", delay.Round(time.Second))
+					eventMessage = fmt.Sprintf("Attempt %d failed; retry scheduled in %s", attempt.Number, delay.Round(time.Second))
 				} else {
 					taskStatus = TaskFailed
 					updates["status"] = taskStatus
 					eventType = "task_failed"
-					eventMessage = "Task exhausted its automatic retries"
+					eventMessage = fmt.Sprintf("Attempt %d failed; automatic retries exhausted", attempt.Number)
 				}
 			default:
 				attemptStatus = AttemptFailed
 				taskStatus = TaskFailed
 				updates["status"] = taskStatus
 				eventType = "task_failed"
-				eventMessage = "Task failed"
+				eventMessage = fmt.Sprintf("Attempt %d failed", attempt.Number)
+			}
+			diagnostics := RedactDiagnostic(taskErr.Diagnostic)
+			if attemptStatus == AttemptFailed {
+				eventMetadata = diagnostics
 			}
 			if err := tx.Model(&Attempt{}).Where("id = ?", attempt.ID).Updates(map[string]any{
 				"status":        attemptStatus,
 				"error_code":    code,
 				"error_message": public,
-				"diagnostics":   RedactDiagnostic(taskErr.Diagnostic),
+				"diagnostics":   diagnostics,
 				"finished_at":   &now,
 			}).Error; err != nil {
 				return err
@@ -863,7 +868,7 @@ func (r *Runtime) finish(task Task, attempt Attempt, result Result, taskErr *Tas
 				}
 			}
 		}
-		if err := addEvent(tx, Event{JobID: task.JobID, TaskID: task.ID, Type: eventType, Message: eventMessage}); err != nil {
+		if err := addEvent(tx, Event{JobID: task.JobID, TaskID: task.ID, Type: eventType, Message: eventMessage, Metadata: eventMetadata}); err != nil {
 			return err
 		}
 		var job Job
@@ -1228,6 +1233,42 @@ func (r *Runtime) ResumeJob(ctx context.Context, jobID string, actorID uint, act
 		job.PauseRequestedAt = nil
 		job.PausedAt = nil
 		if err := addEvent(tx, Event{JobID: jobID, Type: "job_resumed", ActorID: optionalActor(actorID), ActorName: actorName, Message: "Job resumed"}); err != nil {
+			return err
+		}
+		return recomputeJob(tx, &job, now)
+	})
+	if err == nil {
+		r.Wake()
+	}
+	return err
+}
+
+// RunJobNow releases future-scheduled queued tasks without creating a second
+// job or discarding their durable history. It is intentionally limited to jobs
+// that have not started; retry backoff and active work use their own controls.
+func (r *Runtime) RunJobNow(ctx context.Context, jobID string, actorID uint, actorName string) error {
+	now := time.Now()
+	err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		var job Job
+		if err := tx.First(&job, "id = ?", jobID).Error; err != nil {
+			return err
+		}
+		if job.Status != JobQueued || job.PauseRequestedAt != nil || job.CancelRequestedAt != nil {
+			return ErrConflict
+		}
+		result := tx.Model(&Task{}).
+			Where("job_id = ? AND status = ? AND run_after IS NOT NULL AND run_after > ?", jobID, TaskQueued, now).
+			Update("run_after", nil)
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected == 0 {
+			return ErrConflict
+		}
+		if err := addEvent(tx, Event{
+			JobID: jobID, Type: "job_run_requested", ActorID: optionalActor(actorID), ActorName: actorName,
+			Message: "Scheduled wait skipped; job released for immediate execution",
+		}); err != nil {
 			return err
 		}
 		return recomputeJob(tx, &job, now)

--- a/background/runtime_test.go
+++ b/background/runtime_test.go
@@ -268,7 +268,7 @@ func TestTransientFailureRetriesThenSucceeds(t *testing.T) {
 	var calls atomic.Int32
 	if err := runtime.Register("test.retry", func(context.Context, Task) (Result, error) {
 		if calls.Add(1) < 3 {
-			return Result{}, &TaskError{Code: "temporary", Public: "Temporary failure", Diagnostic: "retry diagnostic", Class: ErrorTransient, RetryAfter: time.Millisecond}
+			return Result{}, &TaskError{Code: "temporary", Public: "Temporary failure", Diagnostic: "copy video/out288.ts: unexpected EOF password=topsecret", Class: ErrorTransient, RetryAfter: time.Millisecond}
 		}
 		return Result{}, nil
 	}); err != nil {
@@ -282,6 +282,20 @@ func TestTransientFailureRetriesThenSucceeds(t *testing.T) {
 	}
 	if len(detail.Tasks[0].Attempts) != 3 || detail.Tasks[0].Attempts[0].Status != AttemptFailed || detail.Tasks[0].Attempts[2].Status != AttemptSucceeded {
 		t.Fatalf("unexpected attempt history: %#v", detail.Tasks[0].Attempts)
+	}
+	retryEvents := make([]Event, 0, 2)
+	for _, event := range detail.Events {
+		if event.Type == "task_retry_scheduled" {
+			retryEvents = append(retryEvents, event)
+		}
+	}
+	if len(retryEvents) != 2 {
+		t.Fatalf("retry events = %#v, want 2", retryEvents)
+	}
+	for _, event := range retryEvents {
+		if !strings.Contains(event.Message, "failed; retry scheduled") || !strings.Contains(event.Metadata, "unexpected EOF") || strings.Contains(event.Metadata, "topsecret") {
+			t.Fatalf("retry event did not preserve a redacted diagnostic: %#v", event)
+		}
 	}
 }
 
@@ -339,6 +353,16 @@ func TestPermanentFailureDoesNotRetryAndRedactsDiagnostics(t *testing.T) {
 	diagnostic := attempts[0].Diagnostics
 	if strings.Contains(diagnostic, "super-secret") || strings.Contains(diagnostic, "bearer-secret") || strings.Contains(diagnostic, "json-secret") || strings.Contains(diagnostic, "alice:pw") || strings.Contains(diagnostic, "bob:key") || strings.Contains(diagnostic, "?token=") || !strings.Contains(diagnostic, "[redacted]") {
 		t.Fatalf("diagnostic was not safely redacted: %q", diagnostic)
+	}
+	var failureEvent *Event
+	for index := range detail.Events {
+		if detail.Events[index].Type == "task_failed" {
+			failureEvent = &detail.Events[index]
+			break
+		}
+	}
+	if failureEvent == nil || failureEvent.Metadata != diagnostic || failureEvent.Message != "Attempt 1 failed" {
+		t.Fatalf("failure event did not retain the redacted attempt diagnostic: %#v", failureEvent)
 	}
 }
 
@@ -429,6 +453,53 @@ func TestQueuedJobCanBePausedAndCanceledWithoutExecution(t *testing.T) {
 	detail = waitForJob(t, runtime, job.ID, JobCanceled)
 	if detail.Tasks[0].Status != TaskCanceled || detail.PauseRequestedAt != nil || detail.PausedAt != nil {
 		t.Fatalf("unexpected canceled pause state: %#v", detail)
+	}
+}
+
+func TestRunJobNowReleasesFutureScheduledTask(t *testing.T) {
+	runtime, _ := testRuntime(t)
+	called := make(chan struct{}, 1)
+	if err := runtime.Register("test.scheduled", func(context.Context, Task) (Result, error) {
+		called <- struct{}{}
+		return Result{}, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	startTestRuntime(t, runtime)
+	runAfter := time.Now().Add(time.Hour)
+	job, _, err := runtime.Enqueue(context.Background(), JobSpec{
+		Kind: "test.scheduled", Visibility: VisibilityAdmin, IdempotencyKey: "scheduled-now", Label: "Scheduled work",
+		Tasks: []TaskSpec{{Kind: "test.scheduled", Queue: QueueStorage, Required: true, RunAfter: &runAfter}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-called:
+		t.Fatal("future-scheduled task ran before it was released")
+	case <-time.After(30 * time.Millisecond):
+	}
+	if err := runtime.RunJobNow(context.Background(), job.ID, 12, "admin"); err != nil {
+		t.Fatal(err)
+	}
+	detail := waitForJob(t, runtime, job.ID, JobSucceeded)
+	select {
+	case <-called:
+	default:
+		t.Fatal("released task did not run")
+	}
+	found := false
+	for _, event := range detail.Events {
+		if event.Type == "job_run_requested" && event.ActorName == "admin" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("release event was not recorded: %#v", detail.Events)
+	}
+	if err := runtime.RunJobNow(context.Background(), job.ID, 12, "admin"); !errors.Is(err, ErrConflict) {
+		t.Fatalf("completed job release = %v, want conflict", err)
 	}
 }
 

--- a/controllers/BackgroundJobController.go
+++ b/controllers/BackgroundJobController.go
@@ -325,6 +325,7 @@ func stripTaskDiagnostics(detail *background.JobDetail) {
 	for eventIndex := range detail.Events {
 		detail.Events[eventIndex].ActorID = nil
 		detail.Events[eventIndex].ActorName = ""
+		detail.Events[eventIndex].Metadata = ""
 	}
 }
 

--- a/controllers/BackgroundJobController_test.go
+++ b/controllers/BackgroundJobController_test.go
@@ -28,11 +28,11 @@ func TestUserJobDetailStripsOperatorAndWorkerDiagnostics(t *testing.T) {
 	actorID := uint(4)
 	detail := &background.JobDetail{
 		Job:    background.Job{Tasks: []background.Task{{Attempts: []background.Attempt{{Worker: "host-1", Diagnostics: "secret"}}}}},
-		Events: []background.Event{{ActorID: &actorID, ActorName: "operator"}},
+		Events: []background.Event{{ActorID: &actorID, ActorName: "operator", Metadata: "copy object: unexpected EOF"}},
 	}
 	stripTaskDiagnostics(detail)
 	attempt := detail.Tasks[0].Attempts[0]
-	if attempt.Worker != "" || attempt.Diagnostics != "" || detail.Events[0].ActorID != nil || detail.Events[0].ActorName != "" {
+	if attempt.Worker != "" || attempt.Diagnostics != "" || detail.Events[0].ActorID != nil || detail.Events[0].ActorName != "" || detail.Events[0].Metadata != "" {
 		t.Fatalf("user detail leaked internal data: %#v %#v", attempt, detail.Events[0])
 	}
 }

--- a/controllers/StorageMigrationController.go
+++ b/controllers/StorageMigrationController.go
@@ -126,6 +126,16 @@ func (h *Handlers) KeepStorageMigrationOriginals(c echo.Context) error {
 	return c.JSON(http.StatusOK, migration)
 }
 
+func (h *Handlers) StartStorageMigrationCleanupNow(c echo.Context) error {
+	actorID, actorName := backgroundActor(c)
+	migration, err := h.Logic.StartStorageMigrationCleanupNow(c.Request().Context(), c.Param("id"), actorID, actorName)
+	if err != nil {
+		return storageMigrationError(c, err)
+	}
+	c.Response().Header().Set("Retry-After", "1")
+	return c.JSON(http.StatusAccepted, migration)
+}
+
 func (h *Handlers) CancelFailedStorageMigration(c echo.Context) error {
 	migration, err := h.Logic.CancelFailedStorageMigration(c.Request().Context(), c.Param("id"))
 	if err != nil {

--- a/logic/StorageMigration.go
+++ b/logic/StorageMigration.go
@@ -763,6 +763,79 @@ func (s *Service) ensureStoragePoolNotMigrating(poolID uint) error {
 	return nil
 }
 
+func (s *Service) StartStorageMigrationCleanupNow(ctx context.Context, migrationUUID string, actorID uint, actorName string) (models.StorageMigration, error) {
+	migration, err := s.GetStorageMigration(ctx, migrationUUID)
+	if err != nil {
+		return models.StorageMigration{}, err
+	}
+	now := time.Now().UTC()
+	if s.Deps.Background == nil || migration.Status != models.StorageMigrationRetainingOriginals || migration.KeepOriginals ||
+		migration.CleanupJobID == "" || migration.CleanupAfter == nil || !migration.CleanupAfter.After(now) ||
+		migration.FileCount == 0 || migration.CutoverCount+migration.DeletedCount < migration.FileCount {
+		return models.StorageMigration{}, fmt.Errorf("%w: original cleanup is not waiting in its retention period", ErrStorageMigrationConflict)
+	}
+	cleanupJob, err := s.Deps.Background.Job(ctx, migration.CleanupJobID, nil, true)
+	if err != nil {
+		return models.StorageMigration{}, err
+	}
+	if cleanupJob.Kind != "storage.migration.cleanup" || cleanupJob.Status != background.JobQueued {
+		return models.StorageMigration{}, fmt.Errorf("%w: original cleanup has already changed state", ErrStorageMigrationConflict)
+	}
+
+	previousCleanupAfter := migration.CleanupAfter
+	previousPhase := migration.Phase
+	durableCtx := context.WithoutCancel(ctx)
+	updated := s.Deps.DB.WithContext(durableCtx).Model(&migration).
+		Where("status = ? AND keep_originals = ? AND cleanup_job_id = ?", models.StorageMigrationRetainingOriginals, false, migration.CleanupJobID).
+		Updates(map[string]any{"cleanup_after": &now, "phase": "Original cleanup starting"})
+	if updated.Error != nil {
+		return models.StorageMigration{}, updated.Error
+	}
+	if updated.RowsAffected == 0 {
+		return models.StorageMigration{}, fmt.Errorf("%w: original cleanup changed state before it could start", ErrStorageMigrationConflict)
+	}
+
+	if err := s.Deps.Background.RunJobNow(durableCtx, migration.CleanupJobID, actorID, actorName); err != nil {
+		if errors.Is(err, background.ErrConflict) {
+			if current, loadErr := s.Deps.Background.Job(durableCtx, migration.CleanupJobID, nil, true); loadErr == nil && cleanupJobIsRunningOrDue(current, time.Now().UTC()) {
+				s.Deps.Background.Wake()
+				if loadErr := s.Deps.DB.WithContext(durableCtx).First(&migration, migration.ID).Error; loadErr != nil {
+					return models.StorageMigration{}, loadErr
+				}
+				return migration, nil
+			}
+		}
+		_ = s.Deps.DB.WithContext(durableCtx).Model(&migration).
+			Where("status = ? AND keep_originals = ? AND cleanup_job_id = ? AND phase = ?", models.StorageMigrationRetainingOriginals, false, migration.CleanupJobID, "Original cleanup starting").
+			Updates(map[string]any{"cleanup_after": previousCleanupAfter, "phase": previousPhase}).Error
+		if errors.Is(err, background.ErrConflict) {
+			return models.StorageMigration{}, fmt.Errorf("%w: original cleanup changed state before it could start", ErrStorageMigrationConflict)
+		}
+		return models.StorageMigration{}, err
+	}
+	if err := s.Deps.DB.WithContext(durableCtx).First(&migration, migration.ID).Error; err != nil {
+		return models.StorageMigration{}, err
+	}
+	return migration, nil
+}
+
+func cleanupJobIsRunningOrDue(job *background.JobDetail, now time.Time) bool {
+	if job == nil || job.Kind != "storage.migration.cleanup" {
+		return false
+	}
+	switch job.Status {
+	case background.JobRunning, background.JobSucceeded, background.JobSucceededWithWarnings:
+		return true
+	case background.JobQueued:
+		for _, task := range job.Tasks {
+			if task.Status == background.TaskQueued && (task.RunAfter == nil || !task.RunAfter.After(now)) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func (s *Service) KeepStorageMigrationOriginals(ctx context.Context, migrationUUID string, actorID uint, actorName string) (models.StorageMigration, error) {
 	migration, err := s.GetStorageMigration(ctx, migrationUUID)
 	if err != nil {

--- a/routes/api.go
+++ b/routes/api.go
@@ -83,6 +83,7 @@ func Api(apiGroup *echo.Group, handlers *controllers.Handlers, middlewareFactory
 	adminV2.GET("/storage/migrations/:id/items", handlers.ListStorageMigrationItems)
 	adminV2.POST("/storage/migrations/:id/cancel", handlers.CancelFailedStorageMigration)
 	adminV2.POST("/storage/migrations/:id/keep-originals", handlers.KeepStorageMigrationOriginals)
+	adminV2.POST("/storage/migrations/:id/start-cleanup", handlers.StartStorageMigrationCleanupNow)
 	protectedApi.POST("/folder", handlers.CreateFolder)
 	protectedApi.PUT("/folder", handlers.UpdateFolder)
 	protectedApi.DELETE("/folder", handlers.DeleteFolderLegacy)

--- a/routes/api_test.go
+++ b/routes/api_test.go
@@ -99,6 +99,7 @@ func TestAPIRoutesExposePauseResumeAndStorageMigrationAdminEndpoints(t *testing.
 		http.MethodGet + " /api/v2/admin/storage/migrations/:id/items",
 		http.MethodPost + " /api/v2/admin/storage/migrations/:id/cancel",
 		http.MethodPost + " /api/v2/admin/storage/migrations/:id/keep-originals",
+		http.MethodPost + " /api/v2/admin/storage/migrations/:id/start-cleanup",
 		http.MethodPost + " /api/admin/storage/sftp/host-key",
 		http.MethodPost + " /api/admin/storage/mounts/test",
 	} {

--- a/services/StorageMigration_test.go
+++ b/services/StorageMigration_test.go
@@ -26,7 +26,13 @@ func TestStorageMigrationBackgroundJobCutsOverAndSchedulesDeferredCleanup(t *tes
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := db.AutoMigrate(&models.File{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}, &models.StorageMigrationObject{}); err != nil {
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+	if err := db.AutoMigrate(&models.File{}, &models.Quality{}, &models.Audio{}, &models.Subtitle{}, &models.StorageMigration{}, &models.StorageMigrationAccount{}, &models.StorageMigrationItem{}, &models.StorageMigrationObject{}); err != nil {
 		t.Fatal(err)
 	}
 	if err := background.Migrate(db); err != nil {
@@ -43,7 +49,8 @@ func TestStorageMigrationBackgroundJobCutsOverAndSchedulesDeferredCleanup(t *tes
 	if err := db.Create(&file).Error; err != nil {
 		t.Fatal(err)
 	}
-	putMigrationTestObject(t, source, migrationTestKey(t, file.UUID+"/source/original.mp4"), "media")
+	sourceKey := migrationTestKey(t, file.UUID+"/source/original.mp4")
+	putMigrationTestObject(t, source, sourceKey, "media")
 	migration := models.StorageMigration{UUID: "background-migration", SourcePoolName: "Source", DestinationPoolName: "Destination", Status: models.StorageMigrationQueued, FileCount: 1, PlannedBytes: 5}
 	if err := db.Create(&migration).Error; err != nil {
 		t.Fatal(err)
@@ -93,6 +100,39 @@ func TestStorageMigrationBackgroundJobCutsOverAndSchedulesDeferredCleanup(t *tes
 	}
 	if cleanup.Status != background.JobQueued || len(cleanup.Tasks) != 1 || cleanup.Tasks[0].RunAfter == nil {
 		t.Fatalf("unexpected cleanup job: %#v", cleanup)
+	}
+	if _, err := source.Stat(context.Background(), sourceKey); err != nil {
+		t.Fatalf("source object was not retained before cleanup override: %v", err)
+	}
+	if _, err := worker.logic.StartStorageMigrationCleanupNow(context.Background(), migration.UUID, 7, "admin"); err != nil {
+		t.Fatalf("start cleanup now: %v", err)
+	}
+	waitStorageMigrationJob(t, runtime, migration.CleanupJobID, background.JobSucceeded)
+	cleanup, err = runtime.Job(context.Background(), migration.CleanupJobID, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.First(&migration, migration.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if migration.Status != models.StorageMigrationCompleted || migration.CompletedAt == nil {
+		t.Fatalf("immediate cleanup did not complete migration: %#v", migration)
+	}
+	if _, err := source.Stat(context.Background(), sourceKey); !errors.Is(err, storage.ErrNotFound) {
+		t.Fatalf("source object remained after immediate cleanup: %v", err)
+	}
+	foundReleaseEvent := false
+	for _, event := range cleanup.Events {
+		if event.Type == "job_run_requested" && event.ActorName == "admin" {
+			foundReleaseEvent = true
+			break
+		}
+	}
+	if !foundReleaseEvent {
+		t.Fatalf("immediate cleanup override was not recorded: %#v", cleanup.Events)
+	}
+	if _, err := worker.logic.StartStorageMigrationCleanupNow(context.Background(), migration.UUID, 7, "admin"); err == nil {
+		t.Fatal("completed cleanup override was accepted a second time")
 	}
 }
 


### PR DESCRIPTION
## Summary
- expose retry and failure diagnostics in migration Activity and background task views
- display account usernames correctly in migration selection
- let administrators skip the retention window and start the existing cleanup job immediately
- preserve audit history and guard against duplicate or conflicting cleanup execution

## Verification
- go test ./...
- go vet ./...
- focused race-enabled background and storage migration tests
- bun run generate
- phone-width integrated-browser verification