### PR TITLE
fix(storage): make on-demand cache fills resilient

### DIFF
--- a/controllers/MediaFiles_test.go
+++ b/controllers/MediaFiles_test.go
@@ -5,6 +5,7 @@ import (
 	"ch/kirari04/videocms/auth"
 	"ch/kirari04/videocms/config"
 	"ch/kirari04/videocms/logic"
+	"ch/kirari04/videocms/mediacache"
 	"ch/kirari04/videocms/middlewares"
 	"ch/kirari04/videocms/models"
 	"ch/kirari04/videocms/storage"
@@ -14,6 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo/v4"
 	"gorm.io/driver/sqlite"
@@ -121,6 +123,105 @@ func TestGetVideoDataSupportsRangesAndTracksDeliveredBytes(t *testing.T) {
 	}
 	if traffic.StorageMountUUID != "local" || traffic.DeliverySource != models.TrafficDeliverySourceOrigin {
 		t.Fatalf("storage attribution = mount %q source %q, want local origin", traffic.StorageMountUUID, traffic.DeliverySource)
+	}
+}
+
+func TestGetVideoDataRangeFillsAndThenServesReadCache(t *testing.T) {
+	cacheRoot := t.TempDir()
+	originRoot := t.TempDir()
+	h := mediaTestHandlersWithStores(t, cacheRoot, map[string]string{
+		"local": cacheRoot, "archive": originRoot,
+	}, true)
+	if err := h.Deps.DB.AutoMigrate(
+		&models.StorageMount{}, &models.StoragePool{}, &models.StoragePoolMount{},
+		&models.StorageCacheEntry{}, &models.File{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	cacheMount := models.StorageMount{UUID: "local", Name: "Local cache", Provider: models.StorageProviderLocal, Mounted: true, System: true}
+	originMount := models.StorageMount{UUID: "archive", Name: "Remote origin", Provider: models.StorageProviderS3, Mounted: true}
+	pool := models.StoragePool{UUID: "remote-pool", Name: "Remote pool"}
+	for _, value := range []any{&cacheMount, &originMount, &pool} {
+		if err := h.Deps.DB.Create(value).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, membership := range []models.StoragePoolMount{
+		{StoragePoolID: pool.ID, StorageMountID: originMount.ID, Role: models.StoragePoolMountPrimary},
+		{StoragePoolID: pool.ID, StorageMountID: cacheMount.ID, Role: models.StoragePoolMountCache, CacheMaxBytes: 1024 * 1024},
+	} {
+		if err := h.Deps.DB.Create(&membership).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	file := models.File{
+		UUID: "file-uuid", StorageID: originMount.UUID, StoragePoolID: &pool.ID,
+		StorageState: models.FileStorageAvailable,
+	}
+	if err := h.Deps.DB.Create(&file).Error; err != nil {
+		t.Fatal(err)
+	}
+	h.Deps.MediaCache = mediacache.New(h.Deps.DB, h.Deps.Storage, nil)
+	t.Cleanup(h.Deps.MediaCache.Close)
+	body := []byte("0123456789")
+	mustWriteFile(t, filepath.Join(originRoot, "file-uuid", "720p", "out0.ts"), body)
+
+	request := func(rangeHeader string) *httptest.ResponseRecorder {
+		t.Helper()
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/videos/qualitys/"+testLinkUUID+"/720p/out0.ts", nil)
+		if rangeHeader != "" {
+			req.Header.Set("Range", rangeHeader)
+		}
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetParamNames("UUID", "QUALITY", "FILE")
+		c.SetParamValues(testLinkUUID, "720p", "out0.ts")
+		c.Set(middlewares.MediaClaimsContextKey, &auth.MediaClaims{
+			LinkUUID: testLinkUUID, FileUUID: file.UUID, StorageID: originMount.UUID,
+			StoragePoolID: pool.ID, UserID: 1, FileID: file.ID, QualityIDs: map[string]uint{"720p": 3},
+		})
+		if err := h.GetVideoData(c); err != nil {
+			t.Fatalf("GetVideoData() error = %v", err)
+		}
+		return rec
+	}
+
+	first := request("bytes=2-5")
+	if first.Code != http.StatusPartialContent || first.Body.String() != "2345" {
+		t.Fatalf("first response = %d %q", first.Code, first.Body.String())
+	}
+	if status := first.Header().Get("X-VideoCMS-Cache"); status != mediacache.CacheStatusFilling {
+		t.Fatalf("first cache status = %q, want %q", status, mediacache.CacheStatusFilling)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		var count int64
+		if err := h.Deps.DB.Model(&models.StorageCacheEntry{}).Count(&count).Error; err == nil && count == 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	var entries int64
+	if err := h.Deps.DB.Model(&models.StorageCacheEntry{}).Count(&entries).Error; err != nil || entries != 1 {
+		t.Fatalf("cache entries = %d, err=%v", entries, err)
+	}
+	if err := os.Remove(filepath.Join(originRoot, "file-uuid", "720p", "out0.ts")); err != nil {
+		t.Fatal(err)
+	}
+	second := request("")
+	if second.Code != http.StatusOK || second.Body.String() != string(body) {
+		t.Fatalf("second response = %d %q", second.Code, second.Body.String())
+	}
+	if status := second.Header().Get("X-VideoCMS-Cache"); status != mediacache.CacheStatusHit {
+		t.Fatalf("second cache status = %q, want %q", status, mediacache.CacheStatusHit)
+	}
+	var traffic []models.TrafficLog
+	if err := h.Deps.DB.Order("id ASC").Find(&traffic).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(traffic) != 2 || traffic[0].DeliverySource != models.TrafficDeliverySourceOrigin || traffic[1].DeliverySource != models.TrafficDeliverySourceCache {
+		t.Fatalf("traffic attribution = %#v", traffic)
 	}
 }
 

--- a/controllers/MediaStorage.go
+++ b/controllers/MediaStorage.go
@@ -91,6 +91,9 @@ func (h *Handlers) serveMediaObject(c echo.Context, storeID string, key storage.
 	if object.Info.CacheControl != "" {
 		c.Response().Header().Set("Cache-Control", object.Info.CacheControl)
 	}
+	if delivery.CacheStatus != "" {
+		c.Response().Header().Set("X-VideoCMS-Cache", delivery.CacheStatus)
+	}
 
 	counter := &countingResponseWriter{ResponseWriter: c.Response().Writer}
 	http.ServeContent(counter, c.Request(), key.String(), object.Info.ModTime, object.Body)

--- a/mediacache/capture.go
+++ b/mediacache/capture.go
@@ -17,12 +17,18 @@ type captureBody struct {
 	written  int64
 	started  bool
 	valid    bool
-	done     func(bool)
+	done     func(captureOutcome)
 	once     sync.Once
 	closeErr error
 }
 
-func newCaptureBody(source storage.ReadSeekCloser, target *os.File, expected int64, done func(bool)) *captureBody {
+type captureOutcome struct {
+	Started  bool
+	Complete bool
+	Captured int64
+}
+
+func newCaptureBody(source storage.ReadSeekCloser, target *os.File, expected int64, done func(captureOutcome)) *captureBody {
 	return &captureBody{source: source, target: target, expected: expected, valid: true, done: done}
 }
 
@@ -66,7 +72,7 @@ func (r *captureBody) Close() error {
 		r.closeErr = errors.Join(r.source.Close(), r.target.Close())
 		complete := r.closeErr == nil && r.valid && r.started && r.written == r.expected
 		if r.done != nil {
-			r.done(complete)
+			r.done(captureOutcome{Started: r.started, Complete: complete, Captured: r.written})
 		}
 	})
 	return r.closeErr

--- a/mediacache/s3_integration_test.go
+++ b/mediacache/s3_integration_test.go
@@ -1,0 +1,151 @@
+package mediacache
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"ch/kirari04/videocms/models"
+	"ch/kirari04/videocms/storage"
+	"github.com/google/uuid"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func TestS3OriginPartialPlaybackFillsLocalCacheIntegration(t *testing.T) {
+	endpoint := os.Getenv("VIDEOCMS_S3_INTEGRATION_ENDPOINT")
+	if endpoint == "" {
+		t.Skip("VIDEOCMS_S3_INTEGRATION_ENDPOINT is not configured")
+	}
+	bucket := os.Getenv("VIDEOCMS_S3_INTEGRATION_BUCKET")
+	if bucket == "" {
+		t.Fatal("VIDEOCMS_S3_INTEGRATION_BUCKET is required")
+	}
+	region := os.Getenv("VIDEOCMS_S3_INTEGRATION_REGION")
+	if region == "" {
+		region = "us-east-1"
+	}
+	ctx := context.Background()
+	origin, err := storage.NewS3Store(ctx, storage.S3Options{
+		Bucket: bucket, Region: region, Endpoint: endpoint,
+		Prefix:          "videocms-cache-integration/" + uuid.NewString(),
+		AccessKeyID:     os.Getenv("VIDEOCMS_S3_INTEGRATION_ACCESS_KEY_ID"),
+		SecretAccessKey: os.Getenv("VIDEOCMS_S3_INTEGRATION_SECRET_ACCESS_KEY"),
+		UsePathStyle:    true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cacheStore, err := storage.NewLocalStore(filepath.Join(t.TempDir(), "cache"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspace, err := storage.NewLocalWorkspace(filepath.Join(t.TempDir(), "workspace"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	stores, err := storage.NewServiceWithWorkspace("s3", storage.LegacyMediaLayout{}, workspace, map[string]storage.Store{
+		"s3": origin, "cache": cacheStore,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = stores.Close() })
+
+	db, err := gorm.Open(sqlite.Open("file:"+uuid.NewString()+"?mode=memory&cache=shared"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(
+		&models.StorageMount{}, &models.StoragePool{}, &models.StoragePoolMount{},
+		&models.StorageCacheEntry{}, &models.File{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	originMount := models.StorageMount{UUID: "s3", Name: "S3 origin", Provider: models.StorageProviderS3, Mounted: true}
+	cacheMount := models.StorageMount{UUID: "cache", Name: "Local cache", Provider: models.StorageProviderLocal, Mounted: true}
+	pool := models.StoragePool{UUID: uuid.NewString(), Name: "S3 with local cache"}
+	for _, value := range []any{&originMount, &cacheMount, &pool} {
+		if err := db.Create(value).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, membership := range []models.StoragePoolMount{
+		{StoragePoolID: pool.ID, StorageMountID: originMount.ID, Role: models.StoragePoolMountPrimary},
+		{StoragePoolID: pool.ID, StorageMountID: cacheMount.ID, Role: models.StoragePoolMountCache, CacheMaxBytes: 1024 * 1024},
+	} {
+		if err := db.Create(&membership).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+	file := models.File{UUID: uuid.NewString(), StorageID: originMount.UUID, StoragePoolID: &pool.ID, StorageState: models.FileStorageAvailable}
+	if err := db.Create(&file).Error; err != nil {
+		t.Fatal(err)
+	}
+	service := New(db, stores, nil)
+	t.Cleanup(service.Close)
+
+	key, err := storage.ParseKey(file.UUID + "/720p/out0.ts")
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := bytes.Repeat([]byte("hls-segment-"), 256)
+	expected := int64(len(body))
+	if _, err := origin.Put(ctx, key, bytes.NewReader(body), storage.PutOptions{ExpectedSize: &expected, ContentType: "video/mp2t"}); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = origin.Delete(context.Background(), key) })
+
+	object, result, err := service.OpenWithResult(ctx, OpenRequest{
+		PoolID: pool.ID, OriginMountID: originMount.UUID, FileID: file.ID, Key: key,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.CacheStatus != CacheStatusFilling {
+		t.Fatalf("first cache status = %q", result.CacheStatus)
+	}
+	if _, err := object.Body.Seek(64, io.SeekStart); err != nil {
+		t.Fatal(err)
+	}
+	partial := make([]byte, 128)
+	if _, err := io.ReadFull(object.Body, partial); err != nil {
+		t.Fatal(err)
+	}
+	if err := object.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	waitForCacheEntries(t, db, 1)
+	if err := origin.Delete(ctx, key); err != nil {
+		t.Fatal(err)
+	}
+
+	object, result, err = service.OpenWithResult(ctx, OpenRequest{
+		PoolID: pool.ID, OriginMountID: originMount.UUID, FileID: file.ID, Key: key,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.CacheHit || result.CacheStatus != CacheStatusHit || result.MountUUID != cacheMount.UUID {
+		t.Fatalf("cache result = %#v", result)
+	}
+	read, err := io.ReadAll(object.Body)
+	closeErr := object.Body.Close()
+	if err != nil || closeErr != nil || !bytes.Equal(read, body) {
+		t.Fatalf("cached read bytes=%d err=%v close=%v", len(read), err, closeErr)
+	}
+
+	stats, err := service.MembershipStats(ctx, pool.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stats) != 1 || stats[0].EntryCount != 1 || stats[0].UsedBytes != expected {
+		t.Fatalf("cache stats = %#v", stats)
+	}
+}

--- a/mediacache/service.go
+++ b/mediacache/service.go
@@ -15,6 +15,7 @@ import (
 	"ch/kirari04/videocms/background"
 	"ch/kirari04/videocms/models"
 	"ch/kirari04/videocms/storage"
+	"github.com/google/uuid"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -44,10 +45,18 @@ type OpenRequest struct {
 // OpenResult identifies the mount that actually served the response. On a
 // miss this is the authoritative mount; on a hit it is the cache mount.
 type OpenResult struct {
-	CacheHit  bool
-	PoolID    uint
-	MountUUID string
+	CacheHit    bool
+	CacheStatus string
+	PoolID      uint
+	MountUUID   string
 }
+
+const (
+	CacheStatusBypass  = "BYPASS"
+	CacheStatusHit     = "HIT"
+	CacheStatusMiss    = "MISS"
+	CacheStatusFilling = "FILLING"
+)
 
 type PromotionPayload struct {
 	PoolID           uint               `json:"poolId"`
@@ -109,7 +118,7 @@ func (s *Service) Open(ctx context.Context, request OpenRequest) (*storage.Objec
 }
 
 func (s *Service) OpenWithResult(ctx context.Context, request OpenRequest) (*storage.Object, OpenResult, error) {
-	result := OpenResult{PoolID: request.PoolID, MountUUID: request.OriginMountID}
+	result := OpenResult{CacheStatus: CacheStatusBypass, PoolID: request.PoolID, MountUUID: request.OriginMountID}
 	if s == nil || s.db == nil || s.storage == nil || request.OriginMountID == "" || request.Key.IsZero() {
 		return nil, result, storage.ErrStoreNotConfigured
 	}
@@ -121,6 +130,7 @@ func (s *Service) OpenWithResult(ctx context.Context, request OpenRequest) (*sto
 	if poolID != 0 {
 		if object, mountUUID, ok := s.openCached(ctx, poolID, request); ok {
 			result.CacheHit = true
+			result.CacheStatus = CacheStatusHit
 			result.MountUUID = mountUUID
 			return object, result, nil
 		}
@@ -143,6 +153,9 @@ func (s *Service) OpenWithResult(ctx context.Context, request OpenRequest) (*sto
 	}
 	targets, err := s.targets(ctx, poolID, request.OriginMountID, object.Info.Size)
 	if err != nil || len(targets) == 0 {
+		if s.cacheConfigured(ctx, poolID) {
+			result.CacheStatus = CacheStatusMiss
+		}
 		if err != nil {
 			s.logger.Printf("component=storage_cache event=target_resolution_failed pool=%d error=%q", poolID, err)
 		}
@@ -150,35 +163,206 @@ func (s *Service) OpenWithResult(ctx context.Context, request OpenRequest) (*sto
 	}
 	claimKey := cacheIdentity(poolID, request.OriginMountID, request.Key.String())
 	if !s.claim(claimKey) {
+		result.CacheStatus = CacheStatusFilling
 		return object, result, nil
 	}
 	selected := targets[0]
+	payload := PromotionPayload{
+		PoolID: poolID, OriginMountID: request.OriginMountID, FileID: request.FileID,
+		FileCacheVersion: fileCacheVersion, ObjectKey: request.Key.String(), TargetMountID: selected.MountID,
+		TargetMountIDs: targetMountIDs(targets), Info: object.Info,
+	}
+	result.CacheStatus = CacheStatusFilling
 	releaseWorkspace, ok := s.reserveWorkspace(ctx, object.Info.Size)
 	if !ok {
-		s.release(claimKey)
+		s.fillWithoutResponseCapture(claimKey, payload)
 		return object, result, nil
 	}
 	temporary, cleanup, err := s.storage.Workspace().TempFile(ctx, "playback-cache", "")
 	if err != nil {
 		releaseWorkspace()
-		s.release(claimKey)
+		s.fillWithoutResponseCapture(claimKey, payload)
 		return object, result, nil
 	}
-	payload := PromotionPayload{
-		PoolID: poolID, OriginMountID: request.OriginMountID, FileID: request.FileID,
-		FileCacheVersion: fileCacheVersion, ObjectKey: request.Key.String(), TargetMountID: selected.MountID,
-		TargetMountIDs: targetMountIDs(targets), TemporaryPath: temporary.Name(), Info: object.Info,
-	}
-	object.Body = newCaptureBody(object.Body, temporary, object.Info.Size, func(complete bool) {
+	payload.TemporaryPath = temporary.Name()
+	object.Body = newCaptureBody(object.Body, temporary, object.Info.Size, func(outcome captureOutcome) {
 		releaseWorkspace()
-		if !complete {
+		if !outcome.Started {
 			_ = cleanup()
 			s.release(claimKey)
+			return
+		}
+		if !outcome.Complete {
+			// Browsers are allowed to cancel, seek, or range-read media. That must
+			// not make an on-demand cache permanently ineffective. Discard the
+			// partial capture and finish the requested object independently of the
+			// client connection.
+			_ = cleanup()
+			payload.TemporaryPath = ""
+			if s.enqueuePromotion(payload, "Fill requested playback data", background.VisibilitySystem, errors.New("client response did not consume the complete object")) {
+				s.release(claimKey)
+				return
+			}
+			s.promoteAsync(claimKey, payload, func() error { return nil })
 			return
 		}
 		s.promoteAsync(claimKey, payload, cleanup)
 	})
 	return object, result, nil
+}
+
+func (s *Service) cacheConfigured(ctx context.Context, poolID uint) bool {
+	if poolID == 0 {
+		return false
+	}
+	var count int64
+	err := s.db.WithContext(ctx).Model(&models.StoragePoolMount{}).
+		Where("storage_pool_id = ? AND role = ?", poolID, models.StoragePoolMountCache).
+		Limit(1).Count(&count).Error
+	return err == nil && count > 0
+}
+
+func (s *Service) fillWithoutResponseCapture(claimKey string, payload PromotionPayload) {
+	payload.TemporaryPath = ""
+	if s.enqueuePromotion(payload, "Fill requested playback data", background.VisibilitySystem, errors.New("response capture workspace is unavailable")) {
+		s.release(claimKey)
+		return
+	}
+	s.promoteAsync(claimKey, payload, func() error { return nil })
+}
+
+// Fill completes a cache promotion. A payload with TemporaryPath set promotes
+// a completed response capture. Without one, it performs a fresh on-demand
+// origin read so interrupted and range-based playback can still populate the
+// cache without depending on the lifetime of the HTTP request.
+func (s *Service) Fill(ctx context.Context, payload PromotionPayload) error {
+	if payload.TemporaryPath != "" {
+		return s.Promote(ctx, payload)
+	}
+	return s.captureFromOrigin(ctx, payload)
+}
+
+func (s *Service) captureFromOrigin(ctx context.Context, payload PromotionPayload) error {
+	if payload.OriginMountID == "" || payload.ObjectKey == "" || payload.FileID == 0 || payload.Info.Size <= 0 {
+		return errors.New("cache origin capture payload is incomplete")
+	}
+	key, err := storage.ParseKey(payload.ObjectKey)
+	if err != nil {
+		return err
+	}
+	if object, _, ok := s.openCached(ctx, payload.PoolID, OpenRequest{
+		PoolID: payload.PoolID, OriginMountID: payload.OriginMountID, FileID: payload.FileID, Key: key,
+	}); ok {
+		_ = object.Body.Close()
+		return nil
+	}
+	version, err := s.fileCacheVersion(ctx, payload.FileID)
+	if errors.Is(err, gorm.ErrRecordNotFound) || (err == nil && version != payload.FileCacheVersion) {
+		return errCacheAdmissionSkipped
+	}
+	if err != nil {
+		return err
+	}
+	var combined error
+	for _, targetMountID := range uniqueTargetMountIDs(payload) {
+		if err := ctx.Err(); err != nil {
+			return errors.Join(combined, err)
+		}
+		err = s.promoteOriginToTarget(ctx, payload, key, targetMountID)
+		if err == nil {
+			return nil
+		}
+		if errors.Is(err, errCacheCaptureStale) {
+			return errCacheAdmissionSkipped
+		}
+		if AdmissionSkipped(err) {
+			continue
+		}
+		s.recordMembershipError(payload.PoolID, targetMountID, err)
+		combined = errors.Join(combined, fmt.Errorf("cache mount %d: %w", targetMountID, err))
+	}
+	if combined != nil {
+		return combined
+	}
+	return errCacheAdmissionSkipped
+}
+
+func (s *Service) promoteOriginToTarget(ctx context.Context, payload PromotionPayload, objectKey storage.Key, targetMountID uint) error {
+	unlock := s.lockMembership(payload.PoolID, targetMountID)
+	defer unlock()
+	var membership models.StoragePoolMount
+	if err := s.db.WithContext(ctx).
+		Where("storage_pool_id = ? AND storage_mount_id = ? AND role = ?", payload.PoolID, targetMountID, models.StoragePoolMountCache).
+		First(&membership).Error; err != nil {
+		return errCacheAdmissionSkipped
+	}
+	var mount models.StorageMount
+	if err := s.db.WithContext(ctx).First(&mount, targetMountID).Error; err != nil {
+		return err
+	}
+	if !mount.Mounted || mount.LastError != "" || mount.UUID == payload.OriginMountID {
+		return errCacheAdmissionSkipped
+	}
+	target, err := s.storage.Store(mount.UUID)
+	if err != nil {
+		return err
+	}
+	if err := s.pruneMembership(ctx, membership, target, payload.Info.Size); err != nil {
+		return err
+	}
+	if membership.CacheMaxBytes <= 0 || payload.Info.Size > membership.CacheMaxBytes {
+		return errCacheAdmissionSkipped
+	}
+	origin, err := s.storage.StoreOrDefault(payload.OriginMountID)
+	if err != nil {
+		return err
+	}
+	object, err := origin.Open(ctx, objectKey)
+	if err != nil {
+		return err
+	}
+	if object.Info.Size != payload.Info.Size {
+		_ = object.Body.Close()
+		return fmt.Errorf("cache origin size changed from %d to %d: %w", payload.Info.Size, object.Info.Size, errCacheAdmissionSkipped)
+	}
+	if payload.Info.ETag != "" && object.Info.ETag != "" && payload.Info.ETag != object.Info.ETag {
+		_ = object.Body.Close()
+		return fmt.Errorf("cache origin entity changed: %w", errCacheAdmissionSkipped)
+	}
+	cacheKey, err := s.cacheKey(payload.PoolID, payload.OriginMountID, payload.ObjectKey)
+	if err != nil {
+		_ = object.Body.Close()
+		return err
+	}
+	expected := object.Info.Size
+	written, putErr := target.Put(ctx, cacheKey, object.Body, storage.PutOptions{
+		ExpectedSize: &expected, ContentType: object.Info.ContentType, CacheControl: object.Info.CacheControl,
+	})
+	closeErr := object.Body.Close()
+	if putErr != nil || closeErr != nil {
+		_ = target.Delete(context.WithoutCancel(ctx), cacheKey)
+		return errors.Join(putErr, closeErr)
+	}
+	if written.Size != expected {
+		_ = target.Delete(context.WithoutCancel(ctx), cacheKey)
+		return fmt.Errorf("cache object size mismatch: wrote %d, expected %d", written.Size, expected)
+	}
+	now := time.Now().UTC()
+	modTime := object.Info.ModTime
+	entry := models.StorageCacheEntry{
+		StoragePoolID: payload.PoolID, OriginMountID: payload.OriginMountID,
+		ObjectKeyHash: objectKeyHash(payload.ObjectKey), ObjectKey: payload.ObjectKey,
+		CacheMountID: targetMountID, CacheObjectKey: cacheKey.String(), FileID: payload.FileID,
+		FileCacheVersion: payload.FileCacheVersion,
+		Size:             expected, SourceETag: object.Info.ETag, ContentType: object.Info.ContentType,
+		CacheControl: object.Info.CacheControl, SourceModTime: &modTime, LastAccessedAt: now,
+	}
+	if err := s.commitPromotion(context.WithoutCancel(ctx), &entry); err != nil {
+		_ = target.Delete(context.WithoutCancel(ctx), cacheKey)
+		return err
+	}
+	s.clearMembershipError(payload.PoolID, targetMountID)
+	return nil
 }
 
 func (s *Service) openCached(ctx context.Context, poolID uint, request OpenRequest) (*storage.Object, string, bool) {
@@ -247,7 +431,7 @@ func (s *Service) promoteAsync(claimKey string, payload PromotionPayload, cleanu
 		defer s.release(claimKey)
 		ctx, cancel := context.WithTimeout(context.Background(), promotionTimeout)
 		defer cancel()
-		err := s.Promote(ctx, payload)
+		err := s.Fill(ctx, payload)
 		if err == nil || errors.Is(err, errCacheAdmissionSkipped) {
 			_ = cleanup()
 			return
@@ -388,15 +572,26 @@ func targetMountIDs(targets []target) []uint {
 }
 
 func (s *Service) enqueuePromotionRetry(payload PromotionPayload, cause error) bool {
+	return s.enqueuePromotion(payload, "Retry playback cache fill", background.VisibilityAdmin, cause)
+}
+
+func (s *Service) enqueuePromotion(payload PromotionPayload, label string, visibility string, cause error) bool {
 	if s.runtime == nil {
 		return false
 	}
-	key := cacheIdentity(payload.PoolID, payload.OriginMountID, payload.ObjectKey) + ":" + objectKeyHash(payload.TemporaryPath)
+	attemptKey := objectKeyHash(payload.TemporaryPath)
+	if payload.TemporaryPath == "" {
+		// A direct origin fill has no unique temporary path. Give each new
+		// playback-triggered retry cycle its own identity so a previously failed
+		// job cannot permanently suppress future attempts for the same object.
+		attemptKey = uuid.NewString()
+	}
+	key := cacheIdentity(payload.PoolID, payload.OriginMountID, payload.ObjectKey) + ":" + attemptKey
 	job, _, err := s.runtime.Enqueue(context.Background(), background.JobSpec{
-		Kind: "storage.cache.fill", Visibility: background.VisibilityAdmin,
+		Kind: "storage.cache.fill", Visibility: visibility,
 		SubjectType: "storage_pool", SubjectID: fmt.Sprintf("%d", payload.PoolID),
-		IdempotencyKey: "storage-cache-retry:" + key,
-		Label:          "Retry playback cache fill", Tasks: []background.TaskSpec{{
+		IdempotencyKey: "storage-cache-fill:" + key,
+		Label:          label, Tasks: []background.TaskSpec{{
 			Kind: "storage.cache.fill", Queue: background.QueueStorage, Phase: "Caching playback data",
 			PayloadVersion: 1, Payload: payload, DedupeKey: key, Priority: 5, Required: true, Weight: 1, MaxAttempts: 4,
 		}},

--- a/mediacache/service_test.go
+++ b/mediacache/service_test.go
@@ -2,12 +2,14 @@ package mediacache
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
 
+	"ch/kirari04/videocms/background"
 	"ch/kirari04/videocms/models"
 	"ch/kirari04/videocms/storage"
 	"gorm.io/driver/sqlite"
@@ -138,7 +140,7 @@ func TestOpenWithResultReportsTheMountThatServedPlayback(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if result.CacheHit || result.PoolID != fixture.pool.ID || result.MountUUID != fixture.origin.UUID {
+	if result.CacheHit || result.CacheStatus != CacheStatusFilling || result.PoolID != fixture.pool.ID || result.MountUUID != fixture.origin.UUID {
 		t.Fatalf("origin result = %#v", result)
 	}
 	if _, err := io.ReadAll(object.Body); err != nil {
@@ -156,12 +158,12 @@ func TestOpenWithResultReportsTheMountThatServedPlayback(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer object.Body.Close()
-	if !result.CacheHit || result.PoolID != fixture.pool.ID || result.MountUUID != fixture.target.UUID {
+	if !result.CacheHit || result.CacheStatus != CacheStatusHit || result.PoolID != fixture.pool.ID || result.MountUUID != fixture.target.UUID {
 		t.Fatalf("cache result = %#v", result)
 	}
 }
 
-func TestReadThroughDoesNotCachePartialRange(t *testing.T) {
+func TestReadThroughCompletesPartialRangeFromOrigin(t *testing.T) {
 	fixture := newCacheFixture(t, 1024*1024)
 	key, _ := storage.ParseKey("video/1080p/out2.ts")
 	body := []byte("playback-segment")
@@ -185,12 +187,116 @@ func TestReadThroughDoesNotCachePartialRange(t *testing.T) {
 	if err := object.Body.Close(); err != nil {
 		t.Fatal(err)
 	}
+	waitForCacheEntries(t, fixture.db, 1)
+	if err := fixture.originStore.Delete(context.Background(), key); err != nil {
+		t.Fatal(err)
+	}
+	object, hit, err := fixture.cache.Open(context.Background(), OpenRequest{
+		PoolID: fixture.pool.ID, OriginMountID: fixture.origin.UUID, FileID: fixture.file.ID, Key: key,
+	})
+	if err != nil || !hit {
+		t.Fatalf("cached open after partial range hit=%v err=%v", hit, err)
+	}
+	defer object.Body.Close()
+	read, err := io.ReadAll(object.Body)
+	if err != nil || string(read) != string(body) {
+		t.Fatalf("cached read=%q err=%v", read, err)
+	}
+}
+
+func TestReadThroughDoesNotFillForAnUnreadObject(t *testing.T) {
+	fixture := newCacheFixture(t, 1024*1024)
+	key, _ := storage.ParseKey("video/1080p/unread.ts")
+	body := []byte("playback-segment")
+	expected := int64(len(body))
+	if _, err := fixture.originStore.Put(context.Background(), key, bytesReader(body), storage.PutOptions{ExpectedSize: &expected}); err != nil {
+		t.Fatal(err)
+	}
+	object, result, err := fixture.cache.OpenWithResult(context.Background(), OpenRequest{
+		PoolID: fixture.pool.ID, OriginMountID: fixture.origin.UUID, FileID: fixture.file.ID, Key: key,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.CacheStatus != CacheStatusFilling {
+		t.Fatalf("cache status = %q, want %q", result.CacheStatus, CacheStatusFilling)
+	}
+	if err := object.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(20 * time.Millisecond)
 	var count int64
 	if err := fixture.db.Model(&models.StorageCacheEntry{}).Count(&count).Error; err != nil {
 		t.Fatal(err)
 	}
 	if count != 0 {
-		t.Fatalf("partial request created %d cache entries", count)
+		t.Fatalf("unread request created %d cache entries", count)
+	}
+}
+
+func TestDirectFillFailuresCanEnqueueANewRetryCycle(t *testing.T) {
+	fixture := newCacheFixture(t, 1024*1024)
+	if err := background.Migrate(fixture.db); err != nil {
+		t.Fatal(err)
+	}
+	fixture.cache.runtime = background.New(fixture.db, background.Options{})
+	payload := writePromotionFile(t, fixture, "video/retryable-range.ts", 48)
+	payload.TemporaryPath = ""
+	for attempt := 0; attempt < 2; attempt++ {
+		if !fixture.cache.enqueuePromotionRetry(payload, errors.New("origin read failed")) {
+			t.Fatalf("retry cycle %d was not enqueued", attempt+1)
+		}
+	}
+	var jobs int64
+	if err := fixture.db.Model(&background.Job{}).Where("kind = ?", "storage.cache.fill").Count(&jobs).Error; err != nil {
+		t.Fatal(err)
+	}
+	if jobs != 2 {
+		t.Fatalf("retry jobs = %d, want 2 independent cycles", jobs)
+	}
+}
+
+func TestInterruptedPlaybackHandsFillToDurableRuntime(t *testing.T) {
+	fixture := newCacheFixture(t, 1024*1024)
+	if err := background.Migrate(fixture.db); err != nil {
+		t.Fatal(err)
+	}
+	fixture.cache.runtime = background.New(fixture.db, background.Options{})
+	key, _ := storage.ParseKey("video/durable-range.ts")
+	body := []byte("playback-segment")
+	expected := int64(len(body))
+	if _, err := fixture.originStore.Put(context.Background(), key, bytesReader(body), storage.PutOptions{ExpectedSize: &expected}); err != nil {
+		t.Fatal(err)
+	}
+	object, _, err := fixture.cache.Open(context.Background(), OpenRequest{
+		PoolID: fixture.pool.ID, OriginMountID: fixture.origin.UUID, FileID: fixture.file.ID, Key: key,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := object.Body.Seek(3, io.SeekStart); err != nil {
+		t.Fatal(err)
+	}
+	buffer := make([]byte, 4)
+	if _, err := object.Body.Read(buffer); err != nil && err != io.EOF {
+		t.Fatal(err)
+	}
+	if err := object.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var job background.Job
+	if err := fixture.db.Where("kind = ?", "storage.cache.fill").First(&job).Error; err != nil {
+		t.Fatal(err)
+	}
+	if job.Visibility != background.VisibilitySystem || job.Label != "Fill requested playback data" {
+		t.Fatalf("durable fill job = %#v", job)
+	}
+	var count int64
+	if err := fixture.db.Model(&models.StorageCacheEntry{}).Count(&count).Error; err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("fill ran outside durable runtime: %d entries", count)
 	}
 }
 

--- a/services/BackgroundHandlers.go
+++ b/services/BackgroundHandlers.go
@@ -171,7 +171,7 @@ func (w *WorkerGroup) storageCacheFillHandler(ctx context.Context, task backgrou
 	if err := decodeTaskPayload(task, &payload); err != nil {
 		return background.Result{}, err
 	}
-	if err := w.deps.MediaCache.Promote(ctx, payload); err != nil {
+	if err := w.deps.MediaCache.Fill(ctx, payload); err != nil {
 		if mediacache.AdmissionSkipped(err) {
 			_ = os.Remove(payload.TemporaryPath)
 			return background.Result{Phase: "Cache admission skipped"}, nil
@@ -179,8 +179,8 @@ func (w *WorkerGroup) storageCacheFillHandler(ctx context.Context, task backgrou
 		if ctx.Err() != nil {
 			return background.Result{}, ctx.Err()
 		}
-		if os.IsNotExist(err) {
-			return background.Result{}, background.Permanent("cache_source_missing", "The captured playback data is no longer available", err)
+		if os.IsNotExist(err) || errors.Is(err, storage.ErrNotFound) {
+			return background.Result{}, background.Permanent("cache_source_missing", "The requested playback data is no longer available from primary storage", err)
 		}
 		return background.Result{}, background.Transient("cache_fill_failed", "Playback data could not be added to the cache", err)
 	}


### PR DESCRIPTION
## Summary
- keep cache fills alive when range playback, seeking, or client disconnects interrupt the response
- stream fallback fills directly from primary storage into the selected cache mount without backfilling unrelated media
- expose per-request cache state through the X-VideoCMS-Cache header and surface failed fills in Activity
- add service, controller, interruption, retry, and real Garage/S3 integration coverage
- update the dedicated self-hosting documentation revision

## Validation
- go test ./... -count=1
- go test -race ./mediacache ./controllers ./services -count=1
- go vet ./...
- Garage/S3 integration: partial playback fills local cache, origin deletion, subsequent cache hit
- npm run docs:build