### PR TITLE
fix(storage): cache legacy media generations

### DIFF
--- a/inits/Models.go
+++ b/inits/Models.go
@@ -89,6 +89,15 @@ func MigrateModels(gormDB *gorm.DB) error {
 	); err != nil {
 		return err
 	}
+	// The first cache release added this nullable column through AutoMigrate.
+	// Existing file rows therefore retained NULL while newly inserted rows used
+	// Go's zero value. A NULL generation makes otherwise valid legacy media
+	// silently ineligible for read caching, so normalize every row on upgrade.
+	if err := gormDB.Unscoped().Model(&models.File{}).
+		Where("storage_cache_version IS NULL").
+		UpdateColumn("storage_cache_version", 0).Error; err != nil {
+		return fmt.Errorf("failed to backfill file storage cache versions: %w", err)
+	}
 	if !gormDB.Migrator().HasIndex(&models.TrafficLog{}, "idx_traffic_logs_storage_window") {
 		if err := gormDB.Exec(`CREATE INDEX idx_traffic_logs_storage_window
 			ON traffic_logs (delivery_source, created_at)`).Error; err != nil {

--- a/inits/Models_test.go
+++ b/inits/Models_test.go
@@ -174,3 +174,36 @@ func TestMigrateModelsBackfillsLegacyFileStorageID(t *testing.T) {
 		t.Fatalf("load local storage pool membership: %v", err)
 	}
 }
+
+func TestMigrateModelsBackfillsNullStorageCacheVersions(t *testing.T) {
+	db, err := gorm.Open(
+		sqlite.Open("file:"+strings.ReplaceAll(t.Name(), "/", "_")+"?mode=memory&cache=shared"),
+		&gorm.Config{},
+	)
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	if err := db.AutoMigrate(&models.File{}); err != nil {
+		t.Fatalf("migrate pre-cache file: %v", err)
+	}
+	file := models.File{UUID: "pre-cache-file", StorageID: models.StorageMountLocalUUID}
+	if err := db.Create(&file).Error; err != nil {
+		t.Fatalf("create pre-cache file: %v", err)
+	}
+	if err := db.Exec("UPDATE files SET storage_cache_version = NULL WHERE id = ?", file.ID).Error; err != nil {
+		t.Fatalf("simulate nullable legacy generation: %v", err)
+	}
+
+	if err := MigrateModels(db); err != nil {
+		t.Fatalf("MigrateModels() error = %v", err)
+	}
+
+	var nullVersions int64
+	if err := db.Unscoped().Model(&models.File{}).
+		Where("storage_cache_version IS NULL").Count(&nullVersions).Error; err != nil {
+		t.Fatalf("count null cache versions: %v", err)
+	}
+	if nullVersions != 0 {
+		t.Fatalf("null storage cache versions = %d, want 0", nullVersions)
+	}
+}

--- a/mediacache/s3_integration_test.go
+++ b/mediacache/s3_integration_test.go
@@ -88,6 +88,11 @@ func TestS3OriginPartialPlaybackFillsLocalCacheIntegration(t *testing.T) {
 	if err := db.Create(&file).Error; err != nil {
 		t.Fatal(err)
 	}
+	// Production libraries created before read caching can carry a nullable
+	// generation. Exercise that upgrade path against a real S3 origin too.
+	if err := db.Exec("UPDATE files SET storage_cache_version = NULL WHERE id = ?", file.ID).Error; err != nil {
+		t.Fatal(err)
+	}
 	service := New(db, stores, nil)
 	t.Cleanup(service.Close)
 

--- a/mediacache/service.go
+++ b/mediacache/service.go
@@ -149,6 +149,10 @@ func (s *Service) OpenWithResult(ctx context.Context, request OpenRequest) (*sto
 	}
 	fileCacheVersion, err := s.fileCacheVersion(ctx, request.FileID)
 	if err != nil {
+		if s.cacheConfigured(ctx, poolID) {
+			result.CacheStatus = CacheStatusMiss
+		}
+		s.logger.Printf("component=storage_cache event=file_generation_lookup_failed file=%d pool=%d error=%q", request.FileID, poolID, err)
 		return object, result, nil
 	}
 	targets, err := s.targets(ctx, poolID, request.OriginMountID, object.Info.Size)
@@ -370,7 +374,7 @@ func (s *Service) openCached(ctx context.Context, poolID uint, request OpenReque
 	var entry models.StorageCacheEntry
 	err := s.db.WithContext(ctx).
 		Joins("JOIN storage_pool_mounts AS cache_membership ON cache_membership.storage_pool_id = storage_cache_entries.storage_pool_id AND cache_membership.storage_mount_id = storage_cache_entries.cache_mount_id AND cache_membership.role = ?", models.StoragePoolMountCache).
-		Joins("JOIN files AS cache_file ON cache_file.id = storage_cache_entries.file_id AND cache_file.storage_cache_version = storage_cache_entries.file_cache_version AND cache_file.deleted_at IS NULL").
+		Joins("JOIN files AS cache_file ON cache_file.id = storage_cache_entries.file_id AND COALESCE(cache_file.storage_cache_version, 0) = storage_cache_entries.file_cache_version AND cache_file.deleted_at IS NULL").
 		Where("storage_cache_entries.storage_pool_id = ? AND storage_cache_entries.origin_mount_id = ? AND storage_cache_entries.object_key_hash = ?", poolID, request.OriginMountID, hash).
 		First(&entry).Error
 	if err != nil {
@@ -610,7 +614,7 @@ func (s *Service) InvalidateFile(ctx context.Context, fileID uint) error {
 	var entries []models.StorageCacheEntry
 	if err := s.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.Unscoped().Model(&models.File{}).Where("id = ?", fileID).
-			UpdateColumn("storage_cache_version", gorm.Expr("storage_cache_version + 1")).Error; err != nil {
+			UpdateColumn("storage_cache_version", gorm.Expr("COALESCE(storage_cache_version, 0) + 1")).Error; err != nil {
 			return err
 		}
 		if err := tx.Where("file_id = ?", fileID).Find(&entries).Error; err != nil {
@@ -873,7 +877,7 @@ func (s *Service) pruneMembership(ctx context.Context, membership models.Storage
 func (s *Service) pruneOrphans(ctx context.Context) error {
 	var entries []models.StorageCacheEntry
 	err := s.db.WithContext(ctx).
-		Where("NOT EXISTS (SELECT 1 FROM storage_pool_mounts members WHERE members.storage_pool_id = storage_cache_entries.storage_pool_id AND members.storage_mount_id = storage_cache_entries.cache_mount_id AND members.role = ?) OR NOT EXISTS (SELECT 1 FROM files cache_file WHERE cache_file.id = storage_cache_entries.file_id AND cache_file.storage_cache_version = storage_cache_entries.file_cache_version AND cache_file.deleted_at IS NULL)", models.StoragePoolMountCache).
+		Where("NOT EXISTS (SELECT 1 FROM storage_pool_mounts members WHERE members.storage_pool_id = storage_cache_entries.storage_pool_id AND members.storage_mount_id = storage_cache_entries.cache_mount_id AND members.role = ?) OR NOT EXISTS (SELECT 1 FROM files cache_file WHERE cache_file.id = storage_cache_entries.file_id AND COALESCE(cache_file.storage_cache_version, 0) = storage_cache_entries.file_cache_version AND cache_file.deleted_at IS NULL)", models.StoragePoolMountCache).
 		Find(&entries).Error
 	if err != nil {
 		return err
@@ -909,7 +913,9 @@ func (s *Service) deleteEntryObject(ctx context.Context, entry models.StorageCac
 
 func (s *Service) fileCacheVersion(ctx context.Context, fileID uint) (uint64, error) {
 	var file struct{ StorageCacheVersion uint64 }
-	if err := s.db.WithContext(ctx).Model(&models.File{}).Select("storage_cache_version").First(&file, fileID).Error; err != nil {
+	if err := s.db.WithContext(ctx).Model(&models.File{}).
+		Select("COALESCE(storage_cache_version, 0) AS storage_cache_version").
+		First(&file, fileID).Error; err != nil {
 		return 0, err
 	}
 	return file.StorageCacheVersion, nil
@@ -921,8 +927,8 @@ func (s *Service) commitPromotion(ctx context.Context, entry *models.StorageCach
 		// invalidation commits first the row no longer matches; if this commits
 		// first, invalidation removes the newly inserted entry immediately after.
 		matched := tx.Model(&models.File{}).
-			Where("id = ? AND storage_cache_version = ?", entry.FileID, entry.FileCacheVersion).
-			UpdateColumn("storage_cache_version", gorm.Expr("storage_cache_version"))
+			Where("id = ? AND COALESCE(storage_cache_version, 0) = ?", entry.FileID, entry.FileCacheVersion).
+			UpdateColumn("storage_cache_version", gorm.Expr("COALESCE(storage_cache_version, 0)"))
 		if matched.Error != nil {
 			return matched.Error
 		}

--- a/mediacache/service_test.go
+++ b/mediacache/service_test.go
@@ -125,6 +125,36 @@ func TestReadThroughCachesCompletedPlaybackAndFallsBackToCache(t *testing.T) {
 	}
 }
 
+func TestReadThroughCachesLegacyFileWithNullGeneration(t *testing.T) {
+	fixture := newCacheFixture(t, 1024*1024)
+	if err := fixture.db.Exec("UPDATE files SET storage_cache_version = NULL WHERE id = ?", fixture.file.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	key, _ := storage.ParseKey("video/1080p/legacy.ts")
+	body := []byte("legacy-playback-segment")
+	expected := int64(len(body))
+	if _, err := fixture.originStore.Put(context.Background(), key, bytesReader(body), storage.PutOptions{ExpectedSize: &expected}); err != nil {
+		t.Fatal(err)
+	}
+
+	object, result, err := fixture.cache.OpenWithResult(context.Background(), OpenRequest{
+		PoolID: fixture.pool.ID, OriginMountID: fixture.origin.UUID, FileID: fixture.file.ID, Key: key,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.CacheStatus != CacheStatusFilling {
+		t.Fatalf("legacy cache status = %q, want %q", result.CacheStatus, CacheStatusFilling)
+	}
+	if _, err := io.ReadAll(object.Body); err != nil {
+		t.Fatal(err)
+	}
+	if err := object.Body.Close(); err != nil {
+		t.Fatal(err)
+	}
+	waitForCacheEntries(t, fixture.db, 1)
+}
+
 func TestOpenWithResultReportsTheMountThatServedPlayback(t *testing.T) {
 	fixture := newCacheFixture(t, 1024*1024)
 	key, _ := storage.ParseKey("video/1080p/attributed.ts")
@@ -364,6 +394,23 @@ func TestPromotionCapturedBeforeInvalidationIsDiscarded(t *testing.T) {
 	}
 	if count != 0 {
 		t.Fatalf("stale promotion created %d cache entries", count)
+	}
+}
+
+func TestInvalidationAdvancesNullLegacyGeneration(t *testing.T) {
+	fixture := newCacheFixture(t, 1024*1024)
+	if err := fixture.db.Exec("UPDATE files SET storage_cache_version = NULL WHERE id = ?", fixture.file.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := fixture.cache.InvalidateFile(context.Background(), fixture.file.ID); err != nil {
+		t.Fatal(err)
+	}
+	version, err := fixture.cache.fileCacheVersion(context.Background(), fixture.file.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version != 1 {
+		t.Fatalf("invalidated generation = %d, want 1", version)
 	}
 }
 

--- a/services/StorageMigration.go
+++ b/services/StorageMigration.go
@@ -362,7 +362,7 @@ func (w *WorkerGroup) migrateStorageItem(ctx context.Context, migration models.S
 			Where("id = ? AND storage_id = ? AND storage_state = ?", file.ID, item.SourceMountID, models.FileStorageAvailable).
 			Updates(map[string]any{
 				"storage_id": item.DestinationMountID, "storage_pool_id": migration.DestinationPoolID,
-				"storage_cache_version": gorm.Expr("storage_cache_version + 1"),
+				"storage_cache_version": gorm.Expr("COALESCE(storage_cache_version, 0) + 1"),
 			})
 		if updated.Error != nil {
 			return updated.Error

--- a/services/StorageMigration_test.go
+++ b/services/StorageMigration_test.go
@@ -156,6 +156,9 @@ func TestStorageMigrationCopiesFinalChangesBeforeAtomicCutover(t *testing.T) {
 	if err := db.Create(&file).Error; err != nil {
 		t.Fatal(err)
 	}
+	if err := db.Exec("UPDATE files SET storage_cache_version = NULL WHERE id = ?", file.ID).Error; err != nil {
+		t.Fatal(err)
+	}
 	prefix, err := storage.LegacyMediaLayout{}.FilePrefix(file.UUID)
 	if err != nil {
 		t.Fatal(err)
@@ -195,6 +198,9 @@ func TestStorageMigrationCopiesFinalChangesBeforeAtomicCutover(t *testing.T) {
 	}
 	if file.StoragePoolID == nil || *file.StoragePoolID != migration.DestinationPoolID {
 		t.Fatalf("storage pool id = %v, want %d", file.StoragePoolID, migration.DestinationPoolID)
+	}
+	if file.StorageCacheVersion != 1 {
+		t.Fatalf("storage cache generation = %d, want 1", file.StorageCacheVersion)
 	}
 	if err := db.First(&item, item.ID).Error; err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

- backfill nullable storage-cache generations in upgraded libraries
- make reads, invalidation, migration cutover, and pruning robust to legacy NULL generations
- surface generation lookup failures instead of silently hiding cache bypasses
- cover the upgrade path with unit, race, and real Garage/S3 integration tests

## Validation

- go test ./... -count=1
- go test -race ./inits ./mediacache ./services ./controllers -count=1
- go vet ./...
- Garage/S3 integration: partial playback fills local cache from a legacy NULL-generation row, then serves after origin deletion
- production browser reproduction confirmed requests missed cache before this fix