### PR TITLE
feat(storage): add on-demand read caches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ COPY download ./download
 COPY helpers ./helpers
 COPY inits ./inits
 COPY logic ./logic
+COPY mediacache ./mediacache
 COPY middlewares ./middlewares
 COPY models ./models
 COPY routes ./routes

--- a/app/runtime.go
+++ b/app/runtime.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"ch/kirari04/videocms/background"
+	"ch/kirari04/videocms/mediacache"
 	"sync"
 	"sync/atomic"
 
@@ -61,6 +62,7 @@ type Deps struct {
 	Cache            *cache.Cache
 	RequestGate      *RequestGate
 	Storage          *storage.Service
+	MediaCache       *mediacache.Service
 	StorageCipher    *storage.CredentialCipher
 	StorageLifecycle StorageLifecycle
 	Background       *background.Runtime

--- a/auth/media.go
+++ b/auth/media.go
@@ -16,6 +16,7 @@ type MediaClaims struct {
 	LinkUUID      string          `json:"link_uuid"`
 	FileUUID      string          `json:"file_uuid"`
 	StorageID     string          `json:"storage_id"`
+	StoragePoolID uint            `json:"storage_pool_id,omitempty"`
 	UserID        uint            `json:"user_id"`
 	FileID        uint            `json:"file_id"`
 	QualityIDs    map[string]uint `json:"quality_ids"`

--- a/cmd/ServeMain.go
+++ b/cmd/ServeMain.go
@@ -6,6 +6,7 @@ import (
 	"ch/kirari04/videocms/controllers"
 	"ch/kirari04/videocms/inits"
 	"ch/kirari04/videocms/logic"
+	"ch/kirari04/videocms/mediacache"
 	"ch/kirari04/videocms/middlewares"
 	"ch/kirari04/videocms/routes"
 	"ch/kirari04/videocms/services"
@@ -59,6 +60,8 @@ func ServeMain() {
 		},
 	})
 	deps.Background = backgroundRuntime
+	deps.MediaCache = mediacache.New(deps.DB, deps.Storage, backgroundRuntime)
+	defer deps.MediaCache.Close()
 	if err := workerGroup.RegisterBackgroundHandlers(backgroundRuntime, tusSvc); err != nil {
 		log.Println("failed to register background handlers:", err)
 		return

--- a/controllers/GetAudioDataController.go
+++ b/controllers/GetAudioDataController.go
@@ -40,6 +40,7 @@ func (h *Handlers) GetAudioData(c echo.Context) error {
 	return h.serveMediaObject(c, claims.StorageID, key, "Audio doesn't exist", mediaTraffic{
 		userID:  claims.UserID,
 		fileID:  claims.FileID,
+		poolID:  claims.StoragePoolID,
 		audioID: audioID,
 	})
 }

--- a/controllers/GetSubtitleDataController.go
+++ b/controllers/GetSubtitleDataController.go
@@ -43,6 +43,7 @@ func (h *Handlers) GetSubtitleData(c echo.Context) error {
 	return h.serveMediaObject(c, claims.StorageID, key, "Subtitle file not found", mediaTraffic{
 		userID: claims.UserID,
 		fileID: claims.FileID,
+		poolID: claims.StoragePoolID,
 	})
 }
 

--- a/controllers/GetThumbnailDataController.go
+++ b/controllers/GetThumbnailDataController.go
@@ -28,5 +28,7 @@ func (h *Handlers) GetThumbnailData(c echo.Context) error {
 	if err != nil {
 		return c.NoContent(http.StatusBadRequest)
 	}
-	return h.serveMediaObject(c, object.StoreID, key, "", mediaTraffic{userID: object.UserID, fileID: object.FileID})
+	return h.serveMediaObject(c, object.StoreID, key, "", mediaTraffic{
+		userID: object.UserID, fileID: object.FileID, poolID: object.PoolID,
+	})
 }

--- a/controllers/GetVideoDataController.go
+++ b/controllers/GetVideoDataController.go
@@ -48,6 +48,7 @@ func (h *Handlers) GetVideoData(c echo.Context) error {
 	return h.serveMediaObject(c, claims.StorageID, key, "Video doesn't exist", mediaTraffic{
 		userID:    claims.UserID,
 		fileID:    claims.FileID,
+		poolID:    claims.StoragePoolID,
 		qualityID: qualityID,
 	})
 }

--- a/controllers/MediaStorage.go
+++ b/controllers/MediaStorage.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 
+	"ch/kirari04/videocms/mediacache"
 	"ch/kirari04/videocms/storage"
 
 	"github.com/labstack/echo/v4"
@@ -14,6 +15,7 @@ import (
 type mediaTraffic struct {
 	userID    uint
 	fileID    uint
+	poolID    uint
 	qualityID uint
 	audioID   uint
 }
@@ -53,16 +55,23 @@ func (h *Handlers) serveMediaObject(c echo.Context, storeID string, key storage.
 		c.Logger().Error("media storage is not configured")
 		return mediaStorageResponse(c, http.StatusInternalServerError, "")
 	}
-	store, err := h.Deps.Storage.StoreOrDefault(storeID)
+	var object *storage.Object
+	var err error
+	if h.Deps.MediaCache != nil {
+		object, _, err = h.Deps.MediaCache.Open(c.Request().Context(), mediacache.OpenRequest{
+			PoolID: traffic.poolID, OriginMountID: storeID, FileID: traffic.fileID, Key: key,
+		})
+	} else {
+		var store storage.Store
+		store, err = h.Deps.Storage.StoreOrDefault(storeID)
+		if err == nil {
+			object, err = store.Open(c.Request().Context(), key)
+		}
+	}
 	if err != nil {
-		c.Logger().Error("failed to resolve media storage", err)
 		if errors.Is(err, storage.ErrStoreNotConfigured) {
 			return mediaStorageResponse(c, http.StatusServiceUnavailable, "Media storage is currently unavailable")
 		}
-		return mediaStorageResponse(c, http.StatusInternalServerError, "")
-	}
-	object, err := store.Open(c.Request().Context(), key)
-	if err != nil {
 		if !errors.Is(err, storage.ErrNotFound) {
 			c.Logger().Errorf("failed to open media object %s: %v", key.String(), err)
 			return mediaStorageResponse(c, http.StatusInternalServerError, "")

--- a/controllers/PlayerController.go
+++ b/controllers/PlayerController.go
@@ -454,12 +454,20 @@ func buildMediaClaims(dbLink *models.Link) auth.MediaClaims {
 		LinkUUID:      dbLink.UUID,
 		FileUUID:      dbLink.File.UUID,
 		StorageID:     dbLink.File.StorageID,
+		StoragePoolID: valueOrZero(dbLink.File.StoragePoolID),
 		UserID:        dbLink.UserID,
 		FileID:        dbLink.FileID,
 		QualityIDs:    qualityIDs,
 		AudioIDs:      audioIDs,
 		SubtitleUUIDs: subtitleUUIDs,
 	}
+}
+
+func valueOrZero(value *uint) uint {
+	if value == nil {
+		return 0
+	}
+	return *value
 }
 
 func (h *Handlers) mediaCookie(c echo.Context, linkUUID string, token string, expiration time.Time) *http.Cookie {

--- a/controllers/StorageAdminController.go
+++ b/controllers/StorageAdminController.go
@@ -34,9 +34,16 @@ type sftpHostKeyRequest struct {
 }
 
 type storagePoolRequest struct {
-	Name      string `json:"name" validate:"required,min=1,max=120"`
-	MountIDs  []uint `json:"mount_ids" validate:"required,min=1"`
-	IsDefault bool   `json:"is_default"`
+	Name            string                     `json:"name" validate:"required,min=1,max=120"`
+	MountIDs        []uint                     `json:"mount_ids"`
+	PrimaryMountIDs []uint                     `json:"primary_mount_ids"`
+	CacheMounts     []storageCacheMountRequest `json:"cache_mounts"`
+	IsDefault       bool                       `json:"is_default"`
+}
+
+type storageCacheMountRequest struct {
+	MountID  uint  `json:"mount_id"`
+	MaxBytes int64 `json:"max_bytes"`
 }
 
 type storageReconnectRequest struct {
@@ -185,7 +192,8 @@ func (h *Handlers) CreateStoragePool(c echo.Context) error {
 		return c.String(status, err.Error())
 	}
 	pool, err := h.Logic.CreateStoragePool(logic.StoragePoolInput{
-		Name: request.Name, MountIDs: request.MountIDs, IsDefault: request.IsDefault,
+		Name: request.Name, MountIDs: request.MountIDs, PrimaryMountIDs: request.PrimaryMountIDs,
+		CacheMounts: storageCacheInputs(request.CacheMounts), IsDefault: request.IsDefault,
 	})
 	if err != nil {
 		return storageAdminError(c, err)
@@ -203,12 +211,21 @@ func (h *Handlers) UpdateStoragePool(c echo.Context) error {
 		return c.String(status, err.Error())
 	}
 	pool, err := h.Logic.UpdateStoragePool(poolID, logic.StoragePoolInput{
-		Name: request.Name, MountIDs: request.MountIDs, IsDefault: request.IsDefault,
+		Name: request.Name, MountIDs: request.MountIDs, PrimaryMountIDs: request.PrimaryMountIDs,
+		CacheMounts: storageCacheInputs(request.CacheMounts), IsDefault: request.IsDefault,
 	})
 	if err != nil {
 		return storageAdminError(c, err)
 	}
 	return c.JSON(http.StatusOK, pool)
+}
+
+func storageCacheInputs(requests []storageCacheMountRequest) []logic.StorageCacheMountInput {
+	result := make([]logic.StorageCacheMountInput, 0, len(requests))
+	for _, request := range requests {
+		result = append(result, logic.StorageCacheMountInput{MountID: request.MountID, MaxBytes: request.MaxBytes})
+	}
+	return result
 }
 
 func (h *Handlers) SetDefaultStoragePool(c echo.Context) error {

--- a/inits/Models.go
+++ b/inits/Models.go
@@ -58,6 +58,7 @@ func MigrateModels(gormDB *gorm.DB) error {
 		&models.StorageMount{},
 		&models.StoragePool{},
 		&models.StoragePoolMount{},
+		&models.StorageCacheEntry{},
 		&models.StorageMigration{},
 		&models.StorageMigrationAccount{},
 		&models.StorageMigrationItem{},
@@ -111,6 +112,9 @@ func MigrateModels(gormDB *gorm.DB) error {
 		return fmt.Errorf("failed to backfill file storage state: %w", err)
 	}
 	if err := ensureLocalStorageDefaults(gormDB); err != nil {
+		return err
+	}
+	if err := backfillFileStoragePools(gormDB); err != nil {
 		return err
 	}
 
@@ -174,9 +178,17 @@ func ensureLocalStorageDefaults(gormDB *gorm.DB) error {
 	if err := gormDB.Where("uuid = ?", localPool.UUID).FirstOrCreate(&localPool).Error; err != nil {
 		return fmt.Errorf("failed to initialize local storage pool: %w", err)
 	}
-	membership := models.StoragePoolMount{StoragePoolID: localPool.ID, StorageMountID: localMount.ID}
-	if err := gormDB.FirstOrCreate(&membership).Error; err != nil {
+	membership := models.StoragePoolMount{
+		StoragePoolID: localPool.ID, StorageMountID: localMount.ID, Role: models.StoragePoolMountPrimary,
+	}
+	if err := gormDB.Where("storage_pool_id = ? AND storage_mount_id = ?", localPool.ID, localMount.ID).
+		FirstOrCreate(&membership).Error; err != nil {
 		return fmt.Errorf("failed to initialize local storage pool membership: %w", err)
+	}
+	if err := gormDB.Model(&models.StoragePoolMount{}).
+		Where("role IS NULL OR role = ''").
+		Update("role", models.StoragePoolMountPrimary).Error; err != nil {
+		return fmt.Errorf("failed to backfill storage pool mount roles: %w", err)
 	}
 	var defaultPoolCount int64
 	if err := gormDB.Model(&models.StoragePool{}).Where("is_default = ?", true).Count(&defaultPoolCount).Error; err != nil {
@@ -185,6 +197,34 @@ func ensureLocalStorageDefaults(gormDB *gorm.DB) error {
 	if defaultPoolCount == 0 {
 		if err := gormDB.Model(&localPool).Update("is_default", true).Error; err != nil {
 			return fmt.Errorf("failed to select local storage pool: %w", err)
+		}
+	}
+	return nil
+}
+
+func backfillFileStoragePools(gormDB *gorm.DB) error {
+	type candidate struct {
+		StorageID string
+		PoolID    uint
+		Count     int64
+	}
+	var candidates []candidate
+	if err := gormDB.Table("storage_mounts AS mounts").
+		Select("mounts.uuid AS storage_id, MIN(members.storage_pool_id) AS pool_id, COUNT(*) AS count").
+		Joins("JOIN storage_pool_mounts AS members ON members.storage_mount_id = mounts.id").
+		Where("members.role = ?", models.StoragePoolMountPrimary).
+		Group("mounts.uuid").
+		Scan(&candidates).Error; err != nil {
+		return fmt.Errorf("inspect file storage pool candidates: %w", err)
+	}
+	for _, candidate := range candidates {
+		if candidate.Count != 1 {
+			continue
+		}
+		if err := gormDB.Unscoped().Model(&models.File{}).
+			Where("storage_pool_id IS NULL AND storage_id = ?", candidate.StorageID).
+			Update("storage_pool_id", candidate.PoolID).Error; err != nil {
+			return fmt.Errorf("backfill file storage pool for %s: %w", candidate.StorageID, err)
 		}
 	}
 	return nil

--- a/inits/Models_test.go
+++ b/inits/Models_test.go
@@ -157,6 +157,12 @@ func TestMigrateModelsBackfillsLegacyFileStorageID(t *testing.T) {
 	if !localPool.IsDefault || !localPool.System {
 		t.Fatalf("local storage pool = %#v", localPool)
 	}
+	if file.StoragePoolID == nil || *file.StoragePoolID != localPool.ID {
+		t.Fatalf("file storage pool = %v, want local pool %d", file.StoragePoolID, localPool.ID)
+	}
+	if deleted.StoragePoolID == nil || *deleted.StoragePoolID != localPool.ID {
+		t.Fatalf("deleted file storage pool = %v, want local pool %d", deleted.StoragePoolID, localPool.ID)
+	}
 	var membership models.StoragePoolMount
 	if err := db.Where("storage_pool_id = ? AND storage_mount_id = ?", localPool.ID, localMount.ID).First(&membership).Error; err != nil {
 		t.Fatalf("load local storage pool membership: %v", err)

--- a/logic/CreateFile.go
+++ b/logic/CreateFile.go
@@ -183,7 +183,7 @@ func (s *Service) CreateFileContext(ctx context.Context, fromFile *string, toFol
 	if err != nil {
 		return http.StatusInternalServerError, nil, false, err
 	}
-	storeID, releaseStore, err := s.publishUploadSource(ctx, userId, sourceKey, *fromFile)
+	storeID, storagePoolID, releaseStore, err := s.publishUploadSourceWithPool(ctx, userId, sourceKey, *fromFile)
 	if err != nil {
 		log.Printf("Failed to publish source file to storage pool: %v", err)
 		return http.StatusInternalServerError, nil, false, echo.ErrInternalServerError
@@ -209,19 +209,20 @@ func (s *Service) CreateFileContext(ctx context.Context, fromFile *string, toFol
 	// a transaction is necessary so the service Deleter wont mark an file as unreferenced by accident
 	if err := s.Deps.DB.Transaction(func(tx *gorm.DB) error {
 		dbFile = models.File{
-			UUID:         fileId,
-			Hash:         FileHash,
-			Thumbnail:    thumbnailFileName,
-			StorageID:    storeID,
-			StorageState: models.FileStorageAvailable,
-			SourceKey:    sourceKey.String(),
-			Folder:       fmt.Sprintf("%s/%s", s.Config().FolderVideoQualitysPriv, fileId),
-			UserID:       userId,
-			Height:       int64(videoHeight),
-			Width:        int64(videoWidth),
-			Duration:     videoDuration,
-			AvgFrameRate: avgFramerate,
-			Size:         fileSize,
+			UUID:          fileId,
+			Hash:          FileHash,
+			Thumbnail:     thumbnailFileName,
+			StorageID:     storeID,
+			StoragePoolID: &storagePoolID,
+			StorageState:  models.FileStorageAvailable,
+			SourceKey:     sourceKey.String(),
+			Folder:        fmt.Sprintf("%s/%s", s.Config().FolderVideoQualitysPriv, fileId),
+			UserID:        userId,
+			Height:        int64(videoHeight),
+			Width:         int64(videoWidth),
+			Duration:      videoDuration,
+			AvgFrameRate:  avgFramerate,
+			Size:          fileSize,
 		}
 		if err := tx.Create(&dbFile).Error; err != nil {
 			return err

--- a/logic/GetThumbnailData.go
+++ b/logic/GetThumbnailData.go
@@ -10,6 +10,7 @@ import (
 type ThumbnailObject struct {
 	FileUUID string
 	StoreID  string
+	PoolID   uint
 	UserID   uint
 	FileID   uint
 }
@@ -53,7 +54,15 @@ func (s *Service) ResolveThumbnailObject(fileName string, UUID string) (status i
 	return http.StatusOK, ThumbnailObject{
 		FileUUID: dbLink.File.UUID,
 		StoreID:  dbLink.File.StorageID,
+		PoolID:   valueOrZeroUint(dbLink.File.StoragePoolID),
 		UserID:   dbLink.UserID,
 		FileID:   dbLink.FileID,
 	}, nil
+}
+
+func valueOrZeroUint(value *uint) uint {
+	if value == nil {
+		return 0
+	}
+	return *value
 }

--- a/logic/StorageAdmin.go
+++ b/logic/StorageAdmin.go
@@ -55,7 +55,23 @@ type StoragePoolResponse struct {
 	IsDefault         bool
 	System            bool
 	MountIDs          []uint
+	PrimaryMountIDs   []uint
+	CacheMounts       []StorageCacheMountResponse
 	UserOverrideCount int64
+}
+
+type StorageCacheMountResponse struct {
+	MountID        uint
+	MaxBytes       int64
+	UsedBytes      int64
+	EntryCount     int64
+	CapacityKnown  bool
+	CapacityTotal  uint64
+	CapacityFree   uint64
+	FreePercent    float64
+	MinimumFreePct int
+	LastError      string
+	LastErrorAt    *time.Time
 }
 
 type StorageAdminOverview struct {
@@ -68,9 +84,16 @@ type StorageAdminOverview struct {
 }
 
 type StoragePoolInput struct {
-	Name      string
-	MountIDs  []uint
-	IsDefault bool
+	Name            string
+	MountIDs        []uint
+	PrimaryMountIDs []uint
+	CacheMounts     []StorageCacheMountInput
+	IsDefault       bool
+}
+
+type StorageCacheMountInput struct {
+	MountID  uint
+	MaxBytes int64
 }
 
 type StorageReconnectResult struct {
@@ -156,11 +179,38 @@ func (s *Service) StorageAdminOverview() (StorageAdminOverview, error) {
 	}
 	poolResponses := make([]StoragePoolResponse, 0, len(pools))
 	for _, pool := range pools {
-		mountIDs := make([]uint, 0, len(pool.Members))
-		for _, member := range pool.Members {
-			mountIDs = append(mountIDs, member.StorageMountID)
+		primaryMountIDs := make([]uint, 0, len(pool.Members))
+		cacheMounts := make([]StorageCacheMountResponse, 0)
+		statsByMount := make(map[uint]StorageCacheMountResponse)
+		if s.Deps.MediaCache != nil {
+			stats, err := s.Deps.MediaCache.MembershipStats(context.Background(), pool.ID)
+			if err != nil {
+				return StorageAdminOverview{}, err
+			}
+			for _, stat := range stats {
+				statsByMount[stat.MountID] = StorageCacheMountResponse{
+					MountID: stat.MountID, MaxBytes: stat.MaxBytes, UsedBytes: stat.UsedBytes,
+					EntryCount: stat.EntryCount, CapacityKnown: stat.CapacityKnown,
+					CapacityTotal: stat.CapacityTotal, CapacityFree: stat.CapacityFree,
+					FreePercent: stat.FreePercent, MinimumFreePct: stat.MinimumFreePct,
+				}
+			}
 		}
-		sort.Slice(mountIDs, func(i, j int) bool { return mountIDs[i] < mountIDs[j] })
+		for _, member := range pool.Members {
+			if member.Role == models.StoragePoolMountCache {
+				cache := statsByMount[member.StorageMountID]
+				cache.MountID = member.StorageMountID
+				cache.MaxBytes = member.CacheMaxBytes
+				cache.MinimumFreePct = 10
+				cache.LastError = member.CacheLastError
+				cache.LastErrorAt = member.CacheLastErrorAt
+				cacheMounts = append(cacheMounts, cache)
+				continue
+			}
+			primaryMountIDs = append(primaryMountIDs, member.StorageMountID)
+		}
+		sort.Slice(primaryMountIDs, func(i, j int) bool { return primaryMountIDs[i] < primaryMountIDs[j] })
+		sort.Slice(cacheMounts, func(i, j int) bool { return cacheMounts[i].MountID < cacheMounts[j].MountID })
 		var userCount int64
 		if err := s.Deps.DB.Model(&models.User{}).Where("storage_pool_id = ?", pool.ID).Count(&userCount).Error; err != nil {
 			return StorageAdminOverview{}, err
@@ -171,7 +221,9 @@ func (s *Service) StorageAdminOverview() (StorageAdminOverview, error) {
 			Name:              pool.Name,
 			IsDefault:         pool.IsDefault,
 			System:            pool.System,
-			MountIDs:          mountIDs,
+			MountIDs:          primaryMountIDs,
+			PrimaryMountIDs:   primaryMountIDs,
+			CacheMounts:       cacheMounts,
 			UserOverrideCount: userCount,
 		})
 	}
@@ -667,6 +719,7 @@ func (s *Service) reconnectStorageFileBatch(ctx context.Context, mount models.St
 	if err != nil {
 		return err
 	}
+	storagePoolID := s.uniquePrimaryPoolForMount(mount.ID)
 	type scanResult struct {
 		fileID  uint
 		matched bool
@@ -713,12 +766,15 @@ func (s *Service) reconnectStorageFileBatch(ctx context.Context, mount models.St
 			matchedIDs = matchedIDs[:0]
 			return nil
 		}
+		updates := map[string]any{
+			"storage_id": mount.UUID, "storage_state": models.FileStorageAvailable,
+		}
+		if storagePoolID != nil {
+			updates["storage_pool_id"] = *storagePoolID
+		}
 		update := s.Deps.DB.Model(&models.File{}).
 			Where("id IN ? AND storage_state = ?", matchedIDs, models.FileStorageUnavailable).
-			Updates(map[string]any{
-				"storage_id":    mount.UUID,
-				"storage_state": models.FileStorageAvailable,
-			})
+			Updates(updates)
 		if update.Error != nil {
 			return update.Error
 		}
@@ -758,6 +814,16 @@ func (s *Service) reconnectStorageFileBatch(ctx context.Context, mount models.St
 		return err
 	}
 	return nil
+}
+
+func (s *Service) uniquePrimaryPoolForMount(mountID uint) *uint {
+	var poolIDs []uint
+	if err := s.Deps.DB.Model(&models.StoragePoolMount{}).
+		Where("storage_mount_id = ? AND role = ?", mountID, models.StoragePoolMountPrimary).
+		Order("storage_pool_id ASC").Pluck("storage_pool_id", &poolIDs).Error; err != nil || len(poolIDs) != 1 {
+		return nil
+	}
+	return &poolIDs[0]
 }
 
 func (s *Service) storageFileMatches(ctx context.Context, store storage.Store, file models.File) (bool, error) {
@@ -867,10 +933,23 @@ func (s *Service) saveStoragePool(pool *models.StoragePool, input StoragePoolInp
 			return err
 		}
 	}
-	mountIDs := uniqueUintValues(input.MountIDs)
-	if len(mountIDs) == 0 {
-		return errors.New("storage pool requires at least one mount")
+	primaryMountIDs := input.PrimaryMountIDs
+	if len(primaryMountIDs) == 0 {
+		primaryMountIDs = input.MountIDs
 	}
+	primaryMountIDs = uniqueUintValues(primaryMountIDs)
+	if len(primaryMountIDs) == 0 {
+		return errors.New("storage pool requires at least one primary mount")
+	}
+	cacheMounts, err := normalizeStorageCacheMounts(input.CacheMounts, primaryMountIDs)
+	if err != nil {
+		return err
+	}
+	mountIDs := append([]uint(nil), primaryMountIDs...)
+	for _, cache := range cacheMounts {
+		mountIDs = append(mountIDs, cache.MountID)
+	}
+	mountIDs = uniqueUintValues(mountIDs)
 	var mountCount int64
 	if err := s.Deps.DB.Model(&models.StorageMount{}).Where("id IN ?", mountIDs).Count(&mountCount).Error; err != nil {
 		return err
@@ -901,13 +980,47 @@ func (s *Service) saveStoragePool(pool *models.StoragePool, input StoragePoolInp
 		if err := tx.Where("storage_pool_id = ?", pool.ID).Delete(&models.StoragePoolMount{}).Error; err != nil {
 			return err
 		}
-		for _, mountID := range mountIDs {
-			if err := tx.Create(&models.StoragePoolMount{StoragePoolID: pool.ID, StorageMountID: mountID}).Error; err != nil {
+		for _, mountID := range primaryMountIDs {
+			if err := tx.Create(&models.StoragePoolMount{
+				StoragePoolID: pool.ID, StorageMountID: mountID, Role: models.StoragePoolMountPrimary,
+			}).Error; err != nil {
+				return err
+			}
+		}
+		for _, cache := range cacheMounts {
+			if err := tx.Create(&models.StoragePoolMount{
+				StoragePoolID: pool.ID, StorageMountID: cache.MountID,
+				Role: models.StoragePoolMountCache, CacheMaxBytes: cache.MaxBytes,
+			}).Error; err != nil {
 				return err
 			}
 		}
 		return nil
 	})
+}
+
+func normalizeStorageCacheMounts(values []StorageCacheMountInput, primaryMountIDs []uint) ([]StorageCacheMountInput, error) {
+	primary := make(map[uint]bool, len(primaryMountIDs))
+	for _, mountID := range primaryMountIDs {
+		primary[mountID] = true
+	}
+	seen := make(map[uint]bool, len(values))
+	result := make([]StorageCacheMountInput, 0, len(values))
+	for _, value := range values {
+		if value.MountID == 0 || seen[value.MountID] {
+			return nil, errors.New("each cache mount must be selected once")
+		}
+		if primary[value.MountID] {
+			return nil, errors.New("a mount cannot be primary storage and read cache in the same pool")
+		}
+		if value.MaxBytes <= 0 {
+			return nil, errors.New("cache size must be greater than zero")
+		}
+		seen[value.MountID] = true
+		result = append(result, value)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].MountID < result[j].MountID })
+	return result, nil
 }
 
 func (s *Service) SetDefaultStoragePool(poolID uint) error {
@@ -947,6 +1060,9 @@ func (s *Service) DeleteStoragePool(poolID uint) error {
 			}
 		}
 		if err := tx.Model(&models.User{}).Where("storage_pool_id = ?", pool.ID).Update("storage_pool_id", nil).Error; err != nil {
+			return err
+		}
+		if err := tx.Model(&models.File{}).Where("storage_pool_id = ?", pool.ID).Update("storage_pool_id", nil).Error; err != nil {
 			return err
 		}
 		if err := tx.Where("storage_pool_id = ?", pool.ID).Delete(&models.StoragePoolMount{}).Error; err != nil {

--- a/logic/StorageAdmin_test.go
+++ b/logic/StorageAdmin_test.go
@@ -307,6 +307,70 @@ func TestDeleteStoragePoolFallsBackToLocalAndClearsUserOverrides(t *testing.T) {
 	}
 }
 
+func TestStoragePoolAllowsBuiltInLocalMountAsDedicatedCache(t *testing.T) {
+	db := newStorageAdminTestDB(t)
+	localMount := models.StorageMount{
+		UUID: models.StorageMountLocalUUID, Name: "Local storage", Provider: models.StorageProviderLocal, Mounted: true, System: true,
+	}
+	remoteMount := models.StorageMount{UUID: "remote", Name: "Remote", Provider: models.StorageProviderS3, Mounted: true}
+	if err := db.Create(&localMount).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&remoteMount).Error; err != nil {
+		t.Fatal(err)
+	}
+	service := &Service{Deps: &app.Deps{DB: db}}
+	pool, err := service.CreateStoragePool(StoragePoolInput{
+		Name: "Remote with local cache", PrimaryMountIDs: []uint{remoteMount.ID},
+		CacheMounts: []StorageCacheMountInput{{MountID: localMount.ID, MaxBytes: 50 * 1024 * 1024}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var memberships []models.StoragePoolMount
+	if err := db.Where("storage_pool_id = ?", pool.ID).Order("storage_mount_id ASC").Find(&memberships).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(memberships) != 2 {
+		t.Fatalf("memberships=%#v", memberships)
+	}
+	roles := map[uint]models.StoragePoolMount{}
+	for _, membership := range memberships {
+		roles[membership.StorageMountID] = membership
+	}
+	if roles[remoteMount.ID].Role != models.StoragePoolMountPrimary {
+		t.Fatalf("remote role=%q", roles[remoteMount.ID].Role)
+	}
+	if roles[localMount.ID].Role != models.StoragePoolMountCache || roles[localMount.ID].CacheMaxBytes != 50*1024*1024 {
+		t.Fatalf("local cache membership=%#v", roles[localMount.ID])
+	}
+	overview, err := service.StorageAdminOverview()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var response *StoragePoolResponse
+	for index := range overview.Pools {
+		if overview.Pools[index].ID == pool.ID {
+			response = &overview.Pools[index]
+			break
+		}
+	}
+	if response == nil || len(response.PrimaryMountIDs) != 1 || response.PrimaryMountIDs[0] != remoteMount.ID {
+		t.Fatalf("pool overview=%#v", response)
+	}
+	if len(response.CacheMounts) != 1 || response.CacheMounts[0].MountID != localMount.ID ||
+		response.CacheMounts[0].MaxBytes != 50*1024*1024 || response.CacheMounts[0].MinimumFreePct != 10 {
+		t.Fatalf("cache overview=%#v", response.CacheMounts)
+	}
+	_, err = service.UpdateStoragePool(pool.ID, StoragePoolInput{
+		Name: pool.Name, PrimaryMountIDs: []uint{remoteMount.ID},
+		CacheMounts: []StorageCacheMountInput{{MountID: remoteMount.ID, MaxBytes: 1}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "cannot be primary") {
+		t.Fatalf("same-role validation error=%v", err)
+	}
+}
+
 func TestStorageAdminOverviewReportsRuntimeAvailability(t *testing.T) {
 	db := newStorageAdminTestDB(t)
 	localStore, err := storage.NewLocalStore(t.TempDir())

--- a/logic/StorageMigration.go
+++ b/logic/StorageMigration.go
@@ -613,6 +613,9 @@ func (s *Service) storageMigrationMounts(ctx context.Context, pool models.Storag
 	mounts := make([]StorageMigrationMountPreview, 0, len(pool.Members))
 	ids := make([]string, 0, len(pool.Members))
 	for _, member := range pool.Members {
+		if member.Role != models.StoragePoolMountPrimary {
+			continue
+		}
 		mount := member.StorageMount
 		if !mount.Mounted || strings.TrimSpace(mount.LastError) != "" {
 			return nil, nil, fmt.Errorf("%w: mount %s is not available", ErrStorageMigrationUnavailable, mount.Name)
@@ -629,6 +632,9 @@ func (s *Service) storageMigrationMounts(ctx context.Context, pool models.Storag
 			ID: mount.ID, UUID: mount.UUID, Name: mount.Name, Provider: mount.Provider, UsedBytes: usedBytes,
 		})
 		ids = append(ids, mount.UUID)
+	}
+	if len(ids) == 0 {
+		return nil, nil, fmt.Errorf("%w: pool %s has no primary mounts", ErrStorageMigrationUnavailable, pool.Name)
 	}
 	sort.Slice(mounts, func(i, j int) bool { return mounts[i].UUID < mounts[j].UUID })
 	sort.Strings(ids)

--- a/logic/StoragePlacement.go
+++ b/logic/StoragePlacement.go
@@ -20,17 +20,22 @@ type storagePlacement struct {
 // currently tracked by VideoCMS. The file keeps the actual selected mount ID,
 // so later pool edits never change where existing media is read from.
 func (s *Service) UploadStoreCandidates(userID uint) ([]string, error) {
+	_, candidates, err := s.uploadStoreCandidates(userID)
+	return candidates, err
+}
+
+func (s *Service) uploadStoreCandidates(userID uint) (uint, []string, error) {
 	if s == nil || s.Deps == nil || s.Deps.DB == nil || s.Deps.Storage == nil {
-		return nil, storage.ErrStoreNotConfigured
+		return 0, nil, storage.ErrStoreNotConfigured
 	}
 	var user struct {
 		StoragePoolID *uint
 	}
 	if err := s.Deps.DB.Model(&models.User{}).Select("storage_pool_id").First(&user, userID).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, errors.New("user not found")
+			return 0, nil, errors.New("user not found")
 		}
-		return nil, fmt.Errorf("load user storage pool: %w", err)
+		return 0, nil, fmt.Errorf("load user storage pool: %w", err)
 	}
 	poolID := uint(0)
 	if user.StoragePoolID != nil {
@@ -38,7 +43,7 @@ func (s *Service) UploadStoreCandidates(userID uint) ([]string, error) {
 	} else {
 		var defaultPool models.StoragePool
 		if err := s.Deps.DB.Where("is_default = ?", true).Order("id").First(&defaultPool).Error; err != nil {
-			return nil, fmt.Errorf("load default storage pool: %w", err)
+			return 0, nil, fmt.Errorf("load default storage pool: %w", err)
 		}
 		poolID = defaultPool.ID
 	}
@@ -52,12 +57,12 @@ func (s *Service) UploadStoreCandidates(userID uint) ([]string, error) {
 			END), 0) AS used_bytes`, models.FileStorageAvailable).
 		Joins("JOIN storage_mounts ON storage_mounts.id = pool_mounts.storage_mount_id").
 		Joins("LEFT JOIN files ON files.storage_id = storage_mounts.uuid").
-		Where("pool_mounts.storage_pool_id = ? AND storage_mounts.mounted = ? AND (storage_mounts.last_error IS NULL OR storage_mounts.last_error = '')", poolID, true).
+		Where("pool_mounts.storage_pool_id = ? AND pool_mounts.role = ? AND storage_mounts.mounted = ? AND (storage_mounts.last_error IS NULL OR storage_mounts.last_error = '')", poolID, models.StoragePoolMountPrimary, true).
 		Group("storage_mounts.id, storage_mounts.uuid").
 		Order("used_bytes ASC, storage_mounts.uuid ASC").
 		Scan(&placements).Error
 	if err != nil {
-		return nil, fmt.Errorf("select storage pool member: %w", err)
+		return 0, nil, fmt.Errorf("select storage pool member: %w", err)
 	}
 	candidates := make([]string, 0, len(placements))
 	for _, placement := range placements {
@@ -66,9 +71,9 @@ func (s *Service) UploadStoreCandidates(userID uint) ([]string, error) {
 		}
 	}
 	if len(candidates) == 0 {
-		return nil, errors.New("selected storage pool has no available mounts")
+		return 0, nil, errors.New("selected storage pool has no available primary mounts")
 	}
-	return candidates, nil
+	return poolID, candidates, nil
 }
 
 // publishUploadSource keeps the selected mount stable until its caller has
@@ -76,16 +81,21 @@ func (s *Service) UploadStoreCandidates(userID uint) ([]string, error) {
 // function, then marks that newly committed record unavailable with the rest
 // of the mount. Failed candidates are cleaned up before placement falls back.
 func (s *Service) publishUploadSource(ctx context.Context, userID uint, key storage.Key, localPath string) (string, func(), error) {
-	candidates, err := s.UploadStoreCandidates(userID)
+	storeID, _, release, err := s.publishUploadSourceWithPool(ctx, userID, key, localPath)
+	return storeID, release, err
+}
+
+func (s *Service) publishUploadSourceWithPool(ctx context.Context, userID uint, key storage.Key, localPath string) (string, uint, func(), error) {
+	poolID, candidates, err := s.uploadStoreCandidates(userID)
 	if err != nil {
-		return "", nil, err
+		return "", 0, nil, err
 	}
 	var publishErr error
 	for _, candidate := range candidates {
 		release := s.Deps.StorageLifecycle.ReadLock(candidate)
 		_, err := s.Deps.Storage.PublishFile(ctx, candidate, key, localPath, storage.PutOptions{})
 		if err == nil {
-			return candidate, release, nil
+			return candidate, poolID, release, nil
 		}
 		if store, storeErr := s.Deps.Storage.Store(candidate); storeErr == nil {
 			if cleanupErr := store.Delete(context.WithoutCancel(ctx), key); cleanupErr != nil {
@@ -95,5 +105,5 @@ func (s *Service) publishUploadSource(ctx context.Context, userID uint, key stor
 		release()
 		publishErr = errors.Join(publishErr, fmt.Errorf("%s: %w", candidate, err))
 	}
-	return "", nil, publishErr
+	return "", 0, nil, publishErr
 }

--- a/logic/StoragePlacement_test.go
+++ b/logic/StoragePlacement_test.go
@@ -36,7 +36,8 @@ func TestUploadStoreCandidatesUsesLeastTrackedBytesAndUserOverride(t *testing.T)
 	mountB := models.StorageMount{UUID: "mount-b", Name: "B", Provider: models.StorageProviderS3, Mounted: true}
 	mountC := models.StorageMount{UUID: "mount-c", Name: "C", Provider: models.StorageProviderS3, Mounted: true}
 	mountD := models.StorageMount{UUID: "mount-d", Name: "Unhealthy", Provider: models.StorageProviderS3, Mounted: true, LastError: "connection failed"}
-	for _, mount := range []*models.StorageMount{&mountA, &mountB, &mountC, &mountD} {
+	mountE := models.StorageMount{UUID: "mount-e", Name: "Built-in cache", Provider: models.StorageProviderLocal, Mounted: true, System: true}
+	for _, mount := range []*models.StorageMount{&mountA, &mountB, &mountC, &mountD, &mountE} {
 		if err := db.Create(mount).Error; err != nil {
 			t.Fatal(err)
 		}
@@ -53,6 +54,7 @@ func TestUploadStoreCandidatesUsesLeastTrackedBytesAndUserOverride(t *testing.T)
 		{StoragePoolID: defaultPool.ID, StorageMountID: mountA.ID},
 		{StoragePoolID: defaultPool.ID, StorageMountID: mountB.ID},
 		{StoragePoolID: defaultPool.ID, StorageMountID: mountD.ID},
+		{StoragePoolID: defaultPool.ID, StorageMountID: mountE.ID, Role: models.StoragePoolMountCache, CacheMaxBytes: 1024},
 		{StoragePoolID: overridePool.ID, StorageMountID: mountC.ID},
 	} {
 		if err := db.Create(&member).Error; err != nil {
@@ -78,7 +80,7 @@ func TestUploadStoreCandidatesUsesLeastTrackedBytesAndUserOverride(t *testing.T)
 	}
 
 	stores := map[string]storage.Store{}
-	for _, id := range []string{mountA.UUID, mountB.UUID, mountC.UUID, mountD.UUID} {
+	for _, id := range []string{mountA.UUID, mountB.UUID, mountC.UUID, mountD.UUID, mountE.UUID} {
 		store, err := storage.NewLocalStore(t.TempDir())
 		if err != nil {
 			t.Fatal(err)

--- a/mediacache/capture.go
+++ b/mediacache/capture.go
@@ -1,0 +1,75 @@
+package mediacache
+
+import (
+	"errors"
+	"io"
+	"os"
+	"sync"
+
+	"ch/kirari04/videocms/storage"
+)
+
+type captureBody struct {
+	source   storage.ReadSeekCloser
+	target   *os.File
+	expected int64
+	position int64
+	written  int64
+	started  bool
+	valid    bool
+	done     func(bool)
+	once     sync.Once
+	closeErr error
+}
+
+func newCaptureBody(source storage.ReadSeekCloser, target *os.File, expected int64, done func(bool)) *captureBody {
+	return &captureBody{source: source, target: target, expected: expected, valid: true, done: done}
+}
+
+func (r *captureBody) Read(buffer []byte) (int, error) {
+	count, readErr := r.source.Read(buffer)
+	if count > 0 {
+		if !r.started {
+			r.started = true
+			if r.position != 0 {
+				r.valid = false
+			}
+		}
+		if r.valid && r.position == r.written {
+			written, writeErr := r.target.Write(buffer[:count])
+			r.written += int64(written)
+			if writeErr != nil || written != count {
+				r.valid = false
+			}
+		} else {
+			r.valid = false
+		}
+		r.position += int64(count)
+	}
+	return count, readErr
+}
+
+func (r *captureBody) Seek(offset int64, whence int) (int64, error) {
+	position, err := r.source.Seek(offset, whence)
+	if err != nil {
+		return position, err
+	}
+	r.position = position
+	if r.started && position != r.written {
+		r.valid = false
+	}
+	return position, nil
+}
+
+func (r *captureBody) Close() error {
+	r.once.Do(func() {
+		r.closeErr = errors.Join(r.source.Close(), r.target.Close())
+		complete := r.closeErr == nil && r.valid && r.started && r.written == r.expected
+		if r.done != nil {
+			r.done(complete)
+		}
+	})
+	return r.closeErr
+}
+
+var _ io.ReadSeekCloser = (*captureBody)(nil)

--- a/mediacache/service.go
+++ b/mediacache/service.go
@@ -1,0 +1,775 @@
+package mediacache
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"ch/kirari04/videocms/background"
+	"ch/kirari04/videocms/models"
+	"ch/kirari04/videocms/storage"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+const (
+	MinimumFreePercent  = 10
+	recoveryFreePercent = 12
+	cacheHighWatermark  = 0.90
+	cacheLowWatermark   = 0.80
+	promotionTimeout    = 30 * time.Minute
+)
+
+var errCacheAdmissionSkipped = errors.New("cache admission skipped")
+var errCacheCaptureStale = fmt.Errorf("captured file changed: %w", errCacheAdmissionSkipped)
+
+func AdmissionSkipped(err error) bool {
+	return errors.Is(err, errCacheAdmissionSkipped)
+}
+
+type OpenRequest struct {
+	PoolID        uint
+	OriginMountID string
+	FileID        uint
+	Key           storage.Key
+}
+
+type PromotionPayload struct {
+	PoolID           uint               `json:"poolId"`
+	OriginMountID    string             `json:"originMountId"`
+	FileID           uint               `json:"fileId"`
+	FileCacheVersion uint64             `json:"fileCacheVersion"`
+	ObjectKey        string             `json:"objectKey"`
+	TargetMountID    uint               `json:"targetMountId"`
+	TargetMountIDs   []uint             `json:"targetMountIds,omitempty"`
+	TemporaryPath    string             `json:"temporaryPath"`
+	Info             storage.ObjectInfo `json:"info"`
+}
+
+type MembershipStats struct {
+	MountID        uint
+	MaxBytes       int64
+	UsedBytes      int64
+	EntryCount     int64
+	CapacityKnown  bool
+	CapacityTotal  uint64
+	CapacityFree   uint64
+	FreePercent    float64
+	MinimumFreePct int
+}
+
+type target struct {
+	MountID   uint
+	MountUUID string
+	MaxBytes  int64
+	UsedBytes int64
+}
+
+type Service struct {
+	db      *gorm.DB
+	storage *storage.Service
+	runtime *background.Runtime
+	logger  *log.Logger
+
+	mu                     sync.Mutex
+	active                 map[string]struct{}
+	closed                 bool
+	workers                sync.WaitGroup
+	reservedWorkspaceBytes int64
+
+	membershipMu    sync.Mutex
+	membershipLocks map[string]*sync.Mutex
+}
+
+func New(db *gorm.DB, stores *storage.Service, runtime *background.Runtime) *Service {
+	return &Service{
+		db: db, storage: stores, runtime: runtime, logger: log.Default(), active: make(map[string]struct{}),
+		membershipLocks: make(map[string]*sync.Mutex),
+	}
+}
+
+func (s *Service) Open(ctx context.Context, request OpenRequest) (*storage.Object, bool, error) {
+	if s == nil || s.db == nil || s.storage == nil || request.OriginMountID == "" || request.Key.IsZero() {
+		return nil, false, storage.ErrStoreNotConfigured
+	}
+	poolID := request.PoolID
+	if poolID == 0 {
+		poolID = s.resolvePoolID(ctx, request.OriginMountID)
+	}
+	if poolID != 0 {
+		if object, ok := s.openCached(ctx, poolID, request); ok {
+			return object, true, nil
+		}
+	}
+
+	origin, err := s.storage.StoreOrDefault(request.OriginMountID)
+	if err != nil {
+		return nil, false, err
+	}
+	object, err := origin.Open(ctx, request.Key)
+	if err != nil {
+		return nil, false, err
+	}
+	if poolID == 0 || request.FileID == 0 || object.Info.Size <= 0 {
+		return object, false, nil
+	}
+	fileCacheVersion, err := s.fileCacheVersion(ctx, request.FileID)
+	if err != nil {
+		return object, false, nil
+	}
+	targets, err := s.targets(ctx, poolID, request.OriginMountID, object.Info.Size)
+	if err != nil || len(targets) == 0 {
+		if err != nil {
+			s.logger.Printf("component=storage_cache event=target_resolution_failed pool=%d error=%q", poolID, err)
+		}
+		return object, false, nil
+	}
+	claimKey := cacheIdentity(poolID, request.OriginMountID, request.Key.String())
+	if !s.claim(claimKey) {
+		return object, false, nil
+	}
+	selected := targets[0]
+	releaseWorkspace, ok := s.reserveWorkspace(ctx, object.Info.Size)
+	if !ok {
+		s.release(claimKey)
+		return object, false, nil
+	}
+	temporary, cleanup, err := s.storage.Workspace().TempFile(ctx, "playback-cache", "")
+	if err != nil {
+		releaseWorkspace()
+		s.release(claimKey)
+		return object, false, nil
+	}
+	payload := PromotionPayload{
+		PoolID: poolID, OriginMountID: request.OriginMountID, FileID: request.FileID,
+		FileCacheVersion: fileCacheVersion, ObjectKey: request.Key.String(), TargetMountID: selected.MountID,
+		TargetMountIDs: targetMountIDs(targets), TemporaryPath: temporary.Name(), Info: object.Info,
+	}
+	object.Body = newCaptureBody(object.Body, temporary, object.Info.Size, func(complete bool) {
+		releaseWorkspace()
+		if !complete {
+			_ = cleanup()
+			s.release(claimKey)
+			return
+		}
+		s.promoteAsync(claimKey, payload, cleanup)
+	})
+	return object, false, nil
+}
+
+func (s *Service) openCached(ctx context.Context, poolID uint, request OpenRequest) (*storage.Object, bool) {
+	hash := objectKeyHash(request.Key.String())
+	var entry models.StorageCacheEntry
+	err := s.db.WithContext(ctx).
+		Joins("JOIN storage_pool_mounts AS cache_membership ON cache_membership.storage_pool_id = storage_cache_entries.storage_pool_id AND cache_membership.storage_mount_id = storage_cache_entries.cache_mount_id AND cache_membership.role = ?", models.StoragePoolMountCache).
+		Joins("JOIN files AS cache_file ON cache_file.id = storage_cache_entries.file_id AND cache_file.storage_cache_version = storage_cache_entries.file_cache_version AND cache_file.deleted_at IS NULL").
+		Where("storage_cache_entries.storage_pool_id = ? AND storage_cache_entries.origin_mount_id = ? AND storage_cache_entries.object_key_hash = ?", poolID, request.OriginMountID, hash).
+		First(&entry).Error
+	if err != nil {
+		return nil, false
+	}
+	var mount models.StorageMount
+	if err := s.db.WithContext(ctx).First(&mount, entry.CacheMountID).Error; err != nil || !mount.Mounted || mount.LastError != "" {
+		return nil, false
+	}
+	store, err := s.storage.Store(mount.UUID)
+	if err != nil {
+		return nil, false
+	}
+	key, err := storage.ParseKey(entry.CacheObjectKey)
+	if err != nil {
+		s.dropEntry(context.WithoutCancel(ctx), entry, false)
+		return nil, false
+	}
+	object, err := store.Open(ctx, key)
+	if err != nil {
+		if errors.Is(err, storage.ErrNotFound) {
+			s.dropEntry(context.WithoutCancel(ctx), entry, false)
+		}
+		return nil, false
+	}
+	if object.Info.Size != entry.Size {
+		_ = object.Body.Close()
+		s.dropEntry(context.WithoutCancel(ctx), entry, true)
+		return nil, false
+	}
+	object.Info.Key = request.Key
+	object.Info.Size = entry.Size
+	object.Info.ETag = entry.SourceETag
+	object.Info.ContentType = entry.ContentType
+	object.Info.CacheControl = entry.CacheControl
+	if entry.SourceModTime != nil {
+		object.Info.ModTime = *entry.SourceModTime
+	}
+	now := time.Now().UTC()
+	_ = s.db.WithContext(context.WithoutCancel(ctx)).Model(&models.StorageCacheEntry{}).
+		Where("id = ? AND last_accessed_at < ?", entry.ID, now.Add(-5*time.Minute)).
+		Update("last_accessed_at", now).Error
+	return object, true
+}
+
+func (s *Service) promoteAsync(claimKey string, payload PromotionPayload, cleanup func() error) {
+	s.mu.Lock()
+	if s.closed {
+		s.mu.Unlock()
+		_ = cleanup()
+		s.release(claimKey)
+		return
+	}
+	s.workers.Add(1)
+	s.mu.Unlock()
+	go func() {
+		defer s.workers.Done()
+		defer s.release(claimKey)
+		ctx, cancel := context.WithTimeout(context.Background(), promotionTimeout)
+		defer cancel()
+		err := s.Promote(ctx, payload)
+		if err == nil || errors.Is(err, errCacheAdmissionSkipped) {
+			_ = cleanup()
+			return
+		}
+		if s.enqueuePromotionRetry(payload, err) {
+			return
+		}
+		_ = cleanup()
+		s.recordMembershipError(payload.PoolID, payload.TargetMountID, err)
+		s.logger.Printf("component=storage_cache event=promotion_failed pool=%d mount=%d key=%q error=%q", payload.PoolID, payload.TargetMountID, payload.ObjectKey, err)
+	}()
+}
+
+func (s *Service) Promote(ctx context.Context, payload PromotionPayload) error {
+	targetIDs := uniqueTargetMountIDs(payload)
+	if payload.TemporaryPath == "" || payload.ObjectKey == "" || len(targetIDs) == 0 || payload.Info.Size <= 0 {
+		return errors.New("cache promotion payload is incomplete")
+	}
+	version, err := s.fileCacheVersion(ctx, payload.FileID)
+	if errors.Is(err, gorm.ErrRecordNotFound) || (err == nil && version != payload.FileCacheVersion) {
+		return errCacheAdmissionSkipped
+	}
+	if err != nil {
+		return err
+	}
+	var combined error
+	for _, targetMountID := range targetIDs {
+		if err := ctx.Err(); err != nil {
+			return errors.Join(combined, err)
+		}
+		err = s.promoteToTarget(ctx, payload, targetMountID)
+		if err == nil {
+			return nil
+		}
+		if errors.Is(err, errCacheCaptureStale) {
+			return errCacheAdmissionSkipped
+		}
+		if AdmissionSkipped(err) {
+			continue
+		}
+		s.recordMembershipError(payload.PoolID, targetMountID, err)
+		combined = errors.Join(combined, fmt.Errorf("cache mount %d: %w", targetMountID, err))
+	}
+	if combined != nil {
+		return combined
+	}
+	return errCacheAdmissionSkipped
+}
+
+func (s *Service) promoteToTarget(ctx context.Context, payload PromotionPayload, targetMountID uint) error {
+	unlock := s.lockMembership(payload.PoolID, targetMountID)
+	defer unlock()
+	var membership models.StoragePoolMount
+	if err := s.db.WithContext(ctx).
+		Where("storage_pool_id = ? AND storage_mount_id = ? AND role = ?", payload.PoolID, targetMountID, models.StoragePoolMountCache).
+		First(&membership).Error; err != nil {
+		return errCacheAdmissionSkipped
+	}
+	var mount models.StorageMount
+	if err := s.db.WithContext(ctx).First(&mount, targetMountID).Error; err != nil {
+		return err
+	}
+	if !mount.Mounted || mount.LastError != "" || mount.UUID == payload.OriginMountID {
+		return errCacheAdmissionSkipped
+	}
+	store, err := s.storage.Store(mount.UUID)
+	if err != nil {
+		return err
+	}
+	if err := s.pruneMembership(ctx, membership, store, payload.Info.Size); err != nil {
+		return err
+	}
+	if membership.CacheMaxBytes <= 0 || payload.Info.Size > membership.CacheMaxBytes {
+		return errCacheAdmissionSkipped
+	}
+	file, err := os.Open(payload.TemporaryPath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	cacheKey, err := s.cacheKey(payload.PoolID, payload.OriginMountID, payload.ObjectKey)
+	if err != nil {
+		return err
+	}
+	expected := payload.Info.Size
+	written, err := store.Put(ctx, cacheKey, file, storage.PutOptions{
+		ExpectedSize: &expected, ContentType: payload.Info.ContentType, CacheControl: payload.Info.CacheControl,
+	})
+	if err != nil {
+		_ = store.Delete(context.WithoutCancel(ctx), cacheKey)
+		return err
+	}
+	if written.Size != expected {
+		_ = store.Delete(context.WithoutCancel(ctx), cacheKey)
+		return fmt.Errorf("cache object size mismatch: wrote %d, expected %d", written.Size, expected)
+	}
+	now := time.Now().UTC()
+	modTime := payload.Info.ModTime
+	entry := models.StorageCacheEntry{
+		StoragePoolID: payload.PoolID, OriginMountID: payload.OriginMountID,
+		ObjectKeyHash: objectKeyHash(payload.ObjectKey), ObjectKey: payload.ObjectKey,
+		CacheMountID: targetMountID, CacheObjectKey: cacheKey.String(), FileID: payload.FileID,
+		FileCacheVersion: payload.FileCacheVersion,
+		Size:             expected, SourceETag: payload.Info.ETag, ContentType: payload.Info.ContentType,
+		CacheControl: payload.Info.CacheControl, SourceModTime: &modTime, LastAccessedAt: now,
+	}
+	if err := s.commitPromotion(context.WithoutCancel(ctx), &entry); err != nil {
+		_ = store.Delete(context.WithoutCancel(ctx), cacheKey)
+		return err
+	}
+	s.clearMembershipError(payload.PoolID, targetMountID)
+	return nil
+}
+
+func uniqueTargetMountIDs(payload PromotionPayload) []uint {
+	values := append([]uint(nil), payload.TargetMountIDs...)
+	if len(values) == 0 {
+		values = append(values, payload.TargetMountID)
+	}
+	seen := make(map[uint]bool, len(values))
+	result := make([]uint, 0, len(values))
+	for _, value := range values {
+		if value == 0 || seen[value] {
+			continue
+		}
+		seen[value] = true
+		result = append(result, value)
+	}
+	return result
+}
+
+func targetMountIDs(targets []target) []uint {
+	result := make([]uint, 0, len(targets))
+	for _, target := range targets {
+		result = append(result, target.MountID)
+	}
+	return result
+}
+
+func (s *Service) enqueuePromotionRetry(payload PromotionPayload, cause error) bool {
+	if s.runtime == nil {
+		return false
+	}
+	key := cacheIdentity(payload.PoolID, payload.OriginMountID, payload.ObjectKey) + ":" + objectKeyHash(payload.TemporaryPath)
+	job, _, err := s.runtime.Enqueue(context.Background(), background.JobSpec{
+		Kind: "storage.cache.fill", Visibility: background.VisibilityAdmin,
+		SubjectType: "storage_pool", SubjectID: fmt.Sprintf("%d", payload.PoolID),
+		IdempotencyKey: "storage-cache-retry:" + key,
+		Label:          "Retry playback cache fill", Tasks: []background.TaskSpec{{
+			Kind: "storage.cache.fill", Queue: background.QueueStorage, Phase: "Caching playback data",
+			PayloadVersion: 1, Payload: payload, DedupeKey: key, Priority: 5, Required: true, Weight: 1, MaxAttempts: 4,
+		}},
+	})
+	if err != nil {
+		s.logger.Printf("component=storage_cache event=retry_enqueue_failed error=%q original_error=%q", err, cause)
+		return false
+	}
+	return job != nil
+}
+
+func (s *Service) InvalidateFile(ctx context.Context, fileID uint) error {
+	if s == nil || s.db == nil || fileID == 0 {
+		return nil
+	}
+	var entries []models.StorageCacheEntry
+	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if err := tx.Unscoped().Model(&models.File{}).Where("id = ?", fileID).
+			UpdateColumn("storage_cache_version", gorm.Expr("storage_cache_version + 1")).Error; err != nil {
+			return err
+		}
+		if err := tx.Where("file_id = ?", fileID).Find(&entries).Error; err != nil {
+			return err
+		}
+		return tx.Where("file_id = ?", fileID).Delete(&models.StorageCacheEntry{}).Error
+	}); err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		s.deleteEntryObject(context.WithoutCancel(ctx), entry)
+	}
+	return nil
+}
+
+func (s *Service) Prune(ctx context.Context) error {
+	if s == nil || s.db == nil || s.storage == nil {
+		return nil
+	}
+	var memberships []models.StoragePoolMount
+	if err := s.db.WithContext(ctx).Where("role = ?", models.StoragePoolMountCache).Find(&memberships).Error; err != nil {
+		return err
+	}
+	var combined error
+	for _, membership := range memberships {
+		var mount models.StorageMount
+		if err := s.db.WithContext(ctx).First(&mount, membership.StorageMountID).Error; err != nil {
+			combined = errors.Join(combined, err)
+			continue
+		}
+		store, err := s.storage.Store(mount.UUID)
+		if err != nil {
+			continue
+		}
+		unlock := s.lockMembership(membership.StoragePoolID, membership.StorageMountID)
+		err = s.pruneMembership(ctx, membership, store, 0)
+		unlock()
+		if err != nil {
+			combined = errors.Join(combined, err)
+			s.recordMembershipError(membership.StoragePoolID, membership.StorageMountID, err)
+		} else {
+			s.clearMembershipError(membership.StoragePoolID, membership.StorageMountID)
+		}
+	}
+	if err := s.pruneOrphans(ctx); err != nil {
+		combined = errors.Join(combined, err)
+	}
+	if janitor, ok := s.storage.Workspace().(storage.WorkspaceJanitor); ok {
+		if err := janitor.CleanupTemporaryFiles(ctx, "playback-cache", time.Now().Add(-24*time.Hour)); err != nil {
+			combined = errors.Join(combined, err)
+		}
+	}
+	return combined
+}
+
+func (s *Service) MembershipStats(ctx context.Context, poolID uint) ([]MembershipStats, error) {
+	var memberships []models.StoragePoolMount
+	if err := s.db.WithContext(ctx).Where("storage_pool_id = ? AND role = ?", poolID, models.StoragePoolMountCache).Find(&memberships).Error; err != nil {
+		return nil, err
+	}
+	stats := make([]MembershipStats, 0, len(memberships))
+	for _, membership := range memberships {
+		row := MembershipStats{MountID: membership.StorageMountID, MaxBytes: membership.CacheMaxBytes, MinimumFreePct: MinimumFreePercent}
+		if err := s.db.WithContext(ctx).Model(&models.StorageCacheEntry{}).
+			Select("COALESCE(SUM(size), 0)").
+			Where("storage_pool_id = ? AND cache_mount_id = ?", poolID, membership.StorageMountID).
+			Scan(&row.UsedBytes).Error; err != nil {
+			return nil, err
+		}
+		if err := s.db.WithContext(ctx).Model(&models.StorageCacheEntry{}).
+			Where("storage_pool_id = ? AND cache_mount_id = ?", poolID, membership.StorageMountID).
+			Count(&row.EntryCount).Error; err != nil {
+			return nil, err
+		}
+		var mount models.StorageMount
+		if err := s.db.WithContext(ctx).First(&mount, membership.StorageMountID).Error; err == nil {
+			if store, err := s.storage.Store(mount.UUID); err == nil {
+				if reporter, ok := store.(storage.CapacityReporter); ok {
+					if capacity, err := reporter.Capacity(ctx); err == nil && capacity.Total > 0 {
+						row.CapacityKnown = true
+						row.CapacityTotal = capacity.Total
+						row.CapacityFree = capacity.Free
+						row.FreePercent = float64(capacity.Free) * 100 / float64(capacity.Total)
+					}
+				}
+			}
+		}
+		stats = append(stats, row)
+	}
+	return stats, nil
+}
+
+func (s *Service) Close() {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	s.closed = true
+	s.mu.Unlock()
+	s.workers.Wait()
+}
+
+func (s *Service) targets(ctx context.Context, poolID uint, originMountID string, incoming int64) ([]target, error) {
+	var rows []struct {
+		MountID   uint
+		MountUUID string
+		MaxBytes  int64
+		UsedBytes int64
+	}
+	err := s.db.WithContext(ctx).Table("storage_pool_mounts AS members").
+		Select("members.storage_mount_id AS mount_id, mounts.uuid AS mount_uuid, members.cache_max_bytes AS max_bytes, COALESCE(SUM(entries.size), 0) AS used_bytes").
+		Joins("JOIN storage_mounts AS mounts ON mounts.id = members.storage_mount_id").
+		Joins("LEFT JOIN storage_cache_entries AS entries ON entries.storage_pool_id = members.storage_pool_id AND entries.cache_mount_id = members.storage_mount_id AND entries.deleted_at IS NULL").
+		Where("members.storage_pool_id = ? AND members.role = ? AND members.cache_max_bytes > 0 AND mounts.mounted = ? AND (mounts.last_error IS NULL OR mounts.last_error = '') AND mounts.uuid <> ?", poolID, models.StoragePoolMountCache, true, originMountID).
+		Group("members.storage_mount_id, mounts.uuid, members.cache_max_bytes").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	result := make([]target, 0, len(rows))
+	for _, row := range rows {
+		if row.MaxBytes < incoming {
+			continue
+		}
+		if _, err := s.storage.Store(row.MountUUID); err == nil {
+			result = append(result, target(row))
+		}
+	}
+	sort.Slice(result, func(i, j int) bool {
+		left := float64(result[i].UsedBytes) / float64(result[i].MaxBytes)
+		right := float64(result[j].UsedBytes) / float64(result[j].MaxBytes)
+		if left == right {
+			return result[i].MountID < result[j].MountID
+		}
+		return left < right
+	})
+	return result, nil
+}
+
+func (s *Service) lockMembership(poolID, mountID uint) func() {
+	key := fmt.Sprintf("%d:%d", poolID, mountID)
+	s.membershipMu.Lock()
+	lock := s.membershipLocks[key]
+	if lock == nil {
+		lock = &sync.Mutex{}
+		s.membershipLocks[key] = lock
+	}
+	s.membershipMu.Unlock()
+	lock.Lock()
+	return lock.Unlock
+}
+
+func (s *Service) reserveWorkspace(ctx context.Context, incoming int64) (func(), bool) {
+	reporter, ok := s.storage.Workspace().(storage.CapacityReporter)
+	if !ok {
+		return func() {}, true
+	}
+	capacity, err := reporter.Capacity(ctx)
+	if err != nil || capacity.Total == 0 {
+		return func() {}, true
+	}
+	minimum := int64(capacity.Total * MinimumFreePercent / 100)
+	s.mu.Lock()
+	if s.closed || int64(capacity.Free)-s.reservedWorkspaceBytes-incoming < minimum {
+		s.mu.Unlock()
+		return nil, false
+	}
+	s.reservedWorkspaceBytes += incoming
+	s.mu.Unlock()
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			s.mu.Lock()
+			s.reservedWorkspaceBytes -= incoming
+			s.mu.Unlock()
+		})
+	}, true
+}
+
+func (s *Service) resolvePoolID(ctx context.Context, originMountID string) uint {
+	var row struct{ PoolID uint }
+	err := s.db.WithContext(ctx).Table("storage_pool_mounts AS primary_member").
+		Select("primary_member.storage_pool_id AS pool_id").
+		Joins("JOIN storage_mounts AS origin ON origin.id = primary_member.storage_mount_id").
+		Where("origin.uuid = ? AND primary_member.role = ? AND EXISTS (SELECT 1 FROM storage_pool_mounts cache_member WHERE cache_member.storage_pool_id = primary_member.storage_pool_id AND cache_member.role = ?)", originMountID, models.StoragePoolMountPrimary, models.StoragePoolMountCache).
+		Order("primary_member.storage_pool_id ASC").Limit(1).Scan(&row).Error
+	if err != nil {
+		return 0
+	}
+	return row.PoolID
+}
+
+func (s *Service) cacheKey(poolID uint, originMountID, objectKey string) (storage.Key, error) {
+	var pool models.StoragePool
+	if err := s.db.Select("uuid").First(&pool, poolID).Error; err != nil {
+		return storage.Key{}, err
+	}
+	return storage.ParseKey(fmt.Sprintf("cache/v1/%s/%s/%s", pool.UUID, originMountID, objectKeyHash(objectKey)))
+}
+
+func (s *Service) pruneMembership(ctx context.Context, membership models.StoragePoolMount, store storage.Store, incoming int64) error {
+	if membership.CacheMaxBytes <= 0 || incoming > membership.CacheMaxBytes {
+		return errCacheAdmissionSkipped
+	}
+	var used int64
+	if err := s.db.WithContext(ctx).Model(&models.StorageCacheEntry{}).
+		Select("COALESCE(SUM(size), 0)").
+		Where("storage_pool_id = ? AND cache_mount_id = ?", membership.StoragePoolID, membership.StorageMountID).
+		Scan(&used).Error; err != nil {
+		return err
+	}
+	bytesToFree := int64(0)
+	high := int64(float64(membership.CacheMaxBytes) * cacheHighWatermark)
+	if used+incoming > high {
+		low := int64(float64(membership.CacheMaxBytes) * cacheLowWatermark)
+		bytesToFree = used + incoming - low
+	}
+	if reporter, ok := store.(storage.CapacityReporter); ok {
+		capacity, err := reporter.Capacity(ctx)
+		if err == nil && capacity.Total > 0 {
+			minimum := int64(capacity.Total * MinimumFreePercent / 100)
+			recovery := int64(capacity.Total * recoveryFreePercent / 100)
+			projectedFree := int64(capacity.Free) - incoming
+			if projectedFree < minimum && recovery-projectedFree > bytesToFree {
+				bytesToFree = recovery - projectedFree
+			}
+		}
+	}
+	if bytesToFree <= 0 {
+		return nil
+	}
+	var entries []models.StorageCacheEntry
+	if err := s.db.WithContext(ctx).
+		Where("storage_pool_id = ? AND cache_mount_id = ?", membership.StoragePoolID, membership.StorageMountID).
+		Order("last_accessed_at ASC, id ASC").Find(&entries).Error; err != nil {
+		return err
+	}
+	var freed int64
+	for _, entry := range entries {
+		key, err := storage.ParseKey(entry.CacheObjectKey)
+		if err == nil {
+			if err := store.Delete(ctx, key); err != nil && !errors.Is(err, storage.ErrNotFound) {
+				return err
+			}
+		}
+		if err := s.db.WithContext(ctx).Delete(&entry).Error; err != nil {
+			return err
+		}
+		freed += entry.Size
+		if freed >= bytesToFree {
+			break
+		}
+	}
+	if freed < bytesToFree && incoming > 0 {
+		return errCacheAdmissionSkipped
+	}
+	return nil
+}
+
+func (s *Service) pruneOrphans(ctx context.Context) error {
+	var entries []models.StorageCacheEntry
+	err := s.db.WithContext(ctx).
+		Where("NOT EXISTS (SELECT 1 FROM storage_pool_mounts members WHERE members.storage_pool_id = storage_cache_entries.storage_pool_id AND members.storage_mount_id = storage_cache_entries.cache_mount_id AND members.role = ?) OR NOT EXISTS (SELECT 1 FROM files cache_file WHERE cache_file.id = storage_cache_entries.file_id AND cache_file.storage_cache_version = storage_cache_entries.file_cache_version AND cache_file.deleted_at IS NULL)", models.StoragePoolMountCache).
+		Find(&entries).Error
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		s.dropEntry(ctx, entry, true)
+	}
+	return nil
+}
+
+func (s *Service) dropEntry(ctx context.Context, entry models.StorageCacheEntry, deleteObject bool) {
+	_ = s.db.WithContext(ctx).Delete(&entry).Error
+	if !deleteObject {
+		return
+	}
+	s.deleteEntryObject(ctx, entry)
+}
+
+func (s *Service) deleteEntryObject(ctx context.Context, entry models.StorageCacheEntry) {
+	var mount models.StorageMount
+	if err := s.db.WithContext(ctx).First(&mount, entry.CacheMountID).Error; err != nil {
+		return
+	}
+	store, err := s.storage.Store(mount.UUID)
+	if err != nil {
+		return
+	}
+	key, err := storage.ParseKey(entry.CacheObjectKey)
+	if err == nil {
+		_ = store.Delete(ctx, key)
+	}
+}
+
+func (s *Service) fileCacheVersion(ctx context.Context, fileID uint) (uint64, error) {
+	var file struct{ StorageCacheVersion uint64 }
+	if err := s.db.WithContext(ctx).Model(&models.File{}).Select("storage_cache_version").First(&file, fileID).Error; err != nil {
+		return 0, err
+	}
+	return file.StorageCacheVersion, nil
+}
+
+func (s *Service) commitPromotion(ctx context.Context, entry *models.StorageCacheEntry) error {
+	return s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		// This no-op write serializes the generation check with invalidation. If
+		// invalidation commits first the row no longer matches; if this commits
+		// first, invalidation removes the newly inserted entry immediately after.
+		matched := tx.Model(&models.File{}).
+			Where("id = ? AND storage_cache_version = ?", entry.FileID, entry.FileCacheVersion).
+			UpdateColumn("storage_cache_version", gorm.Expr("storage_cache_version"))
+		if matched.Error != nil {
+			return matched.Error
+		}
+		if matched.RowsAffected != 1 {
+			return errCacheCaptureStale
+		}
+		return tx.Clauses(clause.OnConflict{
+			Columns: []clause.Column{{Name: "storage_pool_id"}, {Name: "origin_mount_id"}, {Name: "object_key_hash"}},
+			DoUpdates: clause.AssignmentColumns([]string{
+				"object_key", "cache_mount_id", "cache_object_key", "file_id", "file_cache_version", "size", "source_e_tag",
+				"content_type", "cache_control", "source_mod_time", "last_accessed_at", "updated_at", "deleted_at",
+			}),
+		}).Create(entry).Error
+	})
+}
+
+func (s *Service) claim(key string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return false
+	}
+	if _, exists := s.active[key]; exists {
+		return false
+	}
+	s.active[key] = struct{}{}
+	return true
+}
+
+func (s *Service) release(key string) {
+	s.mu.Lock()
+	delete(s.active, key)
+	s.mu.Unlock()
+}
+
+func (s *Service) recordMembershipError(poolID, mountID uint, err error) {
+	if s == nil || s.db == nil || err == nil {
+		return
+	}
+	message := strings.TrimSpace(err.Error())
+	if len(message) > 1000 {
+		message = message[:1000]
+	}
+	_ = s.db.Model(&models.StoragePoolMount{}).
+		Where("storage_pool_id = ? AND storage_mount_id = ?", poolID, mountID).
+		Updates(map[string]any{"cache_last_error": message, "cache_last_error_at": time.Now().UTC()}).Error
+}
+
+func (s *Service) clearMembershipError(poolID, mountID uint) {
+	_ = s.db.Model(&models.StoragePoolMount{}).
+		Where("storage_pool_id = ? AND storage_mount_id = ?", poolID, mountID).
+		Updates(map[string]any{"cache_last_error": "", "cache_last_error_at": nil}).Error
+}
+
+func objectKeyHash(value string) string {
+	digest := sha256.Sum256([]byte(value))
+	return fmt.Sprintf("%x", digest[:])
+}
+
+func cacheIdentity(poolID uint, originMountID, objectKey string) string {
+	return fmt.Sprintf("%d:%s:%s", poolID, originMountID, objectKeyHash(objectKey))
+}

--- a/mediacache/service_test.go
+++ b/mediacache/service_test.go
@@ -1,0 +1,347 @@
+package mediacache
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"ch/kirari04/videocms/models"
+	"ch/kirari04/videocms/storage"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+type cacheFixture struct {
+	db          *gorm.DB
+	stores      *storage.Service
+	cache       *Service
+	pool        models.StoragePool
+	origin      models.StorageMount
+	target      models.StorageMount
+	file        models.File
+	originStore storage.Store
+}
+
+func newCacheFixture(t *testing.T, maxBytes int64) cacheFixture {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+t.Name()+"?mode=memory&cache=shared"), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&models.StorageMount{}, &models.StoragePool{}, &models.StoragePoolMount{}, &models.StorageCacheEntry{}, &models.File{}); err != nil {
+		t.Fatal(err)
+	}
+	origin := models.StorageMount{UUID: "origin", Name: "Origin", Provider: models.StorageProviderLocal, Mounted: true}
+	target := models.StorageMount{UUID: "cache", Name: "Cache", Provider: models.StorageProviderLocal, Mounted: true, System: true}
+	pool := models.StoragePool{UUID: "pool", Name: "Remote uploads"}
+	if err := db.Create(&origin).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&target).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&pool).Error; err != nil {
+		t.Fatal(err)
+	}
+	file := models.File{UUID: "cache-file", StorageID: origin.UUID, StorageState: models.FileStorageAvailable}
+	if err := db.Create(&file).Error; err != nil {
+		t.Fatal(err)
+	}
+	for _, membership := range []models.StoragePoolMount{
+		{StoragePoolID: pool.ID, StorageMountID: origin.ID, Role: models.StoragePoolMountPrimary},
+		{StoragePoolID: pool.ID, StorageMountID: target.ID, Role: models.StoragePoolMountCache, CacheMaxBytes: maxBytes},
+	} {
+		if err := db.Create(&membership).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	originStore, err := storage.NewLocalStore(filepath.Join(t.TempDir(), "origin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	cacheStore, err := storage.NewLocalStore(filepath.Join(t.TempDir(), "cache"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace, err := storage.NewLocalWorkspace(filepath.Join(t.TempDir(), "scratch"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	stores, err := storage.NewServiceWithWorkspace("origin", storage.LegacyMediaLayout{}, workspace, map[string]storage.Store{
+		"origin": originStore, "cache": cacheStore,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache := New(db, stores, nil)
+	t.Cleanup(func() { cache.Close(); _ = stores.Close() })
+	return cacheFixture{db: db, stores: stores, cache: cache, pool: pool, origin: origin, target: target, file: file, originStore: originStore}
+}
+
+func TestReadThroughCachesCompletedPlaybackAndFallsBackToCache(t *testing.T) {
+	fixture := newCacheFixture(t, 1024*1024)
+	key, _ := storage.ParseKey("video/1080p/out1.ts")
+	body := []byte("playback-segment")
+	expected := int64(len(body))
+	if _, err := fixture.originStore.Put(context.Background(), key, bytesReader(body), storage.PutOptions{ExpectedSize: &expected}); err != nil {
+		t.Fatal(err)
+	}
+	object, hit, err := fixture.cache.Open(context.Background(), OpenRequest{
+		PoolID: fixture.pool.ID, OriginMountID: fixture.origin.UUID, FileID: fixture.file.ID, Key: key,
+	})
+	if err != nil || hit {
+		t.Fatalf("first open hit=%v err=%v", hit, err)
+	}
+	read, err := io.ReadAll(object.Body)
+	if err != nil || string(read) != string(body) {
+		t.Fatalf("first read=%q err=%v", read, err)
+	}
+	if err := object.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	waitForCacheEntries(t, fixture.db, 1)
+	if err := fixture.originStore.Delete(context.Background(), key); err != nil {
+		t.Fatal(err)
+	}
+
+	object, hit, err = fixture.cache.Open(context.Background(), OpenRequest{
+		PoolID: fixture.pool.ID, OriginMountID: fixture.origin.UUID, FileID: fixture.file.ID, Key: key,
+	})
+	if err != nil || !hit {
+		t.Fatalf("cached open hit=%v err=%v", hit, err)
+	}
+	read, err = io.ReadAll(object.Body)
+	if closeErr := object.Body.Close(); closeErr != nil {
+		t.Fatal(closeErr)
+	}
+	if err != nil || string(read) != string(body) {
+		t.Fatalf("cached read=%q err=%v", read, err)
+	}
+}
+
+func TestReadThroughDoesNotCachePartialRange(t *testing.T) {
+	fixture := newCacheFixture(t, 1024*1024)
+	key, _ := storage.ParseKey("video/1080p/out2.ts")
+	body := []byte("playback-segment")
+	expected := int64(len(body))
+	if _, err := fixture.originStore.Put(context.Background(), key, bytesReader(body), storage.PutOptions{ExpectedSize: &expected}); err != nil {
+		t.Fatal(err)
+	}
+	object, _, err := fixture.cache.Open(context.Background(), OpenRequest{
+		PoolID: fixture.pool.ID, OriginMountID: fixture.origin.UUID, FileID: fixture.file.ID, Key: key,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := object.Body.Seek(2, io.SeekStart); err != nil {
+		t.Fatal(err)
+	}
+	buffer := make([]byte, 4)
+	if _, err := object.Body.Read(buffer); err != nil && err != io.EOF {
+		t.Fatal(err)
+	}
+	if err := object.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var count int64
+	if err := fixture.db.Model(&models.StorageCacheEntry{}).Count(&count).Error; err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("partial request created %d cache entries", count)
+	}
+}
+
+func TestPromotionEvictsLeastRecentlyUsedEntriesBeforeQuota(t *testing.T) {
+	fixture := newCacheFixture(t, 100)
+	first := writePromotionFile(t, fixture, "video/first.ts", 50)
+	if err := fixture.cache.Promote(context.Background(), first); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(time.Millisecond)
+	second := writePromotionFile(t, fixture, "video/second.ts", 50)
+	if err := fixture.cache.Promote(context.Background(), second); err != nil {
+		t.Fatal(err)
+	}
+	var entries []models.StorageCacheEntry
+	if err := fixture.db.Order("id ASC").Find(&entries).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].ObjectKey != second.ObjectKey {
+		t.Fatalf("entries=%#v, want only newest object", entries)
+	}
+}
+
+func TestPromotionResurrectsAPreviouslyEvictedEntry(t *testing.T) {
+	fixture := newCacheFixture(t, 1024*1024)
+	first := writePromotionFile(t, fixture, "video/replayed.ts", 40)
+	first.Info.ETag = "first"
+	if err := fixture.cache.Promote(context.Background(), first); err != nil {
+		t.Fatal(err)
+	}
+	var entry models.StorageCacheEntry
+	if err := fixture.db.First(&entry).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := fixture.db.Delete(&entry).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	second := writePromotionFile(t, fixture, "video/replayed.ts", 48)
+	second.Info.ETag = "second"
+	if err := fixture.cache.Promote(context.Background(), second); err != nil {
+		t.Fatal(err)
+	}
+	var entries []models.StorageCacheEntry
+	if err := fixture.db.Find(&entries).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Size != 48 || entries[0].SourceETag != "second" {
+		t.Fatalf("resurrected entries = %#v", entries)
+	}
+}
+
+func TestPromotionCapturedBeforeInvalidationIsDiscarded(t *testing.T) {
+	fixture := newCacheFixture(t, 1024*1024)
+	payload := writePromotionFile(t, fixture, "video/stale.ts", 48)
+	if err := fixture.cache.InvalidateFile(context.Background(), fixture.file.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := fixture.cache.Promote(context.Background(), payload); !AdmissionSkipped(err) {
+		t.Fatalf("promotion error = %v, want admission skipped", err)
+	}
+	var count int64
+	if err := fixture.db.Model(&models.StorageCacheEntry{}).Count(&count).Error; err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("stale promotion created %d cache entries", count)
+	}
+}
+
+func TestCacheHitRequiresCurrentFileGeneration(t *testing.T) {
+	fixture := newCacheFixture(t, 1024*1024)
+	key, _ := storage.ParseKey("video/generation.ts")
+	body := []byte("current-origin")
+	expected := int64(len(body))
+	if _, err := fixture.originStore.Put(context.Background(), key, bytesReader(body), storage.PutOptions{ExpectedSize: &expected}); err != nil {
+		t.Fatal(err)
+	}
+	payload := writePromotionFile(t, fixture, key.String(), len(body))
+	if err := os.WriteFile(payload.TemporaryPath, body, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	payload.Info.Size = expected
+	if err := fixture.cache.Promote(context.Background(), payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := fixture.db.Model(&models.File{}).Where("id = ?", fixture.file.ID).
+		UpdateColumn("storage_cache_version", gorm.Expr("storage_cache_version + 1")).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	object, hit, err := fixture.cache.Open(context.Background(), OpenRequest{
+		PoolID: fixture.pool.ID, OriginMountID: fixture.origin.UUID, FileID: fixture.file.ID, Key: key,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hit {
+		t.Fatal("stale cache generation was served")
+	}
+	read, err := io.ReadAll(object.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := object.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if string(read) != string(body) {
+		t.Fatalf("origin read = %q", read)
+	}
+}
+
+func TestPromotionFallsBackToTheNextCacheMount(t *testing.T) {
+	fixture := newCacheFixture(t, 1024*1024)
+	unavailable := models.StorageMount{UUID: "cache-gone", Name: "Unavailable cache", Provider: models.StorageProviderLocal, Mounted: true}
+	if err := fixture.db.Create(&unavailable).Error; err != nil {
+		t.Fatal(err)
+	}
+	membership := models.StoragePoolMount{
+		StoragePoolID: fixture.pool.ID, StorageMountID: unavailable.ID,
+		Role: models.StoragePoolMountCache, CacheMaxBytes: 1024 * 1024,
+	}
+	if err := fixture.db.Create(&membership).Error; err != nil {
+		t.Fatal(err)
+	}
+	payload := writePromotionFile(t, fixture, "video/fallback.ts", 48)
+	payload.TargetMountID = unavailable.ID
+	payload.TargetMountIDs = []uint{unavailable.ID, fixture.target.ID}
+	if err := fixture.cache.Promote(context.Background(), payload); err != nil {
+		t.Fatal(err)
+	}
+	var entry models.StorageCacheEntry
+	if err := fixture.db.First(&entry).Error; err != nil {
+		t.Fatal(err)
+	}
+	if entry.CacheMountID != fixture.target.ID {
+		t.Fatalf("cache mount = %d, want fallback %d", entry.CacheMountID, fixture.target.ID)
+	}
+	if err := fixture.db.First(&membership, "storage_pool_id = ? AND storage_mount_id = ?", fixture.pool.ID, unavailable.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if membership.CacheLastError == "" {
+		t.Fatal("failed preferred cache did not retain a health error")
+	}
+}
+
+func writePromotionFile(t *testing.T, fixture cacheFixture, objectKey string, size int) PromotionPayload {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "capture")
+	data := make([]byte, size)
+	for index := range data {
+		data[index] = byte(index)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	key, _ := storage.ParseKey(objectKey)
+	return PromotionPayload{
+		PoolID: fixture.pool.ID, OriginMountID: fixture.origin.UUID, FileID: fixture.file.ID,
+		FileCacheVersion: fixture.file.StorageCacheVersion,
+		ObjectKey:        objectKey, TargetMountID: fixture.target.ID, TemporaryPath: path,
+		Info: storage.ObjectInfo{Key: key, Size: int64(size), ModTime: time.Now().UTC(), ContentType: "video/mp2t"},
+	}
+}
+
+func waitForCacheEntries(t *testing.T, db *gorm.DB, expected int64) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		var count int64
+		if err := db.Model(&models.StorageCacheEntry{}).Count(&count).Error; err == nil && count == expected {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("cache entry count did not reach %d", expected)
+}
+
+func bytesReader(value []byte) io.Reader {
+	return &sliceReader{value: value}
+}
+
+type sliceReader struct{ value []byte }
+
+func (r *sliceReader) Read(buffer []byte) (int, error) {
+	if len(r.value) == 0 {
+		return 0, io.EOF
+	}
+	count := copy(buffer, r.value)
+	r.value = r.value[count:]
+	return count, nil
+}

--- a/models/File.go
+++ b/models/File.go
@@ -2,26 +2,28 @@ package models
 
 type File struct {
 	Model
-	BackgroundJobID string `gorm:"size:36;index" json:"-"`
-	UUID            string
-	Hash            string `gorm:"size:128;" json:"-"`
-	Thumbnail       string
-	Size            int64
-	Duration        float64
-	AvgFrameRate    float64
-	Height          int64
-	Width           int64
-	StorageID       string `gorm:"size:64;index" json:"-"`
-	StorageState    string `gorm:"size:16;index;default:available"`
-	SourceKey       string `gorm:"size:1024" json:"-"`
-	Path            string `gorm:"size:120;" json:"-"`
-	Folder          string `gorm:"size:120;" json:"-"`
-	User            User   `json:"-"`
-	UserID          uint
-	Qualitys        []Quality  `json:"-"`
-	Subtitles       []Subtitle `json:"-"`
-	Audios          []Audio    `json:"-"`
-	Links           []Link     `json:"-"`
+	BackgroundJobID     string `gorm:"size:36;index" json:"-"`
+	UUID                string
+	Hash                string `gorm:"size:128;" json:"-"`
+	Thumbnail           string
+	Size                int64
+	Duration            float64
+	AvgFrameRate        float64
+	Height              int64
+	Width               int64
+	StorageID           string `gorm:"size:64;index" json:"-"`
+	StoragePoolID       *uint  `gorm:"index" json:"-"`
+	StorageCacheVersion uint64 `json:"-"`
+	StorageState        string `gorm:"size:16;index;default:available"`
+	SourceKey           string `gorm:"size:1024" json:"-"`
+	Path                string `gorm:"size:120;" json:"-"`
+	Folder              string `gorm:"size:120;" json:"-"`
+	User                User   `json:"-"`
+	UserID              uint
+	Qualitys            []Quality  `json:"-"`
+	Subtitles           []Subtitle `json:"-"`
+	Audios              []Audio    `json:"-"`
+	Links               []Link     `json:"-"`
 }
 
 type FileCreateValidation struct {

--- a/models/Storage.go
+++ b/models/Storage.go
@@ -12,6 +12,9 @@ const (
 
 	FileStorageAvailable   = "available"
 	FileStorageUnavailable = "unavailable"
+
+	StoragePoolMountPrimary = "primary"
+	StoragePoolMountCache   = "cache"
 )
 
 // StorageMount is a durable identity for a configured storage backend. A
@@ -41,10 +44,35 @@ type StoragePool struct {
 }
 
 type StoragePoolMount struct {
-	StoragePoolID  uint `gorm:"primaryKey"`
-	StorageMountID uint `gorm:"primaryKey"`
-	CreatedAt      *time.Time
+	StoragePoolID    uint   `gorm:"primaryKey"`
+	StorageMountID   uint   `gorm:"primaryKey"`
+	Role             string `gorm:"size:16;index;default:primary"`
+	CacheMaxBytes    int64
+	CacheLastError   string `gorm:"size:1000"`
+	CacheLastErrorAt *time.Time
+	CreatedAt        *time.Time
 
 	StoragePool  StoragePool  `gorm:"foreignKey:StoragePoolID" json:"-"`
 	StorageMount StorageMount `gorm:"foreignKey:StorageMountID" json:"-"`
+}
+
+// StorageCacheEntry records a disposable, verified playback copy. Files keep
+// their authoritative StorageID; deleting this row or its object must never
+// affect media ownership or availability.
+type StorageCacheEntry struct {
+	Model
+	StoragePoolID    uint   `gorm:"index;uniqueIndex:idx_storage_cache_origin"`
+	OriginMountID    string `gorm:"size:64;index;uniqueIndex:idx_storage_cache_origin"`
+	ObjectKeyHash    string `gorm:"size:64;uniqueIndex:idx_storage_cache_origin"`
+	ObjectKey        string `gorm:"type:text"`
+	CacheMountID     uint   `gorm:"index"`
+	CacheObjectKey   string `gorm:"type:text"`
+	FileID           uint   `gorm:"index"`
+	FileCacheVersion uint64
+	Size             int64
+	SourceETag       string `gorm:"size:255"`
+	ContentType      string `gorm:"size:255"`
+	CacheControl     string `gorm:"size:255"`
+	SourceModTime    *time.Time
+	LastAccessedAt   time.Time `gorm:"index"`
 }

--- a/services/BackgroundHandlers.go
+++ b/services/BackgroundHandlers.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"ch/kirari04/videocms/background"
+	"ch/kirari04/videocms/mediacache"
 	"ch/kirari04/videocms/models"
 	"ch/kirari04/videocms/services/tusupload"
 	"ch/kirari04/videocms/storage"
@@ -41,6 +42,8 @@ const (
 	taskStorageCleanup    = "storage.migration.cleanup"
 	taskStorageAbort      = "storage.migration.abort_cleanup"
 	taskStorageReconcile  = "maintenance.storage_migrations"
+	taskStorageCacheFill  = "storage.cache.fill"
+	taskStorageCachePrune = "maintenance.storage_cache"
 )
 
 type encodingTaskPayload struct {
@@ -105,6 +108,8 @@ func (w *WorkerGroup) RegisterBackgroundHandlers(runtime *background.Runtime, tu
 		taskStorageCleanup:    w.storageMigrationCleanupHandler,
 		taskStorageAbort:      w.storageMigrationAbortHandler(runtime),
 		taskStorageReconcile:  w.storageMigrationReconcileHandler(runtime),
+		taskStorageCacheFill:  w.storageCacheFillHandler,
+		taskStorageCachePrune: w.storageCachePruneHandler,
 	}
 	for _, kind := range sortedHandlerKinds(registrations) {
 		if err := runtime.Register(kind, registrations[kind]); err != nil {
@@ -121,6 +126,7 @@ func (w *WorkerGroup) RegisterBackgroundHandlers(runtime *background.Runtime, tu
 		maintenanceSchedule("resource-retention", taskResourceCleanup, time.Hour, false),
 		maintenanceSchedule("background-history-retention", taskJobRetention, 24*time.Hour, false),
 		maintenanceSchedule("storage-migration-reconciliation", taskStorageReconcile, time.Minute, true),
+		maintenanceSchedule("storage-cache-eviction", taskStorageCachePrune, time.Minute, true),
 	}
 	for _, schedule := range schedules {
 		if err := runtime.RegisterSchedule(schedule); err != nil {
@@ -152,9 +158,44 @@ func sortedHandlerKinds(handlers map[string]background.Handler) []string {
 		taskRemoteFetch, taskDownloadPrepare, taskContentDelete, taskAuditRecord, taskSourceCleanup,
 		taskDeletionReconcile, taskDownloadCleanup, taskUploadCleanup, taskAuditCleanup, taskResourceCleanup, taskJobRetention,
 		taskStorageMigration, taskStorageCleanup, taskStorageAbort,
-		taskStorageReconcile,
+		taskStorageReconcile, taskStorageCacheFill, taskStorageCachePrune,
 	}
 	return order
+}
+
+func (w *WorkerGroup) storageCacheFillHandler(ctx context.Context, task background.Task) (background.Result, error) {
+	if w.deps.MediaCache == nil {
+		return background.Result{Phase: "Cache disabled"}, nil
+	}
+	var payload mediacache.PromotionPayload
+	if err := decodeTaskPayload(task, &payload); err != nil {
+		return background.Result{}, err
+	}
+	if err := w.deps.MediaCache.Promote(ctx, payload); err != nil {
+		if mediacache.AdmissionSkipped(err) {
+			_ = os.Remove(payload.TemporaryPath)
+			return background.Result{Phase: "Cache admission skipped"}, nil
+		}
+		if ctx.Err() != nil {
+			return background.Result{}, ctx.Err()
+		}
+		if os.IsNotExist(err) {
+			return background.Result{}, background.Permanent("cache_source_missing", "The captured playback data is no longer available", err)
+		}
+		return background.Result{}, background.Transient("cache_fill_failed", "Playback data could not be added to the cache", err)
+	}
+	_ = os.Remove(payload.TemporaryPath)
+	return background.Result{Phase: "Playback data cached"}, nil
+}
+
+func (w *WorkerGroup) storageCachePruneHandler(ctx context.Context, _ background.Task) (background.Result, error) {
+	if w.deps.MediaCache == nil {
+		return background.Result{Phase: "Cache disabled"}, nil
+	}
+	if err := w.deps.MediaCache.Prune(ctx); err != nil {
+		return background.Result{}, background.Transient("cache_eviction_failed", "Old playback cache data could not be removed", err)
+	}
+	return background.Result{Phase: "Playback cache within limits"}, nil
 }
 
 func decodeTaskPayload(task background.Task, target any) error {
@@ -180,6 +221,11 @@ func (w *WorkerGroup) encodingHandler(ctx context.Context, task background.Task)
 		return background.Result{}, background.Permanent("source_unavailable", "The source video is no longer available", err)
 	}
 	legacyTask := EncodingTask{Type: payload.Type, FileID: file.ID, FileUUID: file.UUID, StorageID: file.StorageID, ID: payload.ID}
+	if w.deps.MediaCache != nil {
+		if err := w.deps.MediaCache.InvalidateFile(context.WithoutCancel(ctx), file.ID); err != nil {
+			return background.Result{}, background.Transient("cache_invalidation_failed", "Existing playback cache data could not be invalidated", err)
+		}
+	}
 	if err := w.markEncodingStarted(payload.Type, payload.ID, task.ID); err != nil {
 		return background.Result{}, background.Transient("state_update_failed", "The encoding state could not be updated", err)
 	}
@@ -191,9 +237,16 @@ func (w *WorkerGroup) encodingHandler(ctx context.Context, task background.Task)
 	}()
 	background.ReportProgress(encodeCtx, 0, "Starting encoder")
 	err := w.runEncode(encodeCtx, legacyTask)
+	var cacheErr error
+	if w.deps.MediaCache != nil {
+		cacheErr = w.deps.MediaCache.InvalidateFile(context.WithoutCancel(ctx), file.ID)
+	}
 	if encodeCtx.Err() != nil {
 		_ = w.resetEncodingProjection(payload.Type, payload.ID)
 		return background.Result{}, encodeCtx.Err()
+	}
+	if cacheErr != nil {
+		return background.Result{}, background.Transient("cache_invalidation_failed", "Playback cache data could not be refreshed after encoding", cacheErr)
 	}
 	if err != nil {
 		message := strings.ToLower(err.Error())

--- a/services/Deleter.go
+++ b/services/Deleter.go
@@ -133,6 +133,15 @@ func (w *WorkerGroup) runDeleter() error {
 			w.refreshDeletedFileMigrationProgress(migrationIDs, &deletionErrors)
 			continue
 		}
+		if w.deps.MediaCache != nil {
+			if err := w.deps.MediaCache.InvalidateFile(context.Background(), todo.ID); err != nil {
+				deletionErrors = append(deletionErrors, err)
+				skippingDeletion++
+				releaseFile()
+				w.refreshDeletedFileMigrationProgress(migrationIDs, &deletionErrors)
+				continue
+			}
+		}
 
 		if err := w.deleteStoredFileCopies(todo, migrationItems); err != nil {
 			log.Printf("Failed to delete stored data for file %d: %v", todo.ID, err)

--- a/services/StorageMigration.go
+++ b/services/StorageMigration.go
@@ -352,10 +352,18 @@ func (w *WorkerGroup) migrateStorageItem(ctx context.Context, migration models.S
 		return err
 	}
 	cutoverAt := time.Now().UTC()
+	if w.deps.MediaCache != nil {
+		if err = w.deps.MediaCache.InvalidateFile(context.WithoutCancel(ctx), file.ID); err != nil {
+			return fmt.Errorf("invalidate playback cache before cutover: %w", err)
+		}
+	}
 	err = w.deps.DB.WithContext(context.WithoutCancel(ctx)).Transaction(func(tx *gorm.DB) error {
 		updated := tx.Model(&models.File{}).
 			Where("id = ? AND storage_id = ? AND storage_state = ?", file.ID, item.SourceMountID, models.FileStorageAvailable).
-			Update("storage_id", item.DestinationMountID)
+			Updates(map[string]any{
+				"storage_id": item.DestinationMountID, "storage_pool_id": migration.DestinationPoolID,
+				"storage_cache_version": gorm.Expr("storage_cache_version + 1"),
+			})
 		if updated.Error != nil {
 			return updated.Error
 		}

--- a/services/StorageMigration_test.go
+++ b/services/StorageMigration_test.go
@@ -172,7 +172,7 @@ func TestStorageMigrationCopiesFinalChangesBeforeAtomicCutover(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = storageService.Close() })
 	worker := NewWorkerGroup(&app.Deps{DB: db, Storage: storageService}, nil)
-	migration := models.StorageMigration{UUID: "migration", Status: models.StorageMigrationRunning, FileCount: 1}
+	migration := models.StorageMigration{UUID: "migration", Status: models.StorageMigrationRunning, FileCount: 1, DestinationPoolID: 99}
 	if err := db.Create(&migration).Error; err != nil {
 		t.Fatal(err)
 	}
@@ -192,6 +192,9 @@ func TestStorageMigrationCopiesFinalChangesBeforeAtomicCutover(t *testing.T) {
 	}
 	if file.StorageID != "destination" {
 		t.Fatalf("storage id = %q, want destination", file.StorageID)
+	}
+	if file.StoragePoolID == nil || *file.StoragePoolID != migration.DestinationPoolID {
+		t.Fatalf("storage pool id = %v, want %d", file.StoragePoolID, migration.DestinationPoolID)
 	}
 	if err := db.First(&item, item.ID).Error; err != nil {
 		t.Fatal(err)

--- a/storage/local.go
+++ b/storage/local.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/shirou/gopsutil/v3/disk"
 )
 
 type LocalStore struct {
@@ -79,6 +81,20 @@ func (s *LocalStore) Open(ctx context.Context, key Key) (*Object, error) {
 		Body: file,
 		Info: localObjectInfo(key, info),
 	}, nil
+}
+
+func (s *LocalStore) Capacity(ctx context.Context) (CapacityInfo, error) {
+	if err := ctx.Err(); err != nil {
+		return CapacityInfo{}, err
+	}
+	if s == nil || s.root == "" {
+		return CapacityInfo{}, ErrStoreNotConfigured
+	}
+	usage, err := disk.Usage(s.root)
+	if err != nil {
+		return CapacityInfo{}, fmt.Errorf("inspect local storage capacity: %w", err)
+	}
+	return CapacityInfo{Total: usage.Total, Free: usage.Free}, nil
 }
 
 func (s *LocalStore) Put(ctx context.Context, key Key, src io.Reader, opts PutOptions) (ObjectInfo, error) {

--- a/storage/managed_store.go
+++ b/storage/managed_store.go
@@ -177,6 +177,19 @@ func (s *managedStore) Check(ctx context.Context) error {
 	return checker.Check(ctx)
 }
 
+func (s *managedStore) Capacity(ctx context.Context) (CapacityInfo, error) {
+	store, release, err := s.acquire()
+	if err != nil {
+		return CapacityInfo{}, err
+	}
+	defer release()
+	reporter, ok := store.(CapacityReporter)
+	if !ok {
+		return CapacityInfo{}, ErrCapacityUnavailable
+	}
+	return reporter.Capacity(ctx)
+}
+
 func (s *managedStore) Close() error {
 	s.retire()
 	return s.waitClosed()
@@ -214,3 +227,4 @@ func (r *managedReadSeekCloser) Close() error {
 var _ Store = (*managedStore)(nil)
 var _ Store = (*managedLocalPathStore)(nil)
 var _ HealthChecker = (*managedStore)(nil)
+var _ CapacityReporter = (*managedStore)(nil)

--- a/storage/sftp.go
+++ b/storage/sftp.go
@@ -205,6 +205,24 @@ func (s *SFTPStore) Open(ctx context.Context, key Key) (*Object, error) {
 	}, nil
 }
 
+func (s *SFTPStore) Capacity(ctx context.Context) (CapacityInfo, error) {
+	type capacityResult struct {
+		total uint64
+		free  uint64
+	}
+	result, _, err := withSFTPConnection(ctx, s, func(connection *sftpConnection) (capacityResult, error) {
+		usage, err := connection.client.StatVFS(connection.root)
+		if err != nil {
+			return capacityResult{}, fmt.Errorf("inspect SFTP storage capacity: %w", err)
+		}
+		return capacityResult{total: usage.TotalSpace(), free: usage.FreeSpace()}, nil
+	}, nil)
+	if err != nil {
+		return CapacityInfo{}, err
+	}
+	return CapacityInfo{Total: result.total, Free: result.free}, nil
+}
+
 func (s *SFTPStore) Put(ctx context.Context, key Key, src io.Reader, options PutOptions) (ObjectInfo, error) {
 	if err := ctx.Err(); err != nil {
 		return ObjectInfo{}, err

--- a/storage/store.go
+++ b/storage/store.go
@@ -8,6 +8,7 @@ import (
 )
 
 var ErrNotFound = errors.New("storage object not found")
+var ErrCapacityUnavailable = errors.New("storage capacity is unavailable")
 
 type ReadSeekCloser interface {
 	io.Reader
@@ -52,4 +53,16 @@ type Store interface {
 
 type HealthChecker interface {
 	Check(context.Context) error
+}
+
+type CapacityInfo struct {
+	Total uint64
+	Free  uint64
+}
+
+// CapacityReporter is optional. Cache eviction uses it to preserve free disk
+// on local and supporting remote filesystems without making it part of the
+// common object-store contract.
+type CapacityReporter interface {
+	Capacity(context.Context) (CapacityInfo, error)
 }

--- a/storage/workspace.go
+++ b/storage/workspace.go
@@ -7,6 +7,10 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
+	"time"
+
+	"github.com/shirou/gopsutil/v3/disk"
 )
 
 var safePurpose = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{0,62}$`)
@@ -17,6 +21,10 @@ var safeSuffix = regexp.MustCompile(`^(\.[a-z0-9]{1,16})?$`)
 type Workspace interface {
 	TempFile(ctx context.Context, purpose string, suffix string) (*os.File, func() error, error)
 	TempDir(ctx context.Context, purpose string) (string, func() error, error)
+}
+
+type WorkspaceJanitor interface {
+	CleanupTemporaryFiles(ctx context.Context, purpose string, olderThan time.Time) error
 }
 
 type LocalWorkspace struct {
@@ -68,6 +76,55 @@ func (w *LocalWorkspace) TempDir(ctx context.Context, purpose string) (string, f
 	}
 	return directory, func() error { return os.RemoveAll(directory) }, nil
 }
+
+func (w *LocalWorkspace) Capacity(ctx context.Context) (CapacityInfo, error) {
+	if err := ctx.Err(); err != nil {
+		return CapacityInfo{}, err
+	}
+	if w == nil || w.root == "" {
+		return CapacityInfo{}, ErrStoreNotConfigured
+	}
+	usage, err := disk.Usage(w.root)
+	if err != nil {
+		return CapacityInfo{}, fmt.Errorf("inspect workspace capacity: %w", err)
+	}
+	return CapacityInfo{Total: usage.Total, Free: usage.Free}, nil
+}
+
+func (w *LocalWorkspace) CleanupTemporaryFiles(ctx context.Context, purpose string, olderThan time.Time) error {
+	if err := validateWorkspaceRequest(ctx, w, purpose); err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(w.root)
+	if err != nil {
+		return err
+	}
+	prefix := "videocms-" + purpose + "-"
+	var combined error
+	for _, entry := range entries {
+		if err := ctx.Err(); err != nil {
+			return errors.Join(combined, err)
+		}
+		if entry.IsDir() || !strings.HasPrefix(entry.Name(), prefix) {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			combined = errors.Join(combined, err)
+			continue
+		}
+		if info.ModTime().After(olderThan) {
+			continue
+		}
+		if err := os.Remove(filepath.Join(w.root, entry.Name())); err != nil && !errors.Is(err, os.ErrNotExist) {
+			combined = errors.Join(combined, err)
+		}
+	}
+	return combined
+}
+
+var _ CapacityReporter = (*LocalWorkspace)(nil)
+var _ WorkspaceJanitor = (*LocalWorkspace)(nil)
 
 func validateWorkspaceRequest(ctx context.Context, workspace *LocalWorkspace, purpose string) error {
 	if err := ctx.Err(); err != nil {

--- a/storage/workspace_test.go
+++ b/storage/workspace_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"testing"
+	"time"
 )
 
 func TestLocalWorkspaceCreatesAndCleansScratchResources(t *testing.T) {
@@ -46,5 +47,47 @@ func TestLocalWorkspaceRejectsUnsafePurpose(t *testing.T) {
 	}
 	if _, _, err := workspace.TempFile(context.Background(), "../escape", ""); err == nil {
 		t.Fatal("TempFile() error = nil, want unsafe purpose rejection")
+	}
+}
+
+func TestLocalWorkspaceCleansOnlyExpiredPurposeFiles(t *testing.T) {
+	workspace, err := NewLocalWorkspace(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	expired, _, err := workspace.TempFile(context.Background(), "playback-cache", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	current, _, err := workspace.TempFile(context.Background(), "playback-cache", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	other, _, err := workspace.TempFile(context.Background(), "thumbnail-input", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, file := range []*os.File{expired, current, other} {
+		if err := file.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+	old := time.Now().Add(-48 * time.Hour)
+	if err := os.Chtimes(expired.Name(), old, old); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(other.Name(), old, old); err != nil {
+		t.Fatal(err)
+	}
+	if err := workspace.CleanupTemporaryFiles(context.Background(), "playback-cache", time.Now().Add(-24*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(expired.Name()); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expired capture remains: %v", err)
+	}
+	for _, path := range []string{current.Name(), other.Name()} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("unrelated or current file was removed: %v", err)
+		}
 	}
 }


### PR DESCRIPTION
Adds configurable cache mounts to storage pools with lazy read-through population, origin fallback, and automatic LRU cleanup under disk pressure.

Includes cache-aware lifecycle handling for uploads, encoding, deletion, and migration; admin background-job visibility; themed storage-pool controls; and self-hosting documentation.

Validation completed locally:
- go test ./...
- go vet ./...
- go test -race ./mediacache ./storage
- frontend production build
- docs production build
- desktop and mobile visual checks